### PR TITLE
Phast updates

### DIFF
--- a/src/app/phast/convert-phast.service.ts
+++ b/src/app/phast/convert-phast.service.ts
@@ -66,9 +66,9 @@ export class ConvertPhastService {
     if (meteredEnergy.meteredEnergyFuel) {
       if (oldSettings.unitsOfMeasure == 'Metric' && newSettings.unitsOfMeasure == 'Imperial') {
         //phast.meteredEnergy.meteredEnergyFuel.heatingValue = this.convertVal(phast.meteredEnergy.meteredEnergyFuel.heatingValue, 'btuScfF', 'kjnm');
-        meteredEnergy.meteredEnergyFuel.fuelFlowRateInput = this.convertVal(meteredEnergy.meteredEnergyFuel.fuelFlowRateInput, 'kJ', 'btu');
+        meteredEnergy.meteredEnergyFuel.fuelFlowRateInput = this.convertVal(meteredEnergy.meteredEnergyFuel.fuelFlowRateInput, 'kJ', 'Btu');
       } else if (oldSettings.unitsOfMeasure == 'Imperial' && newSettings.unitsOfMeasure == 'Metric') {
-        meteredEnergy.meteredEnergyFuel.fuelFlowRateInput = this.convertVal(meteredEnergy.meteredEnergyFuel.fuelFlowRateInput, 'btu', 'kJ');
+        meteredEnergy.meteredEnergyFuel.fuelFlowRateInput = this.convertVal(meteredEnergy.meteredEnergyFuel.fuelFlowRateInput, 'Btu', 'kJ');
       }
     }
     if (meteredEnergy.meteredEnergySteam) {
@@ -193,7 +193,7 @@ export class ConvertPhastService {
       loss.dischargeTemperature = this.convertVal(loss.dischargeTemperature, 'C', 'F');
       loss.chargeFeedRate = this.convertVal(loss.chargeFeedRate, 'kg', 'lb')
       loss.reactionHeat = this.convertVal(loss.reactionHeat, 'kJkg', 'btuLb');
-      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'kJkg', 'btuLb');
+      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'kJ', 'Btu');
       loss.specificHeatLiquid = this.convertVal(loss.specificHeatLiquid, 'kJkgC', 'btulbF');
       loss.specificHeatVapor = this.convertVal(loss.specificHeatVapor, 'kJkgC', 'btulbF');
     } else if (oldSettings.unitsOfMeasure == 'Imperial' && newSettings.unitsOfMeasure == 'Metric') {
@@ -203,7 +203,7 @@ export class ConvertPhastService {
       loss.dischargeTemperature = this.convertVal(loss.dischargeTemperature, 'F', 'C');
       loss.chargeFeedRate = this.convertVal(loss.chargeFeedRate, 'lb', 'kg')
       loss.reactionHeat = this.convertVal(loss.reactionHeat, 'btuLb', 'kJkg');
-      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'btuLb', 'kJkg');
+      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'Btu', 'kJ');
       loss.specificHeatLiquid = this.convertVal(loss.specificHeatLiquid, 'btulbF', 'kJkgC');
       loss.specificHeatVapor = this.convertVal(loss.specificHeatVapor, 'btulbF', 'kJkgC');
     }
@@ -218,9 +218,10 @@ export class ConvertPhastService {
       loss.waterVaporDischargeTemperature = this.convertVal(loss.waterVaporDischargeTemperature, 'C', 'F');
       loss.chargeFeedRate = this.convertVal(loss.chargeFeedRate, 'kg', 'lb');
       loss.reactionHeat = this.convertVal(loss.reactionHeat, 'kJkg', 'btuLb');
-      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'kJkg', 'btuLb');
+      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'kJ', 'Btu');
       loss.specificHeatLiquid = this.convertVal(loss.specificHeatLiquid, 'kJkgC', 'btulbF');
       loss.specificHeatSolid = this.convertVal(loss.specificHeatSolid, 'kJkgC', 'btulbF');
+      loss.latentHeat = this.convertVal(loss.latentHeat, 'kJkg', 'btuLb')
     } else if (oldSettings.unitsOfMeasure == 'Imperial' && newSettings.unitsOfMeasure == 'Metric') {
       loss.meltingPoint = this.convertVal(loss.meltingPoint, 'F', 'C');
       loss.initialTemperature = this.convertVal(loss.initialTemperature, 'F', 'C');
@@ -228,9 +229,10 @@ export class ConvertPhastService {
       loss.waterVaporDischargeTemperature = this.convertVal(loss.waterVaporDischargeTemperature, 'F', 'C');
       loss.chargeFeedRate = this.convertVal(loss.chargeFeedRate, 'lb', 'kg');
       loss.reactionHeat = this.convertVal(loss.reactionHeat, 'btuLb', 'kJkg');
-      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'btuLb', 'kJkg');
+      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'Btu', 'kJ');
       loss.specificHeatLiquid = this.convertVal(loss.specificHeatLiquid, 'btulbF', 'kJkgC');
       loss.specificHeatSolid = this.convertVal(loss.specificHeatSolid, 'btulbF', 'kJkgC');
+      loss.latentHeat = this.convertVal(loss.latentHeat, 'btuLb', 'kJkg')
     }
     return loss;
   }
@@ -241,15 +243,15 @@ export class ConvertPhastService {
       loss.dischargeTemperature = this.convertVal(loss.dischargeTemperature, 'C', 'F');
       loss.feedRate = this.convertVal(loss.feedRate, 'kg', 'lb')
       loss.reactionHeat = this.convertVal(loss.reactionHeat, 'kJkg', 'btuLb');
-      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'kJkg', 'btuLb');
+      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'kJ', 'Btu');
       loss.specificHeatVapor = this.convertVal(loss.specificHeatVapor, 'kJkgC', 'btulbF');
       loss.specificHeatGas = this.convertVal(loss.specificHeatGas, 'kJkgC', 'btulbF');
     } else if (oldSettings.unitsOfMeasure == 'Imperial' && newSettings.unitsOfMeasure == 'Metric') {
       loss.initialTemperature = this.convertVal(loss.initialTemperature, 'F', 'C');
       loss.dischargeTemperature = this.convertVal(loss.dischargeTemperature, 'F', 'C');
-      loss.feedRate = this.convertVal(loss.feedRate, 'lb', 'lb')
+      loss.feedRate = this.convertVal(loss.feedRate, 'lb', 'kg')
       loss.reactionHeat = this.convertVal(loss.reactionHeat, 'btuLb', 'kJkg');
-      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'btuLb', 'kJkg');
+      loss.additionalHeat = this.convertVal(loss.additionalHeat, 'Btu', 'kJ');
       loss.specificHeatVapor = this.convertVal(loss.specificHeatVapor, 'btulbF', 'kJkgC');
       loss.specificHeatGas = this.convertVal(loss.specificHeatGas, 'btulbF', 'kJkgC');
     }
@@ -285,13 +287,13 @@ export class ConvertPhastService {
   convertLiquidCoolingLoss(loss: LiquidCoolingLoss, oldSettings: Settings, newSettings: Settings): LiquidCoolingLoss {
     if (oldSettings.unitsOfMeasure == 'Metric' && newSettings.unitsOfMeasure == 'Imperial') {
       loss.specificHeat = this.convertVal(loss.specificHeat, 'kJkgC', 'btulbF');
-      loss.density = this.convertVal(loss.density, 'kgNm3', 'lbscf');
+      loss.density = this.convertVal(loss.density, 'kgL', 'lbgal');
       loss.flowRate = this.convertVal(loss.flowRate, 'L', 'gal');
       loss.initialTemperature = this.convertVal(loss.initialTemperature, 'C', 'F');
       loss.outletTemperature = this.convertVal(loss.outletTemperature, 'C', 'F');
     } else if (oldSettings.unitsOfMeasure == 'Imperial' && newSettings.unitsOfMeasure == 'Metric') {
       loss.specificHeat = this.convertVal(loss.specificHeat, 'btulbF', 'kJkgC');
-      loss.density = this.convertVal(loss.density, 'lbscf', 'kgNm3');
+      loss.density = this.convertVal(loss.density, 'lbgal', 'kgL');
       loss.flowRate = this.convertVal(loss.flowRate, 'gal', 'L');
       loss.initialTemperature = this.convertVal(loss.initialTemperature, 'F', 'C');
       loss.outletTemperature = this.convertVal(loss.outletTemperature, 'F', 'C');
@@ -452,10 +454,10 @@ export class ConvertPhastService {
   convertOtherLoss(loss: OtherLoss, oldSettings: Settings, newSettings: Settings): OtherLoss {
     //heatLoss
     if (oldSettings.unitsOfMeasure == 'Metric' && newSettings.unitsOfMeasure == 'Imperial') {
-      loss.heatLoss = this.convertVal(loss.heatLoss, 'btu', 'kJ');
+      loss.heatLoss = this.convertVal(loss.heatLoss, 'kJ', 'Btu');
     }
     else if (oldSettings.unitsOfMeasure == 'Imperial' && newSettings.unitsOfMeasure == 'Metric') {
-      loss.heatLoss = this.convertVal(loss.heatLoss, 'kJ', 'btu');
+      loss.heatLoss = this.convertVal(loss.heatLoss, 'Btu', 'kJ');
     }
     return loss;
   }

--- a/src/app/phast/losses/energy-input/energy-input-form/energy-input-form.component.html
+++ b/src/app/phast/losses/energy-input/energy-input-form/energy-input-form.component.html
@@ -78,7 +78,7 @@
       <label class="small" for="otherFuels">Other Fuels</label>
       <div class="input-group">
         <input name="{{'otherFuels_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="otherFuels" id="otherFuels" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('otherFuels')">
-        <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">mm Btu/hr</span>
+        <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">MM Btu/hr</span>
         <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">GJ/hr</span>
       </div>
     </div>
@@ -87,7 +87,7 @@
       <label class="small" for="electricityInput">Electricty Input</label>
       <div class="input-group">
         <input name="{{'electricityInput_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="electricityInput" id="electricityInput" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('electricityInput')">
-        <span class="input-group-addon units">kWh/hr</span>
+        <span class="input-group-addon units">kW</span>
       </div>
     </div>
   </div>

--- a/src/app/phast/losses/energy-input/energy-input-form/energy-input-form.component.html
+++ b/src/app/phast/losses/energy-input/energy-input-form/energy-input-form.component.html
@@ -51,7 +51,7 @@
       <div class="input-group">
         <input name="{{'coalHeatingValue_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="coalHeatingValue" id="coalHeatingValue" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('coalHeatingValue')">
         <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">Btu/lb</span>
-        <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kg/lb</span>
+        <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kJ/kg</span>
 
       </div>
     </div>
@@ -70,7 +70,7 @@
       <div class="input-group">
         <input name="{{'electrodeHeatingValue_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="electrodeHeatingValue" id="electrodeHeatingValue" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('electrodeHeatingValue')">
         <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">Btu/lb</span>
-        <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kg/lb</span>
+        <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kJ/kg/</span>
       </div>
     </div>
 

--- a/src/app/phast/losses/fixture-losses/fixture-losses-form/fixture-losses-form.component.html
+++ b/src/app/phast/losses/fixture-losses/fixture-losses-form/fixture-losses-form.component.html
@@ -26,7 +26,7 @@
         <input name="{{'feedRate_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="feedRate" id="feedRate"
           onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('feedRate')">
         <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">lb/hr</span>
-        <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kJ/kg</span>
+        <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kg/hr</span>
       </div>
     </div>
 

--- a/src/app/phast/phast.component.html
+++ b/src/app/phast/phast.component.html
@@ -18,7 +18,7 @@
       <div class="wrapper">
         <div class="form">
           <app-system-basics *ngIf="subTab == 'system-basics'" [phast]="_phast" [settings]="settings" [saveClicked]="saveClicked" [assessment]="assessment"
-            [isAssessmentSettings]="isAssessmentSettings" (updateSettings)="getSettings($event)" (updateAssessment)="save()"></app-system-basics>
+            [isAssessmentSettings]="isAssessmentSettings" (updateSettings)="getSettings($event)" (save)="saveDb()"></app-system-basics>
           <app-operating-hours *ngIf="subTab == 'operating-hours'" [phast]="_phast" [saveClicked]="saveClicked" (save)="saveDb()"></app-operating-hours>
           <app-energy-costs *ngIf="subTab == 'energy-costs'" [phast]="_phast" [saveClicked]="saveClicked" (save)="saveDb()" [settings]="settings"></app-energy-costs>
         </div>

--- a/src/app/phast/phast.service.ts
+++ b/src/app/phast/phast.service.ts
@@ -129,7 +129,7 @@ export class PhastService {
       inputs.dischargeTemperature = this.convertUnitsService.value(inputs.dischargeTemperature).from('C').to('F');
       inputs.feedRate = this.convertUnitsService.value(inputs.feedRate).from('kg').to('lb')
       inputs.reactionHeat = this.convertUnitsService.value(inputs.reactionHeat).from('kJkg').to('btuLb');
-      inputs.additionalHeat = this.convertUnitsService.value(inputs.additionalHeat).from('kJkg').to('btuLb');
+      inputs.additionalHeat = this.convertUnitsService.value(inputs.additionalHeat).from('kJ').to('Btu');
       inputs.specificHeatVapor = this.convertUnitsService.value(inputs.specificHeatVapor).from('kJkgC').to('btulbF');
       inputs.specificHeatGas = this.convertUnitsService.value(inputs.specificHeatGas).from('kJkgC').to('btulbF');
       results = phastAddon.gasLoadChargeMaterial(inputs);
@@ -157,7 +157,7 @@ export class PhastService {
     let results = 0;
     if (settings.unitsOfMeasure == 'Metric') {
       inputs.specificHeat = this.convertUnitsService.value(inputs.specificHeat).from('kJkgC').to('btulbF');
-      inputs.density = this.convertUnitsService.value(inputs.density).from('kgNm3').to('lbscf');
+      inputs.density = this.convertUnitsService.value(inputs.density).from('kgL').to('lbgal');
       inputs.flowRate = this.convertUnitsService.value(inputs.flowRate).from('L').to('gal');
       inputs.initialTemperature = this.convertUnitsService.value(inputs.initialTemperature).from('C').to('F');
       inputs.outletTemperature = this.convertUnitsService.value(inputs.outletTemperature).from('C').to('F');
@@ -191,7 +191,7 @@ export class PhastService {
       inputs.dischargeTemperature = this.convertUnitsService.value(inputs.dischargeTemperature).from('C').to('F');
       inputs.chargeFeedRate = this.convertUnitsService.value(inputs.chargeFeedRate).from('kg').to('lb')
       inputs.reactionHeat = this.convertUnitsService.value(inputs.reactionHeat).from('kJkg').to('btuLb');
-      inputs.additionalHeat = this.convertUnitsService.value(inputs.additionalHeat).from('kJkg').to('btuLb');
+      inputs.additionalHeat = this.convertUnitsService.value(inputs.additionalHeat).from('kJ').to('Btu');
       inputs.specificHeatLiquid = this.convertUnitsService.value(inputs.specificHeatLiquid).from('kJkgC').to('btulbF');
       inputs.specificHeatVapor = this.convertUnitsService.value(inputs.specificHeatVapor).from('kJkgC').to('btulbF');
       results = phastAddon.liquidLoadChargeMaterial(inputs);
@@ -277,9 +277,10 @@ export class PhastService {
       inputs.waterVaporDischargeTemperature = this.convertUnitsService.value(inputs.waterVaporDischargeTemperature).from('C').to('F');
       inputs.chargeFeedRate = this.convertUnitsService.value(inputs.chargeFeedRate).from('kg').to('lb');
       inputs.reactionHeat = this.convertUnitsService.value(inputs.reactionHeat).from('kJkg').to('btuLb');
-      inputs.additionalHeat = this.convertUnitsService.value(inputs.additionalHeat).from('kJkg').to('btuLb');
+      inputs.additionalHeat = this.convertUnitsService.value(inputs.additionalHeat).from('kJ').to('Btu');
       inputs.specificHeatLiquid = this.convertUnitsService.value(inputs.specificHeatLiquid).from('kJkgC').to('btulbF');
       inputs.specificHeatSolid = this.convertUnitsService.value(inputs.specificHeatSolid).from('kJkgC').to('btulbF');
+      inputs.latentHeat = this.convertUnitsService.value(inputs.latentHeat).from('kJkg').to('btuLb');
       results = phastAddon.solidLoadChargeMaterial(inputs);
       if (isNaN(results) == false) {
         if (settings.energySourceType == 'Electricity') {

--- a/src/app/phast/system-basics/system-basics.component.ts
+++ b/src/app/phast/system-basics/system-basics.component.ts
@@ -24,6 +24,9 @@ export class SystemBasicsComponent implements OnInit {
   assessment: Assessment;
   @Input()
   phast: PHAST;
+  @Output('save')
+  save = new EventEmitter<boolean>();
+
 
   @ViewChild('settingsModal') public settingsModal: ModalDirective;
 
@@ -86,6 +89,8 @@ export class SystemBasicsComponent implements OnInit {
           })
         }
       }
+      console.log('converted')
+      this.save.emit(true);
     }
     //assessment has existing settings
     if (this.isAssessmentSettings) {


### PR DESCRIPTION
connects #755 

the behavior in 755 was most likely from errors being thrown while converting. A few of the conversions had the wrong unit signatures for the service and could have thrown errors that caused issues. Those have been resolved