### PR TITLE
fix psat report, set version num electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "codelyzer": "~2.0.0",
     "css-loader": "^0.28.7",
     "electron": "^1.7.6",
-    "electron-builder": "^19.45.6",
+    "electron-builder": "19.53.2",
     "electron-packager": "^9.0.0",
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",

--- a/src/app/psat/psat-report/output-summary/output-summary.component.ts
+++ b/src/app/psat/psat-report/output-summary/output-summary.component.ts
@@ -88,7 +88,7 @@ export class OutputSummaryComponent implements OnInit {
   }
 
   useModification() {
-    this.reportRollupService.updateSelectedPsats(this.assessment, this.selectedModificationIndex);
+    this.reportRollupService.updateSelectedPsats({assessment: this.assessment, settings: this.settings}, this.selectedModificationIndex);
   }
 
   getDiff(num1: number, num2: number) {


### PR DESCRIPTION
updated psat report rollup to match phast methods

set electron-builder version to know working version without ^