### PR TITLE
Fixing Multiple Issues

### DIFF
--- a/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-form/energy-equivalency-form.component.html
+++ b/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-form/energy-equivalency-form.component.html
@@ -11,7 +11,8 @@
           <label for="fuelFiredEfficiency1">Fuel-Fire Equipment Efficiency</label>
           <div class="input-group">
             <input autofocus name="fuelFiredEfficiency1" [(ngModel)]="energyEquivalencyElectric.fuelFiredEfficiency" type="number" step="any"
-              class="form-control" id="fuelFiredEfficiency1" (input)="calcElectric()" onfocus="this.select();" (focus)="focusField('fuelFiredEfficiency')">
+              class="form-control" id="fuelFiredEfficiency1" (input)="calcElectric()" onfocus="this.select();" (focus)="focusField('fuelFiredEfficiency')"
+                   (blur)="focusOut()">
             <span class="input-group-addon units">%</span>
           </div>
         </div>
@@ -20,7 +21,7 @@
           <div class="input-group">
             <input name="electricallyHeatedEfficiency1" [(ngModel)]="energyEquivalencyElectric.electricallyHeatedEfficiency" type="number"
               step="any" class="form-control" id="electricallyHeatedEfficiency1" (input)="calcElectric()" onfocus="this.select();"
-              (focus)="focusField('electricallyHeatedEfficiency')">
+              (focus)="focusField('electricallyHeatedEfficiency')" (blur)="focusOut()">
             <span class="input-group-addon units">%</span>
           </div>
         </div>
@@ -28,7 +29,7 @@
           <label for="fuelFiredHeatInput1">Heat Input for Fuel-Fire Equipment</label>
           <div class="input-group">
             <input name="fuelFiredHeatInput1" [(ngModel)]="energyEquivalencyElectric.fuelFiredHeatInput" type="number" step="any" class="form-control"
-              id="fuelFiredHeatInput1" (input)="calcElectric()" onfocus="this.select();" (focus)="focusField('fuelFiredHeatInput')">
+              id="fuelFiredHeatInput1" (input)="calcElectric()" onfocus="this.select();" (focus)="focusField('fuelFiredHeatInput')" (blur)="focusOut()">
             <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">MMBtu/hr</span>
             <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Metric'">GJ/hr</span>
           </div>
@@ -58,7 +59,7 @@
           <div class="input-group">
             <input name="electricallyHeatedEfficiency2" [(ngModel)]="energyEquivalencyFuel.electricallyHeatedEfficiency" type="number"
               step="any" class="form-control" id="electricallyHeatedEfficiency2" (input)="calcFuel()" onfocus="this.select();"
-              (focus)="focusField('electricallyHeatedEfficiencyFuel')">
+              (focus)="focusField('electricallyHeatedEfficiencyFuel')" (blur)="focusOut()">
             <span class="input-group-addon units">%</span>
           </div>
         </div>
@@ -66,7 +67,7 @@
           <label for="fuelFiredEfficiency2">Fuel-Fired Equipment Efficiency</label>
           <div class="input-group">
             <input name="fuelFiredEfficiency2" [(ngModel)]="energyEquivalencyFuel.fuelFiredEfficiency" type="number" step="any" class="form-control"
-              id="fuelFiredEfficiency2" (input)="calcFuel()" onfocus="this.select();" (focus)="focusField('fuelFiredEfficiencyFuel')">
+              id="fuelFiredEfficiency2" (input)="calcFuel()" onfocus="this.select();" (focus)="focusField('fuelFiredEfficiencyFuel')" (blur)="focusOut()">
             <span class="input-group-addon units">%</span>
           </div>
         </div>
@@ -74,7 +75,7 @@
           <label for="electricalHeatInput3">Heat Input for Electrically Heated Equipment</label>
           <div class="input-group">
             <input name="electricalHeatInput3" [(ngModel)]="energyEquivalencyFuel.electricalHeatInput" type="number" step="any" class="form-control"
-              id="electricalHeatInput3" (input)="calcFuel()" onfocus="this.select();" (focus)="focusField('electricalHeatInput')">
+              id="electricalHeatInput3" (input)="calcFuel()" onfocus="this.select();" (focus)="focusField('electricalHeatInput')" (blur)="focusOut()">
             <span class="input-group-addon units">kW</span>
           </div>
         </div>

--- a/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-form/energy-equivalency-form.component.ts
+++ b/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-form/energy-equivalency-form.component.ts
@@ -36,7 +36,10 @@ export class EnergyEquivalencyFormComponent implements OnInit {
     this.calculateFuel.emit(true);
   }
 
-  focusField(str: string){
+  focusField(str: string) {
     this.changeField.emit(str);
+  }
+  focusOut() {
+    this.changeField.emit('default');
   }
 }

--- a/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-help/energy-equivalency-help.component.html
+++ b/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-help/energy-equivalency-help.component.html
@@ -10,10 +10,10 @@
         <span class="fa fa-youtube-play"></span> Watch tutorial on entering atmosphere loss data.
       </p>
     </div>-->
-    <div class="help-header">
-      <p> Provides calculations for converting values of energy input requirements when the heat source is changed from fuel-firing
-        (Btu/hr or kJ/hr) to electricity (kW), or vice versa.</p>
-    </div>
+    <!--<div class="help-header">-->
+      <!--<p> Provides calculations for converting values of energy input requirements when the heat source is changed from fuel-firing-->
+        <!--(Btu/hr or kJ/hr) to electricity (kW), or vice versa.</p>-->
+    <!--</div>-->
     <div class="help-content">
       <!--top fuel fired input field-->
       <div class="card" *ngIf="currentField == 'fuelFiredEfficiency'">
@@ -164,6 +164,23 @@
             <br> Minimum Value Allowed:
             <strong>0</strong>
           </p>
+        </div>
+      </div>
+
+      <div class="card" *ngIf="currentField == 'default'">
+        <div class="help-header">
+          <h3>
+            Energy Equivalency
+          </h3>
+          <p> Provides calculations for converting values of energy input requirements when the heat source is changed from fuel-firing
+            (Btu/hr or kJ/hr) to electricity (kW), or vice versa.</p>
+        </div>
+        <div class="card-block">
+          <div class="alert alert-info">
+            <p>
+              Note: This calculator is only valid for natural gas fuels in North America.
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/calculator/furnaces/energy-equivalency/energy-equivalency.component.ts
+++ b/src/app/calculator/furnaces/energy-equivalency/energy-equivalency.component.ts
@@ -28,7 +28,7 @@ export class EnergyEquivalencyComponent implements OnInit {
   energyEquivalencyFuelOutput: EnergyEquivalencyFuelOutput = { fuelFiredHeatInput: 0 };
   energyEquivalencyElectricOutput: EnergyEquivalencyElectricOutput = { electricalHeatInput: 0 };
 
-  currentField: string = 'fuelFiredEfficiency';
+  currentField: string = 'default';
   tabSelect: string = 'results';
   constructor(private phastService: PhastService, private indexedDbService: IndexedDbService, private convertUnitsService: ConvertUnitsService) { }
 

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form/o2-enrichment-form.component.html
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form/o2-enrichment-form.component.html
@@ -10,7 +10,7 @@
           <sub>2</sub> in combustion air</label>
         <div class="input-group">
           <input autofocus type="number" [disabled]="true" min="1" step="any" max="100" class="form-control" id="o2CombAir" (input)="calc()"
-            (focus)="changeField('o2CombAir')" [(ngModel)]="o2Enrichment.o2CombAir" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            (focus)="changeField('o2CombAir')" [(ngModel)]="o2Enrichment.o2CombAir" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units">%</span>
         </div>
         <span class="alert-danger pull-right small" *ngIf="error.o2CombAir !== null">{{error.o2CombAir}}</span>
@@ -20,7 +20,7 @@
         <label class="small" for="combAirTemp">Combustion air preheat temperature</label>
         <div class="input-group">
           <input type="number" min="0" step="10" class="form-control" id="combAirTemp" (input)="calc()" (focus)="changeField('combAirTemp')"
-            [(ngModel)]="o2Enrichment.combAirTemp" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.combAirTemp" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
 
@@ -33,7 +33,7 @@
           <sub>2</sub> in flue gasses</label>
         <div class="input-group">
           <input type="number" min="0" step="any" max="100" class="form-control" id="o2FlueGas" (input)="calc()" (focus)="changeField('o2FlueGas')"
-            [(ngModel)]="o2Enrichment.o2FlueGas" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.o2FlueGas" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units">% Dry</span>
         </div>
         <span class="alert-danger pull-right small" *ngIf="error.o2FlueGas !== null">{{error.o2FlueGas}}</span>
@@ -43,7 +43,7 @@
         <label class="small" for="flueGasTemp">Flue gas temperature</label>
         <div class="input-group">
           <input type="number" min="0" step="10" class="form-control" id="flueGasTemp" (input)="calc()" (focus)="changeField('flueGasTemp')"
-            [(ngModel)]="o2Enrichment.flueGasTemp" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.flueGasTemp" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
 
@@ -55,7 +55,7 @@
         <label class="small" for="fuelConsumption">Fuel consumption</label>
         <div class="input-group">
           <input type="number" min="0" step="any" class="form-control" id="fuelConsumption" (input)="calc()" (focus)="changeField('fuelConsumption')"
-            [(ngModel)]="o2Enrichment.fuelConsumption" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.fuelConsumption" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
 
           <!-- debug -->
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">MMBtu/hr</span>
@@ -88,7 +88,7 @@
           <sub>2</sub> in combustion air</label>
         <div class="input-group">
           <input type="number" min="0" step="any" max="100" class="form-control" id="o2CombAirEnriched" (focus)="changeField('o2CombAir')"
-            [(ngModel)]="o2Enrichment.o2CombAirEnriched" (input)="calc()" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.o2CombAirEnriched" (input)="calc()" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units">%</span>
         </div>
         <span class="alert-danger pull-right small" *ngIf="error.o2CombAirEnriched !== null">{{error.o2CombAirEnriched}}</span>
@@ -98,7 +98,7 @@
         <label class="small" for="combAirTempEnriched">Combustion air preheat temperature</label>
         <div class="input-group">
           <input type="number" min="0"  step="10" class="form-control" id="combAirTempEnriched" (focus)="changeField('combAirTemp')"
-            [(ngModel)]="o2Enrichment.combAirTempEnriched" (input)="calc()" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.combAirTempEnriched" (input)="calc()" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
         </div>
@@ -110,7 +110,7 @@
           <sub>2</sub> in flue gasses</label>
         <div class="input-group">
           <input type="number" min="0" step="any" max="100" class="form-control" id="o2FlueGasEnriched" (input)="calc()" (focus)="changeField('o2FlueGas')"
-            [(ngModel)]="o2Enrichment.o2FlueGasEnriched" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.o2FlueGasEnriched" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units">% Dry</span>
         </div>
         <span class="alert-danger pull-right small" *ngIf="error.o2FlueGasEnriched !== null">{{error.o2FlueGasEnriched}}</span>
@@ -120,7 +120,7 @@
         <label class="small" for="flueGasTempEnriched">Flue gas temperature</label>
         <div class="input-group">
           <input type="number" min="0" step="10" class="form-control" id="flueGasTempEnriched" (input)="calc()" (focus)="changeField('flueGasTemp')"
-            [(ngModel)]="o2Enrichment.flueGasTempEnriched" onfocus="this.select();" (keyup.enter)="enterPlot()">
+            [(ngModel)]="o2Enrichment.flueGasTempEnriched" onfocus="this.select();" (keyup.enter)="enterPlot()" (blur)="focusOut()">
           <span class="input-group-addon units" *ngIf="settings.unitsOfMeasure == 'Imperial'">&#8457;</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">&#8451;</span>
         </div>
@@ -151,3 +151,4 @@
     </div>
   </div>
   <!-- End .col -->
+</div>

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form/o2-enrichment-form.component.ts
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form/o2-enrichment-form.component.ts
@@ -85,7 +85,9 @@ export class O2EnrichmentFormComponent implements OnInit {
   changeField(str: string) {
     this.changeFieldEmit.emit(str);
   }
-
+  focusOut() {
+    this.changeFieldEmit.emit('default');
+  }
   enterPlot() {
     document.getElementById("plotBtn").click();
   }

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
@@ -1,10 +1,11 @@
-<div class="help-header">
-  <h3>O
-    <sub>2</sub> Enrichment Help</h3>
-  <p>Calculation of available heat (an indication of thermal efficiency) for fuel fired furnaces and expected energy savings
-    when oxygen in combustion, “air”, is changed from standard (21%) to a higher value. Enter data for current (“Combustion
-    with Air”) and new (“Combustion with Oxygen Enriched Air”) configurations.</p>
-</div>
+<!--<div class="help-header">-->
+  <!--<h3>-->
+    <!--O<sub>2</sub> Enrichment Help-->
+  <!--</h3>-->
+  <!--<p>Calculation of available heat (an indication of thermal efficiency) for fuel fired furnaces and expected energy savings-->
+    <!--when oxygen in combustion, “air”, is changed from standard (21%) to a higher value. Enter data for current (“Combustion-->
+    <!--with Air”) and new (“Combustion with Oxygen Enriched Air”) configurations.</p>-->
+<!--</div>-->
     <div class="help-content">
       <div class="card" *ngIf="currentField == 'o2CombAir'">
         <div class="card-header">
@@ -85,6 +86,25 @@
           <p>
             Units: MMBtu/hr<strong></strong><br> Minimum Value Allowed: <strong>0</strong><br>
           </p>
+        </div>
+      </div>
+      <div class="card" *ngIf="currentField == 'default'">
+        <div class="help-header">
+          <h3>
+            O<sup>2</sup> Enrichment
+          </h3>
+          <p>
+          Calculation of available heat (an indication of thermal efficiency) for fuel fired furnaces and expected energy savings
+          when oxygen in combustion, “air”, is changed from standard (21%) to a higher value. Enter data for current (“Combustion
+          with Air”) and new (“Combustion with Oxygen Enriched Air”) configurations.
+          </p>
+        </div>
+        <div class="card-block">
+          <div class="alert alert-info">
+            <p>
+              Note: This calculator is only valid for natural gas fuels in North America.
+            </p>
+          </div>
         </div>
       </div>
 </div>

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment.component.ts
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment.component.ts
@@ -35,7 +35,7 @@ export class O2EnrichmentComponent implements OnInit {
 
   lines = [];
   tabSelect: string = 'results';
-  currentField: string = 'o2CombAir';
+  currentField: string = 'default';
   constructor(private phastService: PhastService, private indexedDbService: IndexedDbService, private convertUnitsService: ConvertUnitsService) { }
 
   ngOnInit() {

--- a/src/app/phast/losses/fixture-losses/fixture-losses-form/fixture-losses-form.component.ts
+++ b/src/app/phast/losses/fixture-losses/fixture-losses-form/fixture-losses-form.component.ts
@@ -90,7 +90,7 @@ export class FixtureLossesFormComponent implements OnInit {
       tmpMaterial.specificHeatSolid = this.convertUnitsService.value(tmpMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
     }
     this.lossesForm.patchValue({
-      specificHeat: this.roundVal(tmpMaterial.specificHeatSolid, 4)
+      specificHeat: this.roundVal(tmpMaterial.specificHeatSolid, 3)
     })
     this.checkInputError();
   }
@@ -100,7 +100,7 @@ export class FixtureLossesFormComponent implements OnInit {
     if (material) {
       if (this.settings.unitsOfMeasure == 'Metric') {
         let val = this.convertUnitsService.value(material.specificHeatSolid).from('btulbF').to('kJkgC')
-        material.specificHeatSolid = this.roundVal(val, 4);
+        material.specificHeatSolid = this.roundVal(val, 3);
       }
       if (material.specificHeatSolid != this.lossesForm.controls.specificHeat.value) {
         return true;

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-mass/flue-gas-losses-form-mass.component.html
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-mass/flue-gas-losses-form-mass.component.html
@@ -85,7 +85,7 @@
     </div>
 
     <div class="form-group">
-      <label class="small" for="moistureInAirComposition">Moisture in Air Combustion</label>
+      <label class="small" for="moistureInAirComposition">Moisture in Combustion Air</label>
       <div class="input-group">
         <input name="{{'moistureInAirComposition_'+lossIndex}}" type="number" step="any" min="0" max="100" class="form-control" formControlName="moistureInAirComposition"
           id="moistureInAirComposition" onfocus="this.select();" (input)="checkInputError()" (focus)="focusField('moistureInAirComposition')"

--- a/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-mass/flue-gas-losses-form-mass.component.ts
+++ b/src/app/phast/losses/flue-gas-losses/flue-gas-losses-form-mass/flue-gas-losses-form-mass.component.ts
@@ -195,7 +195,7 @@ export class FlueGasLossesFormMassComponent implements OnInit {
       this.startSavePolling();
     }
     if (this.flueGasLossForm.controls.moistureInAirComposition.value < 0 || this.flueGasLossForm.controls.moistureInAirComposition.value > 100) {
-      this.moistureInAirCompositionError = 'Moisture in Air Combustion must be equal or greater than 0 and less than or equal to 100%';
+      this.moistureInAirCompositionError = 'Moisture in Combustion Air must be equal or greater than 0 and less than or equal to 100%';
     } else {
       this.moistureInAirCompositionError = null;
     }

--- a/src/app/phast/phast-report/phast-input-summary/flue-gas-summary/flue-gas-summary.component.html
+++ b/src/app/phast/phast-report/phast-input-summary/flue-gas-summary/flue-gas-summary.component.html
@@ -120,7 +120,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':moistureInAirDiff[index] == true}">
-                Moisture in Air Combustion
+                Moisture in Combustion Air
               </td>
               <td [ngClass]="{'indicate-report-field-different':moistureInAirDiff[index] == true}">
                 {{data.baseline.moistureInAir}}

--- a/src/app/phast/phast-report/results-data/results-data.component.css
+++ b/src/app/phast/phast-report/results-data/results-data.component.css
@@ -44,3 +44,6 @@ tr > th:not(:first-child){
 .tr-underline {
   border-bottom: 2px groove #bf3d00;
 }
+.tr-border {
+  border-top: 2px groove #bf3d00;
+}

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -17,7 +17,7 @@
         <td *ngIf="baseLineResults.totalChargeMaterialLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalChargeMaterialLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalChargeMaterialLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalChargeMaterialLoss">{{mod.totalChargeMaterialLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalChargeMaterialLoss">{{mod.totalChargeMaterialLoss | sigFigs:'15'}}</span>
           <span *ngIf="!mod.totalChargeMaterialLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -26,7 +26,7 @@
         <td *ngIf="baseLineResults.totalFixtureLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalFixtureLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalFixtureLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalFixtureLoss">{{mod.totalFixtureLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalFixtureLoss">{{mod.totalFixtureLoss | sigFigs:'15'}}</span>
           <span *ngIf="!mod.totalFixtureLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -35,7 +35,7 @@
         <td *ngIf="baseLineResults.totalWallLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalWallLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalWallLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalWallLoss">{{mod.totalWallLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalWallLoss">{{mod.totalWallLoss | sigFigs:'15'}}</span>
           <span *ngIf="!mod.totalWallLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -44,7 +44,7 @@
         <td *ngIf="baseLineResults.totalCoolingLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalCoolingLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalCoolingLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalCoolingLoss">{{mod.totalCoolingLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalCoolingLoss">{{mod.totalCoolingLoss | sigFigs:'15'}}</span>
           <span *ngIf="!mod.totalCoolingLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -53,7 +53,7 @@
         <td *ngIf="baseLineResults.totalAtmosphereLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalAtmosphereLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalAtmosphereLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalAtmosphereLoss">{{mod.totalAtmosphereLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalAtmosphereLoss">{{mod.totalAtmosphereLoss | sigFigs:'15'}}</span>
           <span *ngIf="!mod.totalAtmosphereLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -62,7 +62,7 @@
         <td *ngIf="baseLineResults.totalOpeningLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalOpeningLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalOpeningLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalOpeningLoss">{{mod.totalOpeningLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalOpeningLoss">{{mod.totalOpeningLoss| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalOpeningLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -71,7 +71,7 @@
         <td *ngIf="baseLineResults.totalLeakageLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalLeakageLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalLeakageLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalLeakageLoss">{{mod.totalLeakageLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalLeakageLoss">{{mod.totalLeakageLoss| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalLeakageLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -80,7 +80,7 @@
         <td *ngIf="baseLineResults.totalExtSurfaceLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExtSurfaceLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalExtSurfaceLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalExtSurfaceLoss">{{mod.totalExtSurfaceLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalExtSurfaceLoss">{{mod.totalExtSurfaceLoss| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalExtSurfaceLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -89,7 +89,7 @@
         <td *ngIf="baseLineResults.totalAuxPower" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalAuxPower| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalAuxPower" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalAuxPower">{{mod.totalAuxPower| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalAuxPower">{{mod.totalAuxPower| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalAuxPower">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -98,7 +98,7 @@
         <td *ngIf="baseLineResults.totalSlag" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalSlag| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalSlag" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalSlag">{{mod.totalSlag| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalSlag">{{mod.totalSlag| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalSlag">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -107,7 +107,7 @@
         <td *ngIf="baseLineResults.totalOtherLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalOtherLoss| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalOtherLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalOtherLoss">{{mod.totalOtherLoss| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalOtherLoss">{{mod.totalOtherLoss| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalOtherLoss">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -116,7 +116,7 @@
         <td *ngIf="baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalInput| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalInput">{{mod.totalInput| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalInput">{{mod.totalInput| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalInput">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -134,7 +134,7 @@
         <td *ngIf="baseLineResults.flueGasSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.flueGasSystemLosses| sigFigs:'5'}} </td>
         <td *ngIf="!baseLineResults.flueGasSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.flueGasSystemLosses">{{mod.flueGasSystemLosses| sigFigs:'5'}}</span>
+          <span *ngIf="mod.flueGasSystemLosses">{{mod.flueGasSystemLosses| sigFigs:'6'}}</span>
           <span *ngIf="!mod.flueGasSystemLosses">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -143,7 +143,7 @@
         <td *ngIf="baseLineResults.exothermicHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.exothermicHeat| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.exothermicHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.exothermicHeat">{{mod.exothermicHeat| sigFigs:'5'}}</span>
+          <span *ngIf="mod.exothermicHeat">{{mod.exothermicHeat| sigFigs:'6'}}</span>
           <span *ngIf="!mod.exothermicHeat">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -161,7 +161,7 @@
         <td *ngIf="baseLineResults.totalExhaustGas" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExhaustGas| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalExhaustGas" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalExhaustGas">{{mod.totalExhaustGas| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalExhaustGas">{{mod.totalExhaustGas| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalExhaustGas">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -170,7 +170,7 @@
         <td *ngIf="baseLineResults.totalExhaustGasEAF" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExhaustGasEAF| sigFigs:'5'}} </td>
         <td *ngIf="!baseLineResults.totalExhaustGasEAF" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalExhaustGasEAF">{{mod.totalExhaustGasEAF| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalExhaustGasEAF">{{mod.totalExhaustGasEAF| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalExhaustGasEAF">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -179,7 +179,7 @@
         <td *ngIf="baseLineResults.heatingSystemEfficiency" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.heatingSystemEfficiency| number:'1.0-0'}} %</td>
         <td *ngIf="!baseLineResults.heatingSystemEfficiency" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.heatingSystemEfficiency">{{mod.heatingSystemEfficiency| sigFigs:'5'}}</span>
+          <span *ngIf="mod.heatingSystemEfficiency">{{mod.heatingSystemEfficiency| sigFigs:'6'}}</span>
           <span *ngIf="!mod.heatingSystemEfficiency">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -188,7 +188,7 @@
         <td *ngIf="baseLineResults.totalSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalSystemLosses| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.totalSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalSystemLosses">{{mod.totalSystemLosses| sigFigs:'5'}}</span>
+          <span *ngIf="mod.totalSystemLosses">{{mod.totalSystemLosses| sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalSystemLosses">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -199,7 +199,7 @@
         <td *ngIf="baseLineResults.energyInputHeatDelivered" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.energyInputHeatDelivered| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.energyInputHeatDelivered" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.energyInputHeatDelivered">{{mod.energyInputHeatDelivered| sigFigs:'5'}}</span>
+          <span *ngIf="mod.energyInputHeatDelivered">{{mod.energyInputHeatDelivered| sigFigs:'6'}}</span>
           <span *ngIf="!mod.energyInputHeatDelivered">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -208,7 +208,7 @@
         <td *ngIf="baseLineResults.energyInputTotalChemEnergy" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.energyInputTotalChemEnergy| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.energyInputTotalChemEnergy" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.energyInputTotalChemEnergy">{{mod.energyInputTotalChemEnergy| sigFigs:'5'}}</span>
+          <span *ngIf="mod.energyInputTotalChemEnergy">{{mod.energyInputTotalChemEnergy| sigFigs:'6'}}</span>
           <span *ngIf="!mod.energyInputTotalChemEnergy">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -217,7 +217,7 @@
         <td *ngIf="baseLineResults.grossHeatInput" style="font-weight: bold;" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.grossHeatInput| sigFigs:'5'}}</td>
         <td *ngIf="!baseLineResults.grossHeatInput" style="font-weight: bold;" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults" style="font-weight: bold;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.grossHeatInput">{{mod.grossHeatInput| sigFigs:'5'}}</span>
+          <span *ngIf="mod.grossHeatInput">{{mod.grossHeatInput| sigFigs:'6'}}</span>
           <span *ngIf="!mod.grossHeatInput">&mdash; &mdash;</span>
         </td>
       </tr>

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -14,52 +14,52 @@
     <tbody>
       <tr>
         <td>Charge Materials</td>
-        <td *ngIf="baseLineResults.totalChargeMaterialLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalChargeMaterialLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalChargeMaterialLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalChargeMaterialLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalChargeMaterialLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalChargeMaterialLoss">{{mod.totalChargeMaterialLoss | sigFigs:'15'}}</span>
+          <span *ngIf="mod.totalChargeMaterialLoss">{{mod.totalChargeMaterialLoss | sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalChargeMaterialLoss">&mdash; &mdash;</span>
         </td>
       </tr>
       <tr>
         <td>Fixtures, trays etc.</td>
-        <td *ngIf="baseLineResults.totalFixtureLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalFixtureLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalFixtureLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalFixtureLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalFixtureLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalFixtureLoss">{{mod.totalFixtureLoss | sigFigs:'15'}}</span>
+          <span *ngIf="mod.totalFixtureLoss">{{mod.totalFixtureLoss | sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalFixtureLoss">&mdash; &mdash;</span>
         </td>
       </tr>
       <tr>
         <td>Wall Losses</td>
-        <td *ngIf="baseLineResults.totalWallLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalWallLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalWallLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalWallLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalWallLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalWallLoss">{{mod.totalWallLoss | sigFigs:'15'}}</span>
+          <span *ngIf="mod.totalWallLoss">{{mod.totalWallLoss | sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalWallLoss">&mdash; &mdash;</span>
         </td>
       </tr>
       <tr>
         <td>Cooling Losses</td>
-        <td *ngIf="baseLineResults.totalCoolingLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalCoolingLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalCoolingLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalCoolingLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalCoolingLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalCoolingLoss">{{mod.totalCoolingLoss | sigFigs:'15'}}</span>
+          <span *ngIf="mod.totalCoolingLoss">{{mod.totalCoolingLoss | sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalCoolingLoss">&mdash; &mdash;</span>
         </td>
       </tr>
       <tr>
         <td>Atmosphere Losses</td>
-        <td *ngIf="baseLineResults.totalAtmosphereLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalAtmosphereLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalAtmosphereLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalAtmosphereLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalAtmosphereLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.totalAtmosphereLoss">{{mod.totalAtmosphereLoss | sigFigs:'15'}}</span>
+          <span *ngIf="mod.totalAtmosphereLoss">{{mod.totalAtmosphereLoss | sigFigs:'6'}}</span>
           <span *ngIf="!mod.totalAtmosphereLoss">&mdash; &mdash;</span>
         </td>
       </tr>
       <tr>
         <td>Opening Losses</td>
-        <td *ngIf="baseLineResults.totalOpeningLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalOpeningLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalOpeningLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalOpeningLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalOpeningLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalOpeningLoss">{{mod.totalOpeningLoss| sigFigs:'6'}}</span>
@@ -68,7 +68,7 @@
       </tr>
       <tr>
         <td>Leakage Losses</td>
-        <td *ngIf="baseLineResults.totalLeakageLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalLeakageLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalLeakageLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalLeakageLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalLeakageLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalLeakageLoss">{{mod.totalLeakageLoss| sigFigs:'6'}}</span>
@@ -77,7 +77,7 @@
       </tr>
       <tr>
         <td>Extended Surface Losses</td>
-        <td *ngIf="baseLineResults.totalExtSurfaceLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExtSurfaceLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalExtSurfaceLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExtSurfaceLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalExtSurfaceLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalExtSurfaceLoss">{{mod.totalExtSurfaceLoss| sigFigs:'6'}}</span>
@@ -86,7 +86,7 @@
       </tr>
       <tr *ngIf="showResultsCats.showAuxPower">
         <td>Aux Power Losses</td>
-        <td *ngIf="baseLineResults.totalAuxPower" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalAuxPower| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalAuxPower" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalAuxPower| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalAuxPower" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalAuxPower">{{mod.totalAuxPower| sigFigs:'6'}}</span>
@@ -95,7 +95,7 @@
       </tr>
       <tr *ngIf="showResultsCats.showSlag">
         <td>Slag Losses</td>
-        <td *ngIf="baseLineResults.totalSlag" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalSlag| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalSlag" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalSlag| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalSlag" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalSlag">{{mod.totalSlag| sigFigs:'6'}}</span>
@@ -104,7 +104,7 @@
       </tr>
       <tr class="tr-underline">
         <td>Other Losses</td>
-        <td *ngIf="baseLineResults.totalOtherLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalOtherLoss| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalOtherLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalOtherLoss| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalOtherLoss" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalOtherLoss">{{mod.totalOtherLoss| sigFigs:'6'}}</span>
@@ -113,7 +113,7 @@
       </tr>
       <tr>
         <td>Total Net Heat Required</td>
-        <td *ngIf="baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalInput| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalInput| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalInput">{{mod.totalInput| sigFigs:'6'}}</span>
@@ -131,16 +131,16 @@
       </tr>
       <tr *ngIf="showResultsCats.showFlueGas">
         <td>Flue Gas Losses</td>
-        <td *ngIf="baseLineResults.flueGasSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.flueGasSystemLosses| sigFigs:'5'}} </td>
+        <td *ngIf="baseLineResults.flueGasSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.flueGasSystemLosses| sigFigs:'6'}} </td>
         <td *ngIf="!baseLineResults.flueGasSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.flueGasSystemLosses">{{mod.flueGasSystemLosses| sigFigs:'6'}}</span>
           <span *ngIf="!mod.flueGasSystemLosses">&mdash; &mdash;</span>
         </td>
       </tr>
-      <tr class="tr-underline">
+      <tr>
         <td>Exothermic Heat from Process</td>
-        <td *ngIf="baseLineResults.exothermicHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.exothermicHeat| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.exothermicHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.exothermicHeat| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.exothermicHeat" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.exothermicHeat">{{mod.exothermicHeat| sigFigs:'6'}}</span>
@@ -158,7 +158,7 @@
       </tr>
       <tr *ngIf="showResultsCats.showEnInput2">
         <td>Exhaust Gas Losses</td>
-        <td *ngIf="baseLineResults.totalExhaustGas" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExhaustGas| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalExhaustGas" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExhaustGas| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalExhaustGas" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalExhaustGas">{{mod.totalExhaustGas| sigFigs:'6'}}</span>
@@ -167,7 +167,7 @@
       </tr>
       <tr *ngIf="showResultsCats.showExGas">
         <td>Exhaust Gas Losses</td>
-        <td *ngIf="baseLineResults.totalExhaustGasEAF" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExhaustGasEAF| sigFigs:'5'}} </td>
+        <td *ngIf="baseLineResults.totalExhaustGasEAF" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalExhaustGasEAF| sigFigs:'6'}} </td>
         <td *ngIf="!baseLineResults.totalExhaustGasEAF" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalExhaustGasEAF">{{mod.totalExhaustGasEAF| sigFigs:'6'}}</span>
@@ -185,7 +185,7 @@
       </tr>
       <tr *ngIf="showResultsCats.showSystemEff">
         <td>Total System Losses</td>
-        <td *ngIf="baseLineResults.totalSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalSystemLosses| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.totalSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.totalSystemLosses| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.totalSystemLosses" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.totalSystemLosses">{{mod.totalSystemLosses| sigFigs:'6'}}</span>
@@ -196,7 +196,7 @@
       <tr *ngIf="showResultsCats.showEnInput1 || showResultsCats.showEnInput2">
         <td *ngIf="showResultsCats.showEnInput1">Heat Delivered</td>
         <td *ngIf="showResultsCats.showEnInput2">User Defined Heat Delivered</td>
-        <td *ngIf="baseLineResults.energyInputHeatDelivered" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.energyInputHeatDelivered| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.energyInputHeatDelivered" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.energyInputHeatDelivered| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.energyInputHeatDelivered" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.energyInputHeatDelivered">{{mod.energyInputHeatDelivered| sigFigs:'6'}}</span>
@@ -205,16 +205,16 @@
       </tr>
       <tr *ngIf="showResultsCats.showEnInput1">
         <td>User Defined Total Chemical Energy Delivered</td>
-        <td *ngIf="baseLineResults.energyInputTotalChemEnergy" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.energyInputTotalChemEnergy| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.energyInputTotalChemEnergy" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.energyInputTotalChemEnergy| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.energyInputTotalChemEnergy" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.energyInputTotalChemEnergy">{{mod.energyInputTotalChemEnergy| sigFigs:'6'}}</span>
           <span *ngIf="!mod.energyInputTotalChemEnergy">&mdash; &mdash;</span>
         </td>
       </tr>
-      <tr>
+      <tr class="tr-border">
         <td style="font-weight: bold;">Gross Heat Input</td>
-        <td *ngIf="baseLineResults.grossHeatInput" style="font-weight: bold;" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.grossHeatInput| sigFigs:'5'}}</td>
+        <td *ngIf="baseLineResults.grossHeatInput" style="font-weight: bold;" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.grossHeatInput| sigFigs:'6'}}</td>
         <td *ngIf="!baseLineResults.grossHeatInput" style="font-weight: bold;" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults" style="font-weight: bold;" [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.grossHeatInput">{{mod.grossHeatInput| sigFigs:'6'}}</span>

--- a/src/app/shared/sig-figs.pipe.ts
+++ b/src/app/shared/sig-figs.pipe.ts
@@ -12,7 +12,7 @@ export class SigFigsPipe implements PipeTransform {
       //converted to number to get trailing/leading zeros
       let newValNumber = parseFloat(newValString);
       //convert back to string
-      let numWithZerosAndCommas = newValNumber.toLocaleString();
+      let numWithZerosAndCommas = newValNumber.toLocaleString(undefined, {minimumSignificantDigits: sigFigs, maximumSignificantDigits: sigFigs });
       if (scientificNotation) {
         return newValString;
       } else {


### PR DESCRIPTION
connects #1333 
connects #1337 
connects #1336 
connects #1334 

- Adds a note to O2 enrichment & Energy Equivalency calculators when out of focus from an input field.

- Fixes significant figures displays and pipe.

- Fixture Specific Heat displaying 3 decimals places.

- Solid Fuels change "Moisture in Air Combustion" to "Moisture in Combustion Air". Label, help text and report.

- Fixes borders outline for results data.