### PR TITLE
Various phast issues - see description

### DIFF
--- a/src/app/about-page/about-page.component.html
+++ b/src/app/about-page/about-page.component.html
@@ -114,13 +114,11 @@
           </h4>
         </div>
         <div *ngIf="showPHAST" class="card-block">
-            <p>The Process Heating Assessment and Survey Tool (PHAST), originally developed by E3M, Inc.,
-              Oak Ridge National Laboratory and the Industrial Heating Equipment Association (IHEA),
-              introduces methods to improve thermal efficiency of heating equipment.<br>
-              This tool helps industrial users survey process heating equipment consuming fuel or electricity,
-              and identifies the most energy-intensive equipment.<br>
-              The tool can be used to perform a heat balance that identifies major areas of energy use under
-              various operating conditions and test "what-if" scenarios for various options to reduce energy use.
+            <p>The Process Heating Assessment and Survey Tool (PHAST), originally developed by Dr. Arvind Thekdi of E3M, Inc.,
+              Oak Ridge National Laboratory and the Industrial Heating Equipment Association (IHEA), introduces methods to
+              improve thermal efficiency of heating equipment.<br>This tool helps industrial users survey process heating
+              equipment consuming fuel or electricity, and identifies the most energy-intensive equipment.<br>The tool can be
+              used to perform a heat balance that identifies major areas of energy use under various operating conditions and test "what-if" scenarios for various options to reduce energy use.
             </p>
 
             <h4>Inputs</h4>

--- a/src/app/phast/losses/extended-surface-losses/extended-surface-losses-form/extended-surface-losses-form.component.html
+++ b/src/app/phast/losses/extended-surface-losses/extended-surface-losses-form/extended-surface-losses-form.component.html
@@ -33,10 +33,8 @@
     </div>
 
     <div class="form-group">
-      <label class="small" for="surfaceEmissivity" aria-describedby="emissivityHelp">Surface Emissivity
-    <small id="emissivityHelp" class="form-text text-muted text-help">Typical - 0.9</small>
-    </label>
-      <input name="{{'surfaceEmissivity_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="surfaceEmissivity"
+      <label class="small" for="surfaceEmissivity" aria-describedby="emissivityHelp">Surface Emissivity</label>
+      <input name="{{'surfaceEmissivity_'+lossIndex}}" type="number" step="0.1" min="0" max="1" class="form-control" formControlName="surfaceEmissivity"
         id="surfaceEmissivity" onfocus="this.select();" (input)="checkEmissivity()" (focus)="focusField('surfaceEmissivity')" (blur)="focusOut()">
       <span class="alert-warning pull-right small" *ngIf="emissivityError !== null">{{emissivityError}}</span>
     </div>

--- a/src/app/phast/losses/extended-surface-losses/extended-surface-losses-form/extended-surface-losses-form.component.ts
+++ b/src/app/phast/losses/extended-surface-losses/extended-surface-losses-form/extended-surface-losses-form.component.ts
@@ -78,8 +78,8 @@ export class ExtendedSurfaceLossesFormComponent implements OnInit {
     if (!bool) {
       this.startSavePolling();
     }
-    if (this.lossesForm.value.surfaceEmissivity >> 1) {
-      this.emissivityError = 'Surface emissivity cannot be greater than 1';
+    if (this.lossesForm.value.surfaceEmissivity > 1 || this.lossesForm.value.surfaceEmissivity < 0) {
+      this.emissivityError = 'Surface emissivity must be between 0 and 1';
     } else {
       this.emissivityError = null;
     }

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-mass/flue-gas-losses-form-mass.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-mass/flue-gas-losses-form-mass.component.html
@@ -49,7 +49,7 @@
     </div>
 
     <div class="form-group">
-      <label class="small" for="moistureInAirComposition">Moisture in Air Composition</label>
+      <label class="small" for="moistureInAirComposition">Moisture in Air Combustion</label>
       <input name="{{'moistureInAirComposition_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="moistureInAirComposition"
         id="moistureInAirComposition" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('moistureInAirComposition')" (blur)="focusOut()">
     </div>

--- a/src/app/phast/losses/losses-help/cooling-losses-help/cooling-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/cooling-losses-help/cooling-losses-help.component.html
@@ -1,7 +1,7 @@
 <div class="help-header">
 
   <h3>Cooling Losses Help</h3>
-  <p>Enter loss data</p>
+  <p>Enter loss data<br>Note: the default Average Specific Heat and Density values are for Air or Water (depending on the chosen cooling medium).</p>
   <p class="text-muted">
     <span class="fa fa-youtube-play"></span> Watch tutorial on entering cooling loss data.
   </p>
@@ -106,13 +106,13 @@
 
   <div class="card" *ngIf="currentField == 'avgSpecificHeatGas'">
     <div class="card-header">
-      Specific Heat
+      Average Specific Heat
     </div>
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>
       <p>
-        Amount of heat per unit mass required to raise the temperature by one degree of temperature. Default value is for
-        air; may be more accurate to compute as the average of specific heat based on inlet and outlet temperature.
+        Amount of heat per unit mass required to raise the temperature by one degree of temperature.<br>Default value is for
+        <strong>air</strong>; may be more accurate to compute as the average of specific heat based on inlet and outlet temperature.
       </p>
       <label><u><strong>Input</strong></u></label>
       <p>
@@ -164,7 +164,7 @@
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>
       <p>
-        Amount of heat per unit mass required to raise the temperature by one degree of temperature. Default value is for water;
+        Amount of heat per unit mass required to raise the temperature by one degree of temperature.<br>Default value is for <strong>water</strong>;
         may be more accurate to compute as the average of specific heat based on inlet and outlet temperature.
       </p>
       <label><u><strong>Input</strong></u></label>

--- a/src/app/phast/losses/losses-help/extended-surface-losses-help/extended-surface-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/extended-surface-losses-help/extended-surface-losses-help.component.html
@@ -75,7 +75,7 @@
       </p>
       <label><u><strong>Input</strong></u></label>
       <p>
-        Units:  Minimum Value Allowed: <strong>0</strong><br>  Maximum Value Allowed: <strong>1</strong>
+        Minimum Value Allowed: <strong>0</strong><br>Maximum Value Allowed: <strong>1</strong>
       </p>
     </div>
   </div>

--- a/src/app/phast/losses/losses-help/flue-gas-losses-help/flue-gas-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/flue-gas-losses-help/flue-gas-losses-help.component.html
@@ -111,7 +111,7 @@
   <!--Solid/Liquid-->
   <div class="card" *ngIf="currentField == 'moistureInAirComposition'">
     <div class="card-header">
-      Moisture in Air Composition
+      Moisture in Air Combustion
     </div>
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>

--- a/src/app/phast/losses/losses-help/opening-losses-help/opening-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/opening-losses-help/opening-losses-help.component.html
@@ -149,14 +149,14 @@
       </p>
       <label><u><strong>Input</strong></u></label>
       <p>
-        Minimum Value Allowed: <strong>0</strong><br> Minimum Value Allowed: <strong>1</strong>
+        Minimum Value Allowed: <strong>0</strong><br>Maximum Value Allowed: <strong>1</strong>
       </p>
     </div>
   </div>
 
   <div class="card" *ngIf="currentField == 'percentTimeOpen'">
     <div class="card-header">
-      % of Time Open
+      Percent of Time Open
     </div>
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>

--- a/src/app/phast/losses/losses-help/wall-losses-help/wall-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/wall-losses-help/wall-losses-help.component.html
@@ -89,7 +89,7 @@
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>
       <p>
-        Surface emissivity of the outside surface of heat loss. Default value is 0.8. The user can change this value
+        Surface emissivity of the outside surface of heat loss. Default value is 0.9. The user can change this value
         for their specific case.
       </p>
     </div>

--- a/src/app/phast/losses/losses-help/wall-losses-help/wall-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/wall-losses-help/wall-losses-help.component.html
@@ -92,6 +92,10 @@
         Surface emissivity of the outside surface of heat loss. Default value is 0.9. The user can change this value
         for their specific case.
       </p>
+      <p>
+        Minimum Value Allowed: <strong>0</strong><br>
+        Maximum Value Allowed: <strong>1</strong>
+      </p>
     </div>
   </div>
 

--- a/src/app/phast/losses/opening-losses/opening-losses-form/opening-losses-form.component.ts
+++ b/src/app/phast/losses/opening-losses/opening-losses-form/opening-losses-form.component.ts
@@ -162,10 +162,11 @@ export class OpeningLossesFormComponent implements OnInit {
   getArea() {
     let smallUnit = 'in';
     let largeUnit = 'ft';
-    if(this.settings.unitsOfMeasure == 'Metric'){
-      smallUnit == 'mm';
-      largeUnit == 'm';
+    if (this.settings.unitsOfMeasure == 'Metric') {
+      smallUnit = 'mm';
+      largeUnit = 'm';
     }
+
     this.checkNumOpenings();
     this.checkOpeningDimensions();
     if (this.numOpeningsError !== null || this.lengthError !== null || this.heightError !== null) {

--- a/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.html
+++ b/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.html
@@ -51,7 +51,7 @@
 
     <div class="form-group">
       <label class="small" for="surfaceEmissivity" aria-describedby="emissivityHelp">Surface Emissivity</label>
-      <input name="{{'surfaceEmissivity_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="surfaceEmissivity"
+      <input name="{{'surfaceEmissivity_'+lossIndex}}" type="number" step="0.1" min="0" max="1" class="form-control" formControlName="surfaceEmissivity"
         id="surfaceEmissivity" onfocus="this.select();" (input)="checkEmissivity()" (focus)="focusField('surfaceEmissivity')"  (blur)="focusOut()">
       <span class="alert-warning pull-right small" *ngIf="emissivityError !== null">{{emissivityError}}</span>
     </div>

--- a/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.html
+++ b/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.html
@@ -50,9 +50,7 @@
     </div>
 
     <div class="form-group">
-      <label class="small" for="surfaceEmissivity" aria-describedby="emissivityHelp">Surface Emissivity
-    <small id="emissivityHelp" class="form-text text-muted text-help">Typical - 0.9</small>
-    </label>
+      <label class="small" for="surfaceEmissivity" aria-describedby="emissivityHelp">Surface Emissivity</label>
       <input name="{{'surfaceEmissivity_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="surfaceEmissivity"
         id="surfaceEmissivity" onfocus="this.select();" (input)="checkEmissivity()" (focus)="focusField('surfaceEmissivity')"  (blur)="focusOut()">
       <span class="alert-warning pull-right small" *ngIf="emissivityError !== null">{{emissivityError}}</span>

--- a/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.ts
+++ b/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.ts
@@ -101,8 +101,8 @@ export class WallLossesFormComponent implements OnInit {
     if (!bool) {
       this.startSavePolling();
     }
-    if (this.wallLossesForm.value.surfaceEmissivity > 1) {
-      this.emissivityError = 'Surface emissivity cannot be greater than 1';
+    if (this.wallLossesForm.value.surfaceEmissivity > 1 || this.wallLossesForm.value.surfaceEmissivity < 0) {
+      this.emissivityError = 'Surface emissivity must be between 0 and 1';
     } else {
       this.emissivityError = null;
     }

--- a/src/app/phast/losses/wall-losses/wall-losses.service.ts
+++ b/src/app/phast/losses/wall-losses/wall-losses.service.ts
@@ -39,10 +39,10 @@ export class WallLossesService {
       'avgSurfaceTemp': ['', Validators.required],
       'ambientTemp': ['', Validators.required],
       'correctionFactor': [1.0, Validators.required],
-      'windVelocity': ['', Validators.required],
+      'windVelocity': [0, Validators.required],
       'surfaceShape': ['Vertical Plates', Validators.required],
       'conditionFactor': [1.394, Validators.required],
-      'surfaceEmissivity': ['', Validators.required]
+      'surfaceEmissivity': [0.9, Validators.required]
     })
   }
 


### PR DESCRIPTION
-Fixes unit bug in opening losses area calculation
-Adds wall losses defaults on form init
-Adds new PHAST paragraph in the "About" section
-Update cooling losses help text
-Change Moisture in Air Composition to Moisture in Air Combustion for Solid/Liquid Flue Gas
-Enforce emissivity mins and maxes across all of PHAST and make their keyboard increment values to be 0.1 

connect #913 
connect #926 
connect #920 
connect #936 
connect #917 
connect #929 