### PR TITLE
Adds Flue Gas Oxygen Calculation Method Dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@angular/platform-server": "^5.0.0",
     "@angular/router": "^5.0.0",
     "ajv": "^5.2.2",
-    "amo-tools-suite": "file:../AMO-Tools-Suite",
+    "amo-tools-suite": "0.2.10",
     "bootstrap": "^4.0.0-alpha.6",
     "core-js": "^2.4.1",
     "d3": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@angular/platform-server": "^5.0.0",
     "@angular/router": "^5.0.0",
     "ajv": "^5.2.2",
-    "amo-tools-suite": "0.2.9",
+    "amo-tools-suite": "file:../AMO-Tools-Suite",
     "bootstrap": "^4.0.0-alpha.6",
     "core-js": "^2.4.1",
     "d3": "4.5.0",

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-compare.service.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-compare.service.ts
@@ -43,6 +43,7 @@ export class FlueGasCompareService {
       excessAirPercentage: new BehaviorSubject<boolean>(null),
       combustionAirTemperature: new BehaviorSubject<boolean>(null),
       fuelTemperature: new BehaviorSubject<boolean>(null),
+      oxygenCalculationMethod: new BehaviorSubject<boolean>(null),
     }
     let tmpByMass: FlueGasMassDifferent = {
       gasTypeId: new BehaviorSubject<boolean>(null),
@@ -172,6 +173,7 @@ export interface FlueGasVolumeDifferent {
   excessAirPercentage: BehaviorSubject<boolean>,
   combustionAirTemperature: BehaviorSubject<boolean>,
   fuelTemperature: BehaviorSubject<boolean>,
+  oxygenCalculationMethod: BehaviorSubject<boolean>,
 }
 
 export interface FlueGasMassDifferent {

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
@@ -16,15 +16,30 @@
           id="flueGasTemperature" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('flueGasTemperature')" (blur)="focusOut()">
         <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">&#8457;</span>
         <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
-
       </div>
     </div>
 
     <div class="form-group">
+      <label class="small" for="oxygenCalculationMethod">Oxygen Calculation Method</label>
+      <select name="{{'oxygenCalculationMethod_'+lossIndex}}" class="form-control" formControlName="oxygenCalculationMethod" id="oxygenCalculationMethod" (change)="setProperties()" (focus)="focusField('oxygenCalculationMethod')" (blur)="focusOut()">
+        <option *ngFor="let method of calculationMethods" [ngValue]="method">{{method}}</option>
+      </select>
+    </div>
+
+    <div class="form-group" *ngIf="!isExcessAirDisabled()">
       <label class="small" for="excessAirPercentage">Excess Air</label>
       <div class="input-group">
         <input name="{{'excessAirPercentage_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="excessAirPercentage"
           id="excessAirPercentage" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('excessAirPercentage')" (blur)="focusOut()">
+        <span class="input-group-addon units">%</span>
+      </div>
+    </div>
+
+    <div class="form-group" *ngIf="isExcessAirDisabled()">
+      <label class="small" for="o2InFlueGas">Oxygen In Flue Gas</label>
+      <div class="input-group">
+        <input name="{{'o2InFlueGas_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="o2InFlueGas"
+               id="o2InFlueGas" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
         <span class="input-group-addon units">%</span>
       </div>
     </div>

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
@@ -20,7 +20,7 @@
     </div>
 
     <div class="form-group">
-      <label class="small" for="oxygenCalculationMethod">Oxygen Calculation Method</label>
+      <label class="small" for="oxygenCalculationMethod">Percent Oxygen Or Excess Air?</label>
       <select name="{{'oxygenCalculationMethod_'+lossIndex}}" class="form-control" formControlName="oxygenCalculationMethod" id="oxygenCalculationMethod" (change)="setProperties()" (focus)="focusField('oxygenCalculationMethod')" (blur)="focusOut()">
         <option *ngFor="let method of calculationMethods" [ngValue]="method">{{method}}</option>
       </select>

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
@@ -29,31 +29,33 @@
     <div class="form-group" *ngIf="!isExcessAirDisabled()">
       <label class="small" for="excessAirPercentage">Excess Air</label>
       <div class="input-group">
-        <input name="{{'excessAirPercentage_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="excessAirPercentage"
+        <input name="{{'excessAirPercentage_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="excessAirPercentage"
           id="excessAirPercentage" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('excessAirPercentage')" (blur)="focusOut()">
         <span class="input-group-addon units">%</span>
       </div>
+      <span class="alert-warning pull-right small" *ngIf="calculationWarning !== null">{{calculationWarning}}</span>
       <div class="form-group">
         <label class="small">Oxygen In Flue Gas</label>
         <div class="text-center small">
-          {{50 | number:'2.2-2'}}
+          {{calculationFlueGasO2 | number:'2.2-2'}} %
         </div>
       </div>
     </div>
 
     <div class="form-group" *ngIf="isExcessAirDisabled()">
-      <label class="small" for="o2InFlueGas">Oxygen In Flue Gas</label>
-      <div class="input-group">
-        <input name="{{'o2InFlueGas_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="o2InFlueGas"
-               id="o2InFlueGas" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
-        <span class="input-group-addon units">%</span>
-      </div>
       <div class="form-group">
         <label class="small">Excess Air</label>
         <div class="text-center small">
-          {{13 | number:'2.2-2'}}
+          {{calculationExcessAir | number:'2.2-2'}} %
         </div>
       </div>
+      <label class="small" for="o2InFlueGas">Oxygen In Flue Gas</label>
+      <div class="input-group">
+        <input name="{{'o2InFlueGas_'+lossIndex}}" type="number" step="any" min="0" max="20" class="form-control" formControlName="o2InFlueGas"
+               id="o2InFlueGas" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
+        <span class="input-group-addon units">%</span>
+      </div>
+      <span class="alert-warning pull-right small" *ngIf="calculationWarning !== null">{{calculationWarning}}</span>
     </div>
 
     <div class="form-group">

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
@@ -26,33 +26,33 @@
       </select>
     </div>
 
-    <div class="form-group" *ngIf="!isExcessAirDisabled()">
-      <label class="small" for="excessAirPercentage">Excess Air</label>
+    <div class="form-group" *ngIf="isExcessAirDisabled()">
+      <label class="small" for="o2InFlueGas">Oxygen In Flue Gas</label>
       <div class="input-group">
-        <input name="{{'excessAirPercentage_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="excessAirPercentage"
-          id="excessAirPercentage" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('excessAirPercentage')" (blur)="focusOut()">
+        <input name="{{'o2InFlueGas_'+lossIndex}}" type="number" step="any" min="0" max="20" class="form-control" formControlName="o2InFlueGas"
+               id="o2InFlueGas" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
         <span class="input-group-addon units">%</span>
       </div>
       <span class="alert-warning pull-right small" *ngIf="calculationWarning !== null">{{calculationWarning}}</span>
-      <div class="form-group">
-        <label class="small">Oxygen In Flue Gas</label>
-        <div class="text-center small">
-          {{calculationFlueGasO2 | number:'2.2-2'}} %
-        </div>
-      </div>
-    </div>
-
-    <div class="form-group" *ngIf="isExcessAirDisabled()">
       <div class="form-group">
         <label class="small">Excess Air</label>
         <div class="text-center small">
           {{calculationExcessAir | number:'2.2-2'}} %
         </div>
       </div>
-      <label class="small" for="o2InFlueGas">Oxygen In Flue Gas</label>
+    </div>
+
+    <div class="form-group" *ngIf="!isExcessAirDisabled()">
+      <div class="form-group">
+        <label class="small">Oxygen In Flue Gas</label>
+        <div class="text-center small">
+          {{calculationFlueGasO2 | number:'2.2-2'}} %
+        </div>
+      </div>
+      <label class="small" for="excessAirPercentage">Excess Air</label>
       <div class="input-group">
-        <input name="{{'o2InFlueGas_'+lossIndex}}" type="number" step="any" min="0" max="20" class="form-control" formControlName="o2InFlueGas"
-               id="o2InFlueGas" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
+        <input name="{{'excessAirPercentage_'+lossIndex}}" type="number" step="any" min="0" class="form-control" formControlName="excessAirPercentage"
+               id="excessAirPercentage" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('excessAirPercentage')" (blur)="focusOut()">
         <span class="input-group-addon units">%</span>
       </div>
       <span class="alert-warning pull-right small" *ngIf="calculationWarning !== null">{{calculationWarning}}</span>

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.html
@@ -33,6 +33,12 @@
           id="excessAirPercentage" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('excessAirPercentage')" (blur)="focusOut()">
         <span class="input-group-addon units">%</span>
       </div>
+      <div class="form-group">
+        <label class="small">Oxygen In Flue Gas</label>
+        <div class="text-center small">
+          {{50 | number:'2.2-2'}}
+        </div>
+      </div>
     </div>
 
     <div class="form-group" *ngIf="isExcessAirDisabled()">
@@ -41,6 +47,12 @@
         <input name="{{'o2InFlueGas_'+lossIndex}}" type="number" step="any" class="form-control" formControlName="o2InFlueGas"
                id="o2InFlueGas" onfocus="this.select();" (input)="startSavePolling()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
         <span class="input-group-addon units">%</span>
+      </div>
+      <div class="form-group">
+        <label class="small">Excess Air</label>
+        <div class="text-center small">
+          {{13 | number:'2.2-2'}}
+        </div>
       </div>
     </div>
 

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.ts
@@ -34,6 +34,10 @@ export class FlueGasLossesFormVolumeComponent implements OnInit {
 
   firstChange: boolean = true;
   options: any;
+  calculationMethods = [
+    'Excess Air',
+    'Oxygen in Flue Gas'
+  ];
   counter: any;
   showModal: boolean = false;
   constructor(private suiteDbService: SuiteDbService, private flueGasCompareService: FlueGasCompareService, private windowRefService: WindowRefService, private lossesService: LossesService) { }
@@ -64,6 +68,7 @@ export class FlueGasLossesFormVolumeComponent implements OnInit {
       } else {
         this.enableForm();
       }
+      this.isExcessAirDisabled = (this.flueGasLossForm.value.calculationMethod === 'Excess Air');
     } else {
       this.firstChange = false;
     }
@@ -91,6 +96,10 @@ export class FlueGasLossesFormVolumeComponent implements OnInit {
     for (var i = 0, len = this.elements.length; i < len; ++i) {
       this.elements[i].disabled = false;
     }
+  }
+
+  isExcessAirDisabled() {
+    return this.flueGasLossForm.value.oxygenCalculationMethod === 'Oxygen in Flue Gas';
   }
 
   setProperties() {

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-volume/flue-gas-losses-form-volume.component.ts
@@ -68,7 +68,6 @@ export class FlueGasLossesFormVolumeComponent implements OnInit {
       } else {
         this.enableForm();
       }
-      this.isExcessAirDisabled = (this.flueGasLossForm.value.calculationMethod === 'Excess Air');
     } else {
       this.firstChange = false;
     }
@@ -169,6 +168,13 @@ export class FlueGasLossesFormVolumeComponent implements OnInit {
         });
         // fuelTemperature
         this.flueGasCompareService.differentArray[this.lossIndex].different.flueGasVolumeDifferent.fuelTemperature.subscribe((val) => {
+          let fuelTemperatureElements = doc.getElementsByName('fuelTemperature_' + this.lossIndex);
+          fuelTemperatureElements.forEach(element => {
+            element.classList.toggle('indicate-different', val);
+          });
+        });
+        // Oxygen Calculation Method
+        this.flueGasCompareService.differentArray[this.lossIndex].different.flueGasVolumeDifferent.oxygenCalculationMethod.subscribe((val) => {
           let fuelTemperatureElements = doc.getElementsByName('fuelTemperature_' + this.lossIndex);
           fuelTemperatureElements.forEach(element => {
             element.classList.toggle('indicate-different', val);

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses.service.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses.service.ts
@@ -31,7 +31,9 @@ export class FlueGasLossesService {
     return this.formBuilder.group({
       'gasTypeId': [1, Validators.required],
       'flueGasTemperature': ['', Validators.required],
+      'oxygenCalculationMethod': ['', Validators.required],
       'excessAirPercentage': ['', Validators.required],
+      'o2InFlueGas': ['', Validators.required],
       'combustionAirTemperature': ['', Validators.required],
       'fuelTemperature': ['', Validators.required],
       'CH4': ['', Validators.required],
@@ -72,7 +74,9 @@ export class FlueGasLossesService {
     return this.formBuilder.group({
       'gasTypeId': [loss.flueGasByVolume.gasTypeId, Validators.required],
       'flueGasTemperature': [loss.flueGasByVolume.flueGasTemperature, Validators.required],
+      'oxygenCalculationMethod': [loss.flueGasByVolume.oxygenCalculationMethod, Validators.required],
       'excessAirPercentage': [loss.flueGasByVolume.excessAirPercentage, Validators.required],
+      'o2InFlueGas': [loss.flueGasByVolume.o2InFlueGas, Validators.required],
       'combustionAirTemperature': [loss.flueGasByVolume.combustionAirTemperature, Validators.required],
       'fuelTemperature': [loss.flueGasByVolume.fuelTemperature, Validators.required],
       'CH4': [loss.flueGasByVolume.CH4, Validators.required],
@@ -134,7 +138,9 @@ export class FlueGasLossesService {
     let tmpFlueGas: FlueGasByVolume = {
       gasTypeId: form.value.gasTypeId,
       flueGasTemperature: form.value.flueGasTemperature,
+      oxygenCalculationMethod: form.value.oxygenCalculationMethod,
       excessAirPercentage: form.value.excessAirPercentage,
+      o2InFlueGas: form.value.o2InFlueGas,
       combustionAirTemperature: form.value.combustionAirTemperature,
       fuelTemperature: form.value.fuelTemperature,
       CH4: form.value.CH4,

--- a/src/app/phast/phast.service.ts
+++ b/src/app/phast/phast.service.ts
@@ -305,6 +305,14 @@ export class PhastService {
     return results;
   }
 
+  flueGasCalculateExcessAir(input: any) {
+    return phastAddon.flueGasCalculateExcessAir(input);
+  }
+
+  flueGasCalculateO2(input: any) {
+    return phastAddon.flueGasCalculateO2(input);
+  }
+
   atmosphere(input: AtmosphereLoss, settings: Settings) {
     let inputs = this.createInputCopy(input);
     let results = 0;

--- a/src/app/shared/mocks/mock-directory.ts
+++ b/src/app/shared/mocks/mock-directory.ts
@@ -243,7 +243,7 @@ export const MockDirectory: Directory = {
                 flueGasTemperature: 1400,
                 oxygenCalculationMethod: 'Excess Air',
                 excessAirPercentage: 10.0,
-                o2InFlueGas: 99.3,
+                o2InFlueGas: 0.5,
                 combustionAirTemperature: 500,
                 fuelTemperature: 125,
                 gasTypeId: 1,

--- a/src/app/shared/mocks/mock-directory.ts
+++ b/src/app/shared/mocks/mock-directory.ts
@@ -241,7 +241,9 @@ export const MockDirectory: Directory = {
               flueGasType: "By Volume",
               flueGasByVolume: {
                 flueGasTemperature: 1400,
+                oxygenCalculationMethod: 'Excess Air',
                 excessAirPercentage: 10.0,
+                o2InFlueGas: 99.3,
                 combustionAirTemperature: 500,
                 fuelTemperature: 125,
                 gasTypeId: 1,

--- a/src/app/shared/models/phast/losses/flueGas.ts
+++ b/src/app/shared/models/phast/losses/flueGas.ts
@@ -25,7 +25,9 @@ export interface FlueGasByMass {
 export interface FlueGasByVolume {
     gasTypeId?: number,
     flueGasTemperature?: number,
+    oxygenCalculationMethod?: string,
     excessAirPercentage?: number,
+    o2InFlueGas?: number,
     combustionAirTemperature?: number,
     fuelTemperature?: number,
     CH4?: number,


### PR DESCRIPTION
Allows the user to select excess air or oxygen in flue gas via dropdown menu for the flue gas by volume calculation. The non-selected field will be shown as a calculated, non-editable value.

connect #927 