### PR TITLE
update version number and npm run clean command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amo-tools-desktop",
-  "version": "0.2.01",
+  "version": "0.2.1",
   "main": "main.js",
   "license": "MIT",
   "description": "AMO-Tools-Desktop",
@@ -16,7 +16,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build-prod": "ng build --prod --aot --env=prod",
-    "clean": "rm -rf node_modules && rm -rf dist && rm package-lock.json",
+    "clean": "rm -rf node_modules && rm -rf dist && rm -f package-lock.json",
     "electron": "electron .",
     "lint": "ng lint",
     "test": "ng test",


### PR DESCRIPTION
updates version number and gets rid of the npm error that happens when the package-lock.json file doesn't exist