### PR TITLE
Adds limiting values to the Specific Speed graph

### DIFF
--- a/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement.component.ts
+++ b/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement.component.ts
@@ -37,7 +37,7 @@ export class EfficiencyImprovementComponent implements OnInit {
           this.initDefaultValues(this.settings);
           this.calculate();
         }
-      })
+      });
     } else {
       this.initDefaultValues(this.settings);
       this.calculate();

--- a/src/app/calculator/pumps/specific-speed/specific-speed-graph/specific-speed-graph.component.ts
+++ b/src/app/calculator/pumps/specific-speed/specific-speed-graph/specific-speed-graph.component.ts
@@ -240,13 +240,27 @@ export class SpecificSpeedGraphComponent implements OnInit {
         .style("font-size", "13px");
 
       var data = [];
-      for (var i = 100; i < 100000; i = i + 25) {
-        var efficiencyCorrection = this.psatService.achievableEfficiency(this.speedForm.controls.pumpType.value, i);
-        if (efficiencyCorrection <= 5.5) {
-          data.push({
-            x: i,
-            y: efficiencyCorrection
-          });
+
+      if (this.speedForm.controls.pumpType.value === "Vertical Turbine") {
+
+        for (var i = 1720; i < 16350; i = i + 25) {
+          var efficiencyCorrection = this.psatService.achievableEfficiency(this.speedForm.controls.pumpType.value, i);
+          if (efficiencyCorrection <= 5.5) {
+            data.push({
+              x: i,
+              y: efficiencyCorrection
+            });
+          }
+        }
+      } else {
+        for (var i = 680; i < 7300; i = i + 25) {
+          var efficiencyCorrection = this.psatService.achievableEfficiency(this.speedForm.controls.pumpType.value, i);
+          if (efficiencyCorrection <= 5.5) {
+            data.push({
+              x: i,
+              y: efficiencyCorrection
+            });
+          }
         }
       }
 
@@ -464,14 +478,24 @@ export class SpecificSpeedGraphComponent implements OnInit {
         if (this.y(efficiencyCorrection) >= 0) {
           return "translate(" + this.x(specificSpeed) + "," + this.y(efficiencyCorrection) + ")";
         }
+
       })
       .style("display", () => {
-        if (this.y(efficiencyCorrection) >= 0) {
-          return null;
+
+        if (this.speedForm.controls.pumpType.value === "Vertical Turbine") {
+          if (specificSpeed >= 1720 && specificSpeed <= 16350) {
+            return null;
+          } else {
+            return "none";
+          }
+        } else {
+          if (specificSpeed >= 680 && specificSpeed <= 7300) {
+            return null;
+          } else {
+            return "none";
+          }
         }
-        else {
-          return "none";
-        }
+
       });
 
     this.svg.append("text")
@@ -518,7 +542,7 @@ export class SpecificSpeedGraphComponent implements OnInit {
       .style("stroke", "#2ECC71")
       .style('pointer-events', 'none');
 
-      
+
   }
 
 }


### PR DESCRIPTION
	modified:   src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement.component.ts
	modified:   src/app/calculator/pumps/specific-speed/specific-speed-graph/specific-speed-graph.component.ts

Limits the values shown on the Specific Speed graph depending on if the pump type is VTP or not. Values that are outside the range are valid inputs in the text box, but will not show as a point on the graph.

connects #892