### PR TITLE
add travis_retry command to `npm install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 ##  - clang
 
 before_install:
-  - npm i -g npm@5.3.0
+  - travis_retry npm i -g npm@5.3.0
 
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 #      brew update;
@@ -23,7 +23,7 @@ before_install:
 #      sudo apt-get install npm;
 #    fi
 
-install: npm install
+install: travis_retry npm install
 
 script:
   - npm run build


### PR DESCRIPTION
Adds `travis_retry` to the `npm installs` which will prevent random network disconnects on the travis CI machines (that rarely, but still do happen). `travis_retry` simply retries the command up to 3 times if it returned non-zero. 

connect #844 