### PR TITLE
Liter and acronym in unit converter and assessment settings

### DIFF
--- a/src/app/calculator/utilities/unit-converter/unit-converter.component.html
+++ b/src/app/calculator/utilities/unit-converter/unit-converter.component.html
@@ -9,14 +9,14 @@
   <div class="col-6">
     <input type="number" step="any" class="form-control text-center" id="value1" [(ngModel)]="value1" (input)="getValue2()">
     <select class="form-control" id="from" [(ngModel)]="from" (change)="getValue2()">
-      <option *ngFor="let possibility of possibilities" [value]="possibility.unit">{{possibility.display}}</option>
+      <option *ngFor="let possibility of possibilities" [value]="possibility.unit">{{possibility.display}} ({{possibility.unit}})</option>
     </select>
   </div>
 
   <div class="col-6">
     <input type="number" step="any" class="form-control text-center" id="value2" [(ngModel)]="value2" (input)="getValue1()">
     <select class="form-control" id="to" [(ngModel)]="to" (change)="getValue1()">
-    <option *ngFor="let possibility of possibilities" [value]="possibility.unit">{{possibility.display}}</option>
+    <option *ngFor="let possibility of possibilities" [value]="possibility.unit">{{possibility.display}} ({{possibility.unit}})</option>
   </select>
   </div>
 </div>

--- a/src/app/settings/psat-settings/psat-settings.component.html
+++ b/src/app/settings/psat-settings/psat-settings.component.html
@@ -2,25 +2,25 @@
   <div class="form-group">
     <label for="distanceMeasurement">Head Measurement</label>
     <select class="form-control" formControlName="distanceMeasurement" id="distanceMeasurement" (change)="setCustom()" ngModel="{{settingsForm.value.distanceMeasurement}}">
-        <option *ngFor="let measurement of distanceMeasurements" [ngValue]="measurement.unit">{{measurement.display}}</option>
+        <option *ngFor="let measurement of distanceMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} )</option>
     </select>
   </div>
   <div class="form-group">
     <label for="flowMeasurement">Flow Measurement</label>
     <select class="form-control" formControlName="flowMeasurement" id="flowMeasurement" (change)="setCustom()" ngModel="{{settingsForm.value.flowMeasurement}}">
-        <option *ngFor="let measurement of flowMeasurements" [ngValue]="measurement.unit">{{measurement.display}}</option>
+        <option *ngFor="let measurement of flowMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} )</option>
     </select>
   </div>
   <div class="form-group">
     <label for="powerMeasurement">Power Measurement</label>
     <select class="form-control" formControlName="powerMeasurement" id="powerMeasurement" (change)="setCustom()" ngModel="{{settingsForm.value.powerMeasurement}}">
-        <option *ngFor="let measurement of powerMeasurements" [ngValue]="measurement.unit">{{measurement.display}}</option>
+        <option *ngFor="let measurement of powerMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} )</option>
     </select>
   </div>
   <div class="form-group">
     <label for="pressureMeasurement">Pressure Measurement</label>
     <select class="form-control" formControlName="pressureMeasurement" id="pressureMeasurement" (change)="setCustom()" ngModel="{{settingsForm.value.pressureMeasurement}}">
-        <option *ngFor="let measurement of pressureMeasurements" [ngValue]="measurement.unit">{{measurement.display}}</option>
+        <option *ngFor="let measurement of pressureMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} ) </option>
     </select>
   </div>
     <!--<div class="form-group">

--- a/src/app/settings/psat-settings/psat-settings.component.ts
+++ b/src/app/settings/psat-settings/psat-settings.component.ts
@@ -38,7 +38,7 @@ export class PsatSettingsComponent implements OnInit {
       'gpm',
       'MGD',
       'm3/h',
-      'l/s',
+      'L/s',
       'm3/min'
     ];
     tmpList.forEach(unit => {

--- a/src/app/shared/convert-units/definitions/volume.ts
+++ b/src/app/shared/convert-units/definitions/volume.ts
@@ -14,31 +14,31 @@ export const volume = {
             }
             , to_anchor: 1 / 1000
         }
-        , ml: {
+        , mL: {
             name: {
-                singular: 'Millilitre'
-                , plural: 'Millilitres'
+                singular: 'Milliliter'
+                , plural: 'Milliliters'
             }
             , to_anchor: 1 / 1000
         }
-        , cl: {
+        , cL: {
             name: {
-                singular: 'Centilitre'
-                , plural: 'Centilitres'
+                singular: 'Centiliter'
+                , plural: 'Centiliters'
             }
             , to_anchor: 1 / 100
         }
-        , dl: {
+        , dL: {
             name: {
-                singular: 'Decilitre'
-                , plural: 'Decilitres'
+                singular: 'Deciliter'
+                , plural: 'Deciliters'
             }
             , to_anchor: 1 / 10
         }
-        , l: {
+        , L: {
             name: {
-                singular: 'Litre'
-                , plural: 'Litres'
+                singular: 'Liter'
+                , plural: 'Liters'
             }
             , to_anchor: 1
         }
@@ -176,7 +176,7 @@ export const volume = {
     },
     _anchors: {
         metric: {
-            unit: 'l'
+            unit: 'L'
             , ratio: 33.8140226
         }
         , imperial: {

--- a/src/app/shared/convert-units/definitions/volumeFlowRate.ts
+++ b/src/app/shared/convert-units/definitions/volumeFlowRate.ts
@@ -14,66 +14,66 @@ export const volumeFlowRate = {
             }
             , to_anchor: 1 / 1000
         }
-        , 'ml/s': {
+        , 'mL/s': {
             name: {
-                singular: 'Millilitre per second'
-                , plural: 'Millilitres per second'
+                singular: 'Milliliter per second'
+                , plural: 'Milliliters per second'
             }
             , to_anchor: 1 / 1000
         }
-        , 'cl/s': {
+        , 'cL/s': {
             name: {
-                singular: 'Centilitre per second'
-                , plural: 'Centilitres per second'
+                singular: 'Centiliter per second'
+                , plural: 'Centiliters per second'
             }
             , to_anchor: 1 / 100
         }
-        , 'dl/s': {
+        , 'dL/s': {
             name: {
-                singular: 'Decilitre per second'
-                , plural: 'Decilitres per second'
+                singular: 'Deciliter per second'
+                , plural: 'Deciliters per second'
             }
             , to_anchor: 1 / 10
         }
-        , 'l/s': {
+        , 'L/s': {
             name: {
-                singular: 'Litre per second'
-                , plural: 'Litres per second'
+                singular: 'Liter per second'
+                , plural: 'Liters per second'
             }
             , to_anchor: 1
         }
-        , 'l/min': {
+        , 'L/min': {
             name: {
-                singular: 'Litre per minute'
-                , plural: 'Litres per minute'
+                singular: 'Liter per minute'
+                , plural: 'Liters per minute'
             }
             , to_anchor: 1 / 60
         }
-        , 'l/h': {
+        , 'L/h': {
             name: {
-                singular: 'Litre per hour'
-                , plural: 'Litres per hour'
+                singular: 'Liter per hour'
+                , plural: 'Liters per hour'
             }
             , to_anchor: 1 / 3600
         }
-        , 'kl/s': {
+        , 'kL/s': {
             name: {
-                singular: 'Kilolitre per second'
-                , plural: 'Kilolitres per second'
+                singular: 'Kiloliter per second'
+                , plural: 'Kiloliters per second'
             }
             , to_anchor: 1000
         }
-        , 'kl/min': {
+        , 'kL/min': {
             name: {
-                singular: 'Kilolitre per minute'
-                , plural: 'Kilolitres per minute'
+                singular: 'Kiloliter per minute'
+                , plural: 'Kiloliters per minute'
             }
             , to_anchor: 50 / 3
         }
-        , 'kl/h': {
+        , 'kL/h': {
             name: {
-                singular: 'Kilolitre per hour'
-                , plural: 'Kilolitres per hour'
+                singular: 'Kiloliter per hour'
+                , plural: 'Kiloliters per hour'
             }
             , to_anchor: 5 / 18
         }
@@ -273,7 +273,7 @@ export const volumeFlowRate = {
     }
     , _anchors: {
         metric: {
-            unit: 'l/s'
+            unit: 'L/s'
             , ratio: 33.8140227
         }
         , imperial: {


### PR DESCRIPTION
Changed all instances of litre to liter and the associated acronym from l to L according to technical editor's advice. Added acronyms of units to the unit converter and assessment settings page. Only text should have been edited.