### PR TITLE
Typos and Max Value Fixes

### DIFF
--- a/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement-form/efficiency-improvement-form.component.html
+++ b/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement-form/efficiency-improvement-form.component.html
@@ -14,14 +14,14 @@
           <label class="col-4 col-form-label" for="currentFlueGasOxygen">Flue Gas Oxygen</label>
           <div class="col-4">
             <div class="input-group">
-              <input autofocus class="form-control" name="currentFlueGasOxygen" type="number" step="any" id="currentFlueGasOxygen" [(ngModel)]="efficiencyImprovementInputs.currentFlueGasOxygen"
+              <input autofocus class="form-control" name="currentFlueGasOxygen" type="number" max="100" step="any" id="currentFlueGasOxygen" [(ngModel)]="efficiencyImprovementInputs.currentFlueGasOxygen"
                 (input)="calc()" onfocus="this.select();" (focus)="focusField('flueGasOxygen')" (blur)="focusOut()">
               <span class="input-group-addon units">% Dry</span>
             </div>
           </div>
           <div class="col-4">
             <div class="input-group">
-              <input class="form-control" name="newFlueGasOxygen" type="number" step="any" id="newFlueGasOxygen" [(ngModel)]="efficiencyImprovementInputs.newFlueGasOxygen"
+              <input class="form-control" name="newFlueGasOxygen" type="number" max="100" step="any" id="newFlueGasOxygen" [(ngModel)]="efficiencyImprovementInputs.newFlueGasOxygen"
                 (input)="calc()" onfocus="this.select();" (focus)="focusField('flueGasOxygen')" (blur)="focusOut()">
               <span class="input-group-addon units">% Dry</span>
             </div>

--- a/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement-help/efficiency-improvement-help.component.html
+++ b/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement-help/efficiency-improvement-help.component.html
@@ -49,8 +49,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong> &#8457;</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed:
-            <strong>3,000</strong><br>
+            Units: <strong> &#8457;</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -67,8 +66,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong> &#8457;</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed:
-            <strong>1,600</strong><br>
+            Units: <strong> &#8457;</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -84,8 +82,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>MMBtu/hr</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed:
-            <strong>10,000</strong><br>
+            Units: <strong>MMBtu/hr</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>

--- a/src/app/calculator/furnaces/energy-use/energy-use-help/energy-use-help.component.html
+++ b/src/app/calculator/furnaces/energy-use/energy-use-help/energy-use-help.component.html
@@ -35,7 +35,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>inch</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed: <strong>100</strong><br>
+            Units: <strong>inch</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -50,7 +50,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>inch</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed: <strong>100</strong><br>
+            Units: <strong>inch</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -65,8 +65,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>inch W.C.</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed:
-            <strong>100</strong><br>
+            Units: <strong>inch W.C.</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -81,7 +80,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>Hours</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed: <strong>10,000</strong><br>
+            Units: <strong>Hours</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -107,8 +106,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong> &#8457;</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed:
-            <strong>3,000</strong><br>
+            Units: <strong> &#8457;</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -123,8 +121,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>psig</strong><br> Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed:
-            <strong>100</strong><br>
+            Units: <strong>psig</strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -154,8 +151,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Units: <strong>Btu / ft<sup>3</sup></strong><br> Minimum Value Allowed: <strong>0</strong><br>Maximum
-            Value Allowed: <strong>5,000</strong><br>
+            Units: <strong>Btu / ft<sup>3</sup></strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>
@@ -170,7 +166,7 @@
           </p>
           <label><u>Input:</u></label>
           <p>
-            Minimum Value Allowed: <strong>0</strong><br> Maximum Value Allowed: <strong>5</strong><br>
+            Minimum Value Allowed: <strong>0</strong><br>
           </p>
         </div>
       </div>

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form/o2-enrichment-form.component.html
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form/o2-enrichment-form.component.html
@@ -19,7 +19,7 @@
       <div class="form-group">
         <label class="small" for="combAirTemp">Combustion air preheat temperature</label>
         <div class="input-group">
-          <input type="number" min="0" max="2000" step="10" class="form-control" id="combAirTemp" (input)="calc()" (focus)="changeField('combAirTemp')"
+          <input type="number" min="0" step="10" class="form-control" id="combAirTemp" (input)="calc()" (focus)="changeField('combAirTemp')"
             [(ngModel)]="o2Enrichment.combAirTemp" onfocus="this.select();" (keyup.enter)="enterPlot()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
@@ -42,7 +42,7 @@
       <div class="form-group">
         <label class="small" for="flueGasTemp">Flue gas temperature</label>
         <div class="input-group">
-          <input type="number" min="0" max="4000" step="10" class="form-control" id="flueGasTemp" (input)="calc()" (focus)="changeField('flueGasTemp')"
+          <input type="number" min="0" step="10" class="form-control" id="flueGasTemp" (input)="calc()" (focus)="changeField('flueGasTemp')"
             [(ngModel)]="o2Enrichment.flueGasTemp" onfocus="this.select();" (keyup.enter)="enterPlot()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
@@ -97,7 +97,7 @@
       <div class="form-group">
         <label class="small" for="combAirTempEnriched">Combustion air preheat temperature</label>
         <div class="input-group">
-          <input type="number" min="0" max="2000" step="10" class="form-control" id="combAirTempEnriched" (focus)="changeField('combAirTemp')"
+          <input type="number" min="0"  step="10" class="form-control" id="combAirTempEnriched" (focus)="changeField('combAirTemp')"
             [(ngModel)]="o2Enrichment.combAirTempEnriched" (input)="calc()" onfocus="this.select();" (keyup.enter)="enterPlot()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
@@ -119,7 +119,7 @@
       <div class="form-group">
         <label class="small" for="flueGasTempEnriched">Flue gas temperature</label>
         <div class="input-group">
-          <input type="number" min="0" max="4000" step="10" class="form-control" id="flueGasTempEnriched" (input)="calc()" (focus)="changeField('flueGasTemp')"
+          <input type="number" min="0" step="10" class="form-control" id="flueGasTempEnriched" (input)="calc()" (focus)="changeField('flueGasTemp')"
             [(ngModel)]="o2Enrichment.flueGasTempEnriched" onfocus="this.select();" (keyup.enter)="enterPlot()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
@@ -5,36 +5,6 @@
     when oxygen in combustion, “air”, is changed from standard (21%) to a higher value. Enter data for current (“Combustion
     with Air”) and new (“Combustion with Oxygen Enriched Air”) configurations.</p>
 </div>
-
-<div class="help-content">
-  <div class="card" *ngIf="currentField == 'o2CombAir'">
-    <div class="card-header">
-      O
-      <sub>2</sub> Combustion Air
-    </div>
-    <div class="card-block">
-      <label>
-        <u>Description:</u>
-      </label>
-      <p>
-        Molar (or volumetric) fraction (%) of O
-        <sub>2</sub> in incoming air for combustion. Oxygen enrichment can result in increased efficiency, lower emissions, and
-        improved temperature stability.
-      </p>
-      <label>
-        <u>Input:</u>
-      </label>
-      <p>
-        Units: %
-        <strong></strong>
-        <br> Minimum Value Allowed:
-        <strong>0</strong>
-        <br> Maximum Value Allowed:
-        <strong>100</strong>
-        <br>
-      </p>
-    </div>
-
     <div class="help-content">
       <div class="card" *ngIf="currentField == 'o2CombAir'">
         <div class="card-header">
@@ -137,11 +107,7 @@
       <p>
         Units: &#8457; or &#8451;
         <strong></strong>
-        <br> Minimum Value Allowed:
-        <strong>0</strong>
-        <br> Maximum Value Allowed:
-        <strong>2,000</strong>
-        <br>
+        <br> Minimum Value Allowed: <strong>0</strong>
       </p>
     </div>
   </div>
@@ -192,18 +158,13 @@
       <p>
         Units: &#8457; or &#8451;
         <strong></strong>
-        <br> Minimum Value Allowed:
-        <strong>0</strong>
-        <br> Maximum Value Allowed:
-        <strong>4,000</strong>
-        <br>
+        <br> Minimum Value Allowed: <strong>0</strong>
       </p>
     </div>
   </div>
   <div class="card" *ngIf="currentField == 'fuelConsumption'">
     <div class="card-header">
-      O
-      <sub>2</sub> Combustion Air
+      Fuel consumption
     </div>
     <div class="card-block">
       <label>
@@ -220,9 +181,6 @@
         <strong></strong>
         <br> Minimum Value Allowed:
         <strong>0</strong>
-        <br> Maximum Value Allowed:
-        <strong>10,000</strong>
-        <br>
       </p>
     </div>
   </div>

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
@@ -87,8 +87,8 @@
           </p>
         </div>
       </div>
-    </div>
-  </div>
+
+
   <div class="card" *ngIf="currentField == 'combAirTemp'">
     <div class="card-header">
       Combustion Air Preheat Temperature

--- a/src/app/phast/losses/losses-help/atmosphere-losses-help/atmosphere-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/atmosphere-losses-help/atmosphere-losses-help.component.html
@@ -52,7 +52,7 @@
 
   <div class="card" *ngIf="currentField == 'inletTemp'">
     <div class="card-header">
-      Initial temperature
+      Inlet Temperature
     </div>
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>

--- a/src/app/phast/losses/losses-help/exhaust-gas-help/exhaust-gas-help.component.html
+++ b/src/app/phast/losses/losses-help/exhaust-gas-help/exhaust-gas-help.component.html
@@ -69,7 +69,7 @@
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>
       <p>
-        Total volume of exhaust gases (use average value).
+        Average value of combustible gases percentage in exhaust gases. Note that the values vary with time during the cycle and this is average over the cycle time.
       </p>
       <label><u><strong>Input</strong></u></label>
       <p>
@@ -85,7 +85,7 @@
     <div class="card-block">
       <label><u><strong>Description</strong></u></label>
       <p>
-        Average value of combustible gases percentage in exhaust gases. Note that the values vary with time during the cycle and this is average over the cycle time.
+        Total volume of exhaust gases (use average value).
       </p>
       <label><u><strong>Input</strong></u></label>
       <p>


### PR DESCRIPTION
connects #1217 
connects #1224 
connects #1225 
connects #1226 

- Fixing typo in help text atmosphere  Initial Temperature = Inlet Temperature

- Corrected help description for combustible Gas as CH4 and Total Volumetric Flow Rate

- Removed double help text for O2 in combustion Air

- Removed Maximum Values Allowed for calculators:

1. O2 Enrichment
2. Efficiency Improvement
3. Energy Equivalency
4. Flow Calculations Energy Use
5. Pre-Assessment
