### PR TITLE
Various PHAST issues

### DIFF
--- a/src/app/phast/losses/charge-material/charge-material.component.ts
+++ b/src/app/phast/losses/charge-material/charge-material.component.ts
@@ -257,8 +257,8 @@ export class ChargeMaterialComponent implements OnInit {
       if (material.chargeMaterialType == 'Gas') {
         if (!material.gasForm.controls.name.value) {
           material.gasForm.patchValue({
-            name: 'Loss #' + lossIndex
-          })
+            name: 'Material #' + lossIndex
+          });
         }
         lossIndex++;
         tmpMaterial = this.chargeMaterialService.buildGasChargeMaterial(material.gasForm);
@@ -267,8 +267,8 @@ export class ChargeMaterialComponent implements OnInit {
       } else if (material.chargeMaterialType == 'Solid') {
         if (!material.solidForm.controls.name.value) {
           material.solidForm.patchValue({
-            name: 'Loss #' + lossIndex
-          })
+            name: 'Material #' + lossIndex
+          });
         }
         lossIndex++;
         tmpMaterial = this.chargeMaterialService.buildSolidChargeMaterial(material.solidForm);
@@ -277,8 +277,8 @@ export class ChargeMaterialComponent implements OnInit {
       } else if (material.chargeMaterialType == 'Liquid') {
         if (!material.liquidForm.controls.name.value) {
           material.liquidForm.patchValue({
-            name: 'Loss #' + lossIndex
-          })
+            name: 'Material #' + lossIndex
+          });
         }
         lossIndex++;
         tmpMaterial = this.chargeMaterialService.buildLiquidChargeMaterial(material.liquidForm);
@@ -286,7 +286,7 @@ export class ChargeMaterialComponent implements OnInit {
         tmpMaterial.chargeMaterialType = 'Liquid';
       }
       tmpChargeMaterials.push(tmpMaterial);
-    })
+    });
     this.losses.chargeMaterials = tmpChargeMaterials;
     this.setCompareVals();
     this.savedLoss.emit(true);

--- a/src/app/phast/losses/charge-material/charge-material.service.ts
+++ b/src/app/phast/losses/charge-material/charge-material.service.ts
@@ -38,9 +38,8 @@ export class ChargeMaterialService {
       'heatOfReaction': [0, Validators.required],
       'endothermicOrExothermic': ['Endothermic', Validators.required],
       'additionalHeatRequired': [0, Validators.required],
-      'name': ['Loss #' + lossNum]
-
-    })
+      'name': ['Material #' + lossNum]
+    });
   }
   //gas charge material form from GasChargeMaterial
   getGasChargeMaterialForm(chargeMaterial: ChargeMaterial): FormGroup {
@@ -104,8 +103,8 @@ export class ChargeMaterialService {
       'heatOfReaction': [0, Validators.required],
       'endothermicOrExothermic': ['Endothermic', Validators.required],
       'additionalHeatRequired': [0, Validators.required],
-      'name': ['Loss #' + lossNum]
-    })
+      'name': ['Material #' + lossNum]
+    });
   }
 
   //liquid charge material form from LiquidChargeMaterial
@@ -179,8 +178,8 @@ export class ChargeMaterialService {
       'heatOfReaction': [0, Validators.required],
       'endothermicOrExothermic': ['Endothermic', Validators.required],
       'additionalHeatRequired': [0, Validators.required],
-      'name': ['Loss #' + lossNum]
-    })
+      'name': ['Material #' + lossNum]
+    });
   }
 
   //solid material form from SolidChargeMaterial

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses.component.html
@@ -61,7 +61,7 @@
       <div class="form-group">
         <label class="small font-weight-bold">Available Heat</label>
         <div *ngIf="loss.availableHeat" class="text-center small font-weight-bold">
-          {{loss.availableHeat | number:'2.0-0'}} %
+          {{loss.availableHeat | number:'2.1-1'}} %
         </div>
         <div *ngIf="!loss.availableHeat" class="text-center small font-weight-bold">
           &mdash; &mdash;
@@ -79,7 +79,7 @@
         </div>
       </div>
       <div class="form-group">
-        <label class="small font-weight-bold">System Losses</label>
+        <label class="small font-weight-bold">Flue Gas Losses</label>
         <div *ngIf="loss.systemLosses" class="text-center small font-weight-bold">
           {{loss.systemLosses | sigFigs:'5'}}
           <span>{{resultsUnit}}</span>

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses.component.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses.component.ts
@@ -218,14 +218,6 @@ export class FlueGasLossesComponent implements OnInit {
         const sumHeat = this.phastService.sumHeatInput(this.losses, this.settings);
         loss.grossHeat = (sumHeat / availableHeat) - sumAdditionalHeat;
         loss.systemLosses = (loss.grossHeat + sumAdditionalHeat) * (1 - availableHeat);
-
-        // loss.systemLosses = grossHeat * (1 - availableHeat);
-
-        // const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
-        // results.flueGasAvailableHeat = availableHeat * 100;
-        // results.flueGasGrossHeat = (results.totalInput / availableHeat);
-        // results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - availableHeat);
-        // results.totalFlueGas = results.flueGasSystemLosses;
       } else {
         loss.availableHeat = null;
         loss.grossHeat = null;

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses.component.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses.component.ts
@@ -208,16 +208,24 @@ export class FlueGasLossesComponent implements OnInit {
     if (loss.measurementType == "By Volume") {
       if (loss.formByVolume.status == 'VALID') {
         let tmpLoss: FlueGas = this.flueGasLossesService.buildByVolumeLossFromForm(loss.formByVolume);
-        let tmpResult = this.phastService.flueGasByVolume(tmpLoss.flueGasByVolume, this.settings);
-        loss.availableHeat = tmpResult * 100;
+        const availableHeat = this.phastService.flueGasByVolume(tmpLoss.flueGasByVolume, this.settings);
+        loss.availableHeat = availableHeat * 100;
         if (loss.availableHeat < 0 || loss.availableHeat > 100) {
           this.availableHeatError = 'Available heat is' + ' ' + loss.availableHeat.toFixed(2) + '%' + '.' + ' ' + 'Check your input fields.';
         } else {
           this.availableHeatError = null;
         }
-        let sumHeat = this.phastService.sumHeatInput(this.losses, this.settings);
-        loss.grossHeat = (sumHeat / tmpResult) - sumAdditionalHeat;
-        loss.systemLosses = loss.grossHeat * (1 - tmpResult);
+        const sumHeat = this.phastService.sumHeatInput(this.losses, this.settings);
+        loss.grossHeat = (sumHeat / availableHeat) - sumAdditionalHeat;
+        loss.systemLosses = (loss.grossHeat + sumAdditionalHeat) * (1 - availableHeat);
+
+        // loss.systemLosses = grossHeat * (1 - availableHeat);
+
+        // const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
+        // results.flueGasAvailableHeat = availableHeat * 100;
+        // results.flueGasGrossHeat = (results.totalInput / availableHeat);
+        // results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - availableHeat);
+        // results.totalFlueGas = results.flueGasSystemLosses;
       } else {
         loss.availableHeat = null;
         loss.grossHeat = null;
@@ -226,16 +234,16 @@ export class FlueGasLossesComponent implements OnInit {
     } else if (loss.measurementType == "By Mass") {
       if (loss.formByMass.status == 'VALID') {
         let tmpLoss: FlueGas = this.flueGasLossesService.buildByMassLossFromForm(loss.formByMass);
-        let tmpResult = this.phastService.flueGasByMass(tmpLoss.flueGasByMass, this.settings);
-        loss.availableHeat = tmpResult * 100;
+        const availableHeat = this.phastService.flueGasByMass(tmpLoss.flueGasByMass, this.settings);
+        loss.availableHeat = availableHeat * 100;
         if (loss.availableHeat < 0 || loss.availableHeat > 100) {
           this.availableHeatError = 'Available heat is' + ' ' + loss.availableHeat.toFixed(2) + '%' + '.' + ' ' + 'Check your input fields.';
         } else {
           this.availableHeatError = null;
         }
-        let heatInput = this.phastService.sumHeatInput(this.losses, this.settings);
-        loss.grossHeat = (heatInput / tmpResult) - sumAdditionalHeat;;
-        loss.systemLosses = loss.grossHeat * (1 - tmpResult);
+        const heatInput = this.phastService.sumHeatInput(this.losses, this.settings);
+        loss.grossHeat = (heatInput / availableHeat) - sumAdditionalHeat;
+        loss.systemLosses = (loss.grossHeat + sumAdditionalHeat) * (1 - availableHeat);
       } else {
         loss.availableHeat = null;
         loss.grossHeat = null;

--- a/src/app/phast/phast-report/phast-input-summary/cooling-summary/cooling-summary.component.html
+++ b/src/app/phast/phast-report/phast-input-summary/cooling-summary/cooling-summary.component.html
@@ -46,10 +46,10 @@
                 Name of Cooling Medium
               </td>
               <td [ngClass]="{'indicate-report-field-different':nameDiff[index] == true}">
-                {{data.baseline.name}}
+                {{data.baseline.coolingMedium}}
               </td>
-              <td *ngFor="let mod of data.modifications" [ngClass]="{'indicate-report-field-different': checkDiff(data.baseline.name, mod.name, 'nameDiff', index)}">
-                {{mod.name}}
+              <td *ngFor="let mod of data.modifications" [ngClass]="{'indicate-report-field-different': checkDiff(data.baseline.coolingMedium, mod.coolingMedium, 'nameDiff', index)}">
+                {{mod.coolingMedium}}
               </td>
             </tr>
             <tr>

--- a/src/app/phast/phast-report/phast-input-summary/cooling-summary/cooling-summary.component.ts
+++ b/src/app/phast/phast-report/phast-input-summary/cooling-summary/cooling-summary.component.ts
@@ -117,6 +117,7 @@ export class CoolingSummaryComponent implements OnInit {
     }
     let tmpCoolingLossData: CoolingLossData = {
       name: loss.name,
+      coolingMedium: loss.coolingMedium,
       coolingType: loss.coolingLossType,
       flowRate: tmpFlowRate,
       density: tmpDensity,
@@ -124,7 +125,7 @@ export class CoolingSummaryComponent implements OnInit {
       outletTemperature: tmpOutletTemp,
       specificHeat: tmpSpecificHeat,
       correctionFactor: tmpCorrectionFactor
-    }
+    };
     return tmpCoolingLossData;
   }
 }
@@ -132,6 +133,7 @@ export class CoolingSummaryComponent implements OnInit {
 
 export interface CoolingLossData {
   name: string,
+  coolingMedium: string,
   coolingType: string,
   flowRate: number,
   density: number,

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -158,10 +158,10 @@
       </tr>
       <tr *ngIf="showResultsCats.showFlueGas">
         <td>Available Heat</td>
-        <td *ngIf="baseLineResults.flueGasAvailableHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.flueGasAvailableHeat| number:'1.0-0'}} %</td>
+        <td *ngIf="baseLineResults.flueGasAvailableHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.flueGasAvailableHeat| number:'2.1-1'}} %</td>
         <td *ngIf="!baseLineResults.flueGasAvailableHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.flueGasAvailableHeat">{{mod.flueGasAvailableHeat| number:'1.0-0'}} %</span>
+          <span *ngIf="mod.flueGasAvailableHeat">{{mod.flueGasAvailableHeat| number:'2.1-1'}} %</span>
           <span *ngIf="!mod.flueGasAvailableHeat">&mdash; &mdash;</span>
         </td>
       </tr>

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -137,22 +137,15 @@ export class PhastResultsService {
         if (tmpFlueGas.flueGasType == 'By Mass') {
           let tmpForm = this.flueGasLossesService.initByMassFormFromLoss(tmpFlueGas);
           if (tmpForm.status == 'VALID') {
-            let tmpVal = this.phastService.flueGasByMass(tmpFlueGas.flueGasByMass, settings);
-            results.flueGasAvailableHeat = tmpVal * 100;
-            results.flueGasGrossHeat = (results.totalInput / tmpVal);
-            results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - tmpVal);
+            const availableHeat = this.phastService.flueGasByMass(tmpFlueGas.flueGasByMass, settings);
+            results.flueGasAvailableHeat = availableHeat * 100;
+            results.flueGasGrossHeat = (results.totalInput / availableHeat);
+            results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - availableHeat);
             results.totalFlueGas = results.flueGasSystemLosses;
           }
         } else if (tmpFlueGas.flueGasType == 'By Volume') {
           let tmpForm = this.flueGasLossesService.initByVolumeFormFromLoss(tmpFlueGas);
           if (tmpForm.status == 'VALID') {
-            // const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
-            // results.flueGasAvailableHeat = availableHeat * 100;
-            // results.flueGasGrossHeat = (results.totalInput / availableHeat);
-            // results.flueGasSystemLosses = results.flueGasGrossHeat - results.totalInput;
-            // results.totalFlueGas = results.flueGasSystemLosses;
-
-            // original stuff
             const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
             results.flueGasAvailableHeat = availableHeat * 100;
             results.flueGasGrossHeat = (results.totalInput / availableHeat);

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -146,18 +146,18 @@ export class PhastResultsService {
         } else if (tmpFlueGas.flueGasType == 'By Volume') {
           let tmpForm = this.flueGasLossesService.initByVolumeFormFromLoss(tmpFlueGas);
           if (tmpForm.status == 'VALID') {
+            // const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
+            // results.flueGasAvailableHeat = availableHeat * 100;
+            // results.flueGasGrossHeat = (results.totalInput / availableHeat);
+            // results.flueGasSystemLosses = results.flueGasGrossHeat - results.totalInput;
+            // results.totalFlueGas = results.flueGasSystemLosses;
+
+            // original stuff
             const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
             results.flueGasAvailableHeat = availableHeat * 100;
             results.flueGasGrossHeat = (results.totalInput / availableHeat);
-            results.flueGasSystemLosses = results.flueGasGrossHeat - results.totalInput;
+            results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - availableHeat);
             results.totalFlueGas = results.flueGasSystemLosses;
-
-            // original stuff
-            // let availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
-            // results.flueGasAvailableHeat = availableHeat * 100;
-            // results.flueGasGrossHeat = (results.totalInput / availableHeat);
-            // results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - availableHeat);
-            // results.totalFlueGas = results.flueGasSystemLosses;
           }
         }
         results.grossHeatInput = results.totalInput + results.flueGasSystemLosses - results.exothermicHeat;

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -146,11 +146,18 @@ export class PhastResultsService {
         } else if (tmpFlueGas.flueGasType == 'By Volume') {
           let tmpForm = this.flueGasLossesService.initByVolumeFormFromLoss(tmpFlueGas);
           if (tmpForm.status == 'VALID') {
-            let tmpVal = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
-            results.flueGasAvailableHeat = tmpVal * 100;
-            results.flueGasGrossHeat = (results.totalInput / tmpVal);
-            results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - tmpVal);
+            const availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
+            results.flueGasAvailableHeat = availableHeat * 100;
+            results.flueGasGrossHeat = (results.totalInput / availableHeat);
+            results.flueGasSystemLosses = results.flueGasGrossHeat - results.totalInput;
             results.totalFlueGas = results.flueGasSystemLosses;
+
+            // original stuff
+            // let availableHeat = this.phastService.flueGasByVolume(tmpFlueGas.flueGasByVolume, settings);
+            // results.flueGasAvailableHeat = availableHeat * 100;
+            // results.flueGasGrossHeat = (results.totalInput / availableHeat);
+            // results.flueGasSystemLosses = results.flueGasGrossHeat * (1 - availableHeat);
+            // results.totalFlueGas = results.flueGasSystemLosses;
           }
         }
         results.grossHeatInput = results.totalInput + results.flueGasSystemLosses - results.exothermicHeat;

--- a/src/app/phast/phast.service.ts
+++ b/src/app/phast/phast.service.ts
@@ -573,7 +573,6 @@ export class PhastService {
     }
     if (losses.chargeMaterials) {
       grossHeatRequired += this.sumChargeMaterials(losses.chargeMaterials, settings);
-      grossHeatRequired -= this.sumChargeMaterialExothermic(losses.chargeMaterials, settings);
     }
     if (losses.coolingLosses) {
       grossHeatRequired += this.sumCoolingLosses(losses.coolingLosses, settings);

--- a/src/app/phast/phast.service.ts
+++ b/src/app/phast/phast.service.ts
@@ -573,6 +573,7 @@ export class PhastService {
     }
     if (losses.chargeMaterials) {
       grossHeatRequired += this.sumChargeMaterials(losses.chargeMaterials, settings);
+      grossHeatRequired -= this.sumChargeMaterialExothermic(losses.chargeMaterials, settings);
     }
     if (losses.coolingLosses) {
       grossHeatRequired += this.sumCoolingLosses(losses.coolingLosses, settings);

--- a/src/app/settings/phast-settings/phast-settings.component.ts
+++ b/src/app/settings/phast-settings/phast-settings.component.ts
@@ -49,12 +49,16 @@ export class PhastSettingsComponent implements OnInit {
     if (this.settingsForm.controls.energySourceType.value == 'Fuel') {
       this.settingsForm.patchValue({
         furnaceType: 'Ladle Heater'
-      })
+      });
     } else if (this.settingsForm.controls.energySourceType.value == 'Electricity') {
       this.settingsForm.patchValue({
         furnaceType: 'Electrical Infrared',
         energyResultUnit: 'kWh'
-      })
+      });
+    } else if (this.settingsForm.controls.energySourceType.value === 'Steam') {
+      this.settingsForm.patchValue({
+        furnaceType: 'Steam'
+      });
     }
   }
 

--- a/src/app/shared/json-to-csv/json-to-csv.service.ts
+++ b/src/app/shared/json-to-csv/json-to-csv.service.ts
@@ -54,6 +54,8 @@ export class JsonToCsvService {
       PumpRatedSpeed: psat.inputs.pump_rated_speed,
       PumpRatedSpeedUnit: 'rpms',
       Drive: this.psatService.getDriveFromEnum(psat.inputs.drive),
+      FluidType: psat.inputs.fluidType,
+      FluidTemperature: psat.inputs.fluidTemperature,
       KinematicViscosity: psat.inputs.kinematic_viscosity,
       KinematicViscosityUnit: 'cST',
       SpecificGravity: psat.inputs.specific_gravity,
@@ -107,7 +109,7 @@ export class JsonToCsvService {
       AnnualCost: tmpResults.annual_cost,
       AnnualCostUnit: '$',
       Optimized: isOptimized
-    }
+    };
     return tmpPsatCsvData;
   }
 }
@@ -122,6 +124,8 @@ export interface PsatCsvData {
   PumpRatedSpeed: number,
   PumpRatedSpeedUnit: string,
   Drive: string,
+  FluidType: string,
+  FluidTemperature: number,
   KinematicViscosity: number,
   KinematicViscosityUnit: string,
   SpecificGravity: number,
@@ -186,6 +190,8 @@ export const PsatCsvDataFields = [
   "PumpRatedSpeed",
   "PumpRatedSpeedUnit",
   "Drive",
+  "FluidType",
+  "FluidTemperature",
   "KinematicViscosity",
   "KinematicViscosityUnit",
   "SpecificGravity",
@@ -234,4 +240,4 @@ export const PsatCsvDataFields = [
   "AnnualCost",
   "AnnualCostUnit",
   "Optimized"
-]
+];


### PR DESCRIPTION
connects #1106
connects #1184
connects #1200
connects #1242
connects #1244
connects #1245
connects #1246 

-Adds cooling medium name for cooling losses in reports
-Changes Charge Materials "Loss" default name to "Material" default name
-Export to CSV for PSAT now includes fluid type and fluid temperature
-When using Steam as a furnace type, the furnace type now defaults "Steam" instead of Ladle
-Exothermic heating values are now computed correctly for charge materials
-System Losses is now Flue Gas Losses on the flue gas page, the results page results are computed the same way as the immediate values on the flue gas page
-Available heat has one more sig fig, for a total of 3 sig figs
