### PR TITLE
Quick fixes for PHAST

### DIFF
--- a/src/app/calculator/compressed-air/compressed-air.component.html
+++ b/src/app/calculator/compressed-air/compressed-air.component.html
@@ -52,9 +52,9 @@
           <div class="col-11">
             <a class="click-item" (click)="showTool('receiver-tank')">Receiver Tank Calculations</a>
             <p>
-              The receiver tank is used to store a supply of compressed air and assure a steady supply without excessive line pulsations
-              or frequent loading and unloading of the compressor. There are four methods to calculate the size of the receiver
-              tank required. There is also a method for calculating the quantity of compressed air available for use.
+              The receiver tank is used to store a supply of compressed air and assure a steady supply without excessive line pulsations or
+              frequent loading and unloading of the compressor. The different methods to calculate the size of the receiver tank and the quantity
+              of compressed air available for use are included in this calculator.
             </p>
           </div>
         </div>
@@ -66,7 +66,7 @@
           <div class="col-11">
             <a class="click-item" (click)="showTool('pipe-sizing')">Pipe Sizing</a>
             <p>
-              Find the pipe diameter, when we know the volumetric flow velocity, pressure and design velocity are known.
+              Find the pipe diameter when the volumetric flow, pressure and design velocity are known.
             </p>
           </div>
         </div>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-charge-materials-form/explore-charge-materials-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-charge-materials-form/explore-charge-materials-form.component.html
@@ -20,7 +20,7 @@
         <div class="form-group">
           <label for="baselineInTemp">Baseline Initial Temperature</label>
           <div class="input-group">
-            <input name="{{'baselineInTemp_'+index}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="material.baseline.initialTemperature"
+            <input name="{{'baselineInTemp_'+index}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="material.baseline.initialTemperature"
               id="{{baselineInTemp_+index}}" onfocus="this.select();" (input)="calculate()" (focus)="focusField('initialTemperature')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">&#8457;</span>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-fixtures-form/explore-fixtures-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-fixtures-form/explore-fixtures-form.component.html
@@ -20,7 +20,7 @@
         <div class="form-group">
           <label for="baselineCost">Baseline Feed Rate</label>
           <div class="input-group">
-            <input name="{{'feedRate_'+index}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.feedRate" id="{{feedRate_+index}}"
+            <input name="{{'feedRate_'+index}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.feedRate" id="{{feedRate_+index}}"
               onfocus="this.select();" (input)="checkFeedRate(1, loss.feedRate, index)" (focus)="focusField('feedRate')" (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">lb/hr</span>
             <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">kg/hr</span>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-flue-gas-form/explore-flue-gas-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-flue-gas-form/explore-flue-gas-form.component.html
@@ -16,7 +16,7 @@
         <div class="form-group">
           <label for="baselineO2">Baseline Oxygen in Flue Gas</label>
           <div class="input-group">
-            <input name="baselineO2" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.o2InFlueGas"
+            <input name="baselineO2" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.o2InFlueGas"
               id="baselineO2" onfocus="this.select();" (input)="calculate()" (focus)="focusField('o2InFlueGas')" (blur)="focusOut()">
             <span class="input-group-addon units">%</span>
           </div>
@@ -43,7 +43,7 @@
         <div class="form-group">
           <label for="baselineExcessAir">Baseline Excess Air in Flue Gas</label>
           <div class="input-group">
-            <input name="baselineExcessAir" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.excessAirPercentage"
+            <input name="baselineExcessAir" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.excessAirPercentage"
               id="baselineExcessAir" onfocus="this.select();" (input)="calculate()" (focus)="focusField('excessAirPercentage')"
               (blur)="focusOut()">
             <span class="input-group-addon units">%</span>
@@ -72,7 +72,7 @@
         <div class="form-group">
           <label for="baselineFlueTemperature">Baseline Flue Gas Temperature</label>
           <div class="input-group">
-            <input name="baselineFlueTemperature" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.flueGasTemperature"
+            <input name="baselineFlueTemperature" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.flueGasTemperature"
               id="baselineFlueTemperature" onfocus="this.select();" (input)="calculate()" (focus)="focusField('flueGasTemperature')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">&#8457;</span>
@@ -103,7 +103,7 @@
         <div class="form-group">
           <label for="baselineAirTemp">Baseline Combustion Air Temperature</label>
           <div class="input-group">
-            <input name="baselineAirTemp" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.combustionAirTemperature"
+            <input name="baselineAirTemp" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="baselineFlueGas.combustionAirTemperature"
               id="baselineAirTemp" onfocus="this.select();" (input)="calculate()" (focus)="focusField('combustionAirTemperature')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">&#8457;</span>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-leakage-form/explore-leakage-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-leakage-form/explore-leakage-form.component.html
@@ -20,7 +20,7 @@
         <div class="form-group">
           <label class="small" for="openingArea">Baseline Opening Area</label>
           <div class="input-group">
-            <input name="{{'openingArea_'+index}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.openingArea"
+            <input name="{{'openingArea_'+index}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.openingArea"
               id="openingArea" onfocus="this.select();" (input)="checkOpening(1, loss.openingArea, index)" (focus)="focusField('openingArea')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-opening-form/explore-opening-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-opening-form/explore-opening-form.component.html
@@ -25,7 +25,7 @@
           <label class="small" for="numberOfOpenings" aria-describedby="numberOfOpeningsHelp">Number of Openings
             <small id="numberOfOpeningsHelp" class="form-text text-muted text-help">Same Size and Shape</small>
           </label>
-          <input name="{{'numberOfOpenings_'+lossIndex}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.numberOfOpenings"
+          <input name="{{'numberOfOpenings_'+lossIndex}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.numberOfOpenings"
             id="numberOfOpenings" onfocus="this.select();" (input)="getArea(1, loss, index)" (focus)="focusField('numberOfOpenings')"
             (blur)="focusOut()">
           <span class="alert-warning pull-right small" *ngIf="numOpeningsError1[index] !== null">{{numOpeningsError1[index]}}</span>
@@ -33,7 +33,7 @@
         <div class="form-group">
           <label class="small" for="wallThickness">Furnace Wall Thickness</label>
           <div class="input-group">
-            <input name="{{'wallThickness_'+lossIndex}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.thickness"
+            <input name="{{'wallThickness_'+lossIndex}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.thickness"
               id="wallThickness" onfocus="this.select();" (input)="getArea(1, loss, index)" (focus)="focusField('wallThickness')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">in</span>
@@ -46,7 +46,7 @@
           <label *ngIf="loss.openingType != 'Round'" class="small" for="lengthOfOpening">Length of Openings</label>
           <label *ngIf="loss.openingType == 'Round'" class="small" for="lengthOfOpening">Diameter of Openings</label>
           <div class="input-group">
-            <input name="{{'lengthOfOpening_'+lossIndex}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.lengthOfOpening"
+            <input name="{{'lengthOfOpening_'+lossIndex}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.lengthOfOpening"
               id="lengthOfOpening" onfocus="this.select();" (input)="getArea(1, loss, index)" (focus)="focusField('lengthOfOpening')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">in</span>
@@ -58,7 +58,7 @@
         <div class="form-group" *ngIf="loss.openingType != 'Round'">
           <label class="small" for="heightOfOpening">Height of Openings</label>
           <div class="input-group">
-            <input name="{{'heightOfOpening_'+lossIndex}}" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.heightOfOpening"
+            <input name="{{'heightOfOpening_'+lossIndex}}" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="loss.heightOfOpening"
               id="heightOfOpening" onfocus="this.select();" (input)="getArea(1, loss, index)" (focus)="focusField('heightOfOpening')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">in</span>
@@ -160,7 +160,7 @@
               <a id="{{'viewFactor1_'+lossIndex}}" class="click-link small" (click)="calculateViewFactor(loss)">Calculate View Factor</a>
             </span>
           </label>
-          <input name="{{'viewFactor1_'+lossIndex}}" type="number" step="0.1" min="0" max="1" class="form-control" [(ngModel)]="loss.viewFactor"
+          <input name="{{'viewFactor1_'+lossIndex}}" disabled="true" type="number" step="0.1" min="0" max="1" class="form-control" [(ngModel)]="loss.viewFactor"
             id="viewFactor1" onfocus="this.select();" (input)="checkViewFactor(1, loss.viewFactor)" (focus)="focusField('viewFactor')">
           <span class="alert-warning pull-right small" *ngIf="viewFactorError1[index] !== null">{{viewFactorError1[index]}}</span>
         </div>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-operations-form/explore-operations-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-operations-form/explore-operations-form.component.html
@@ -17,7 +17,7 @@
         <div class="form-group">
           <label for="baselineHours">Baseline Operating Hours</label>
           <div class="input-group">
-            <input name="baseOpHours" type="number" step="any" min="0" class="form-control" [(ngModel)]="phast.operatingHours.hoursPerYear"
+            <input name="baseOpHours" disabled="true" type="number" step="any" min="0" class="form-control" [(ngModel)]="phast.operatingHours.hoursPerYear"
               id="baseOpHours" onfocus="this.select();" (input)="calculate()" (focus)="focusField('operatingHours')" (blur)="focusOut()">
             <span class="input-group-addon units">hrs/yr</span>
           </div>
@@ -43,7 +43,7 @@
         <div class="form-group">
           <label for="baselineFuelCosts">Baseline Fuel Costs</label>
           <div class="input-group">
-            <input name="baselineFuelCosts" type="number" step="any" class="form-control" id="baselineFuelCosts" (input)="calculate()"
+            <input name="baselineFuelCosts" disabled="true" type="number" step="any" class="form-control" id="baselineFuelCosts" (input)="calculate()"
               [(ngModel)]="phast.operatingCosts.fuelCost" (focus)="focusField('operatingCosts')">
             <span class="units input-group-addon" *ngIf="settings.unitsOfMeasure == 'Imperial'">$/MMBtu</span>
             <span class="units input-group-addon" *ngIf="settings.unitsOfMeasure == 'Metric'">$/GJ</span>
@@ -71,7 +71,7 @@
         <div class="form-group">
           <label for="baselineSteamCosts">Baseline Steam Costs</label>
           <div class="input-group">
-            <input name="baselineSteamCosts" type="number" step="any" class="form-control" id="baselineSteamCosts" (input)="calculate()"
+            <input name="baselineSteamCosts" disabled="true" type="number" step="any" class="form-control" id="baselineSteamCosts" (input)="calculate()"
               [(ngModel)]="phast.operatingCosts.steamCost" (focus)="focusField('operatingCosts')">
             <span class="units input-group-addon" *ngIf="settings.unitsOfMeasure == 'Imperial'">$/MMBtu</span>
             <span class="units input-group-addon" *ngIf="settings.unitsOfMeasure == 'Metric'">$/GJ</span>
@@ -98,7 +98,7 @@
         <div class="form-group">
           <label for="baselineElectricityCosts">Baseline Electricity Costs</label>
           <div class="input-group">
-            <input name="baselineElectricityCosts" type="number" step="any" class="form-control" id="baselineElectricityCosts" (input)="calculate()"
+            <input name="baselineElectricityCosts" disabled="true" type="number" step="any" class="form-control" id="baselineElectricityCosts" (input)="calculate()"
               [(ngModel)]="phast.operatingCosts.electricityCost" (focus)="focusField('operatingCosts')">
             <span class="units input-group-addon">$/kWh</span>
           </div>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-system-efficiency-form/explore-system-efficiency-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-system-efficiency-form/explore-system-efficiency-form.component.html
@@ -11,7 +11,7 @@
         <div class="form-group">
           <label for="baseEfficiency">Baseline System Efficiency</label>
           <div class="input-group">
-            <input name="baseEfficiency" type="number" step="any" min="0" max="100" class="form-control" [(ngModel)]="phast.systemEfficiency" id="baseEfficiency" onfocus="this.select();"
+            <input name="baseEfficiency" disabled="true" type="number" step="any" min="0" max="100" class="form-control" [(ngModel)]="phast.systemEfficiency" id="baseEfficiency" onfocus="this.select();"
               (input)="calculate()" (focus)="focusField('efficiency')">
             <span class="input-group-addon units">%</span>
           </div>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-wall-form/explore-wall-form.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-wall-form/explore-wall-form.component.html
@@ -20,7 +20,7 @@
         <div class="form-group">
           <label class="small" for="avgSurfaceTemp">Baseline Surface Temperature</label>
           <div class="input-group">
-            <input name="{{'avgSurfaceTemp_'+lossIndex}}" type="number" step="any" class="form-control" [(ngModel)]="loss.surfaceTemperature"
+            <input name="{{'avgSurfaceTemp_'+lossIndex}}" disabled="true" type="number" step="any" class="form-control" [(ngModel)]="loss.surfaceTemperature"
               id="avgSurfaceTemp" onfocus="this.select();" (input)="checkSurfaceTemp(1, loss.surfaceTemperature, index)" (focus)="focusField('avgSurfaceTemp')"
               (blur)="focusOut()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">&#8457;</span>

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.html
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.html
@@ -12,8 +12,10 @@
     <div class="no-data col-6 scroll-item" [ngStyle]="{'height.px': containerHeight}" *ngIf="!exploreModExists">
       <h3>Now that your baseline set up, click below to start exploring potential opportunities.</h3>
       <button type="button" class="btn btn-primary" (click)="openModal()">Explore Opportunities</button>
-      <p>Data will be copied from your current baseline condition. You will not be able to add or remove losses after creating
-        a modification.</p>
+      <p>The Explore Opportunities section is a novice view to help you find and evaluate different opportunities for your system.
+        Notes for each type of loss can be added in the right tab (NOTES), these will be added to your final report.
+        Data will be copied from your current baseline condition. You will not be able to add or remove losses after creating a modification.
+      </p>
     </div>
     <div class="col-md-6 scroll-item no-padding-left" [ngStyle]="{'height.px': containerHeight}" *ngIf="exploreModExists">
       <app-losses-result-panel [inSetup]="false" [currentField]="currentField" [settings]="settings" [phast]="phast"
@@ -41,9 +43,9 @@
       </div>
       <div class="modal-body">
         <p>
-          You are about to add your first modification to your system. After doing so you will not be able to add or remove losses
-          from your baseline. You will need to delete all of your modifications to add or remove losses from your baseline.
-          Do you wish to proceed?
+          The Modify All Conditions section is an expert view, allowing you to change any input. You can create many different modifications,
+          to compare changes to your system. Notes for each loss page can be added in the right tab (NOTES), these will be added to your final report.
+          Data will be copied from your current baseline condition. You will not be able to add or remove losses after creating a modification.
         </p>
       </div>
       <div class="modal-footer">

--- a/src/app/phast/losses/losses.component.html
+++ b/src/app/phast/losses/losses.component.html
@@ -180,8 +180,10 @@
             </li>
             <li class="add-modification">
               <button class="btn btn-primary" (click)="addModification()">Add Modified Condition</button>
-              <p>Data will be copied from
-                <br/> your baseline operating condition</p>
+              <p>The Modify All Conditions section is an expert view, allowing you to change any input. You can create many different modifications,
+                to compare changes to your system. Notes for each loss page can be added in the right tab (NOTES), these will be added to your final report.
+                Data will be copied from your current baseline condition. You will not be able to add or remove losses after creating a modification.
+              </p>
             </li>
           </ul>
           <div class="losses-container edit-modification" *ngIf="showEditModification && editModification">
@@ -193,8 +195,10 @@
       <div class="no-data col-6" *ngIf="_modifications.length == 0 && !inSetup">
         <h3>Now that your baseline set up, click below to start adding modifications.</h3>
         <button type="button" (click)="openModal()">Add Modified Condition</button>
-        <p>Data will be copied from your current baseline condition. You will not be able to add or remove losses after creating
-          a modification.</p>
+        <p>The Modify All Conditions section is an expert view, allowing you to change any input. You can create many different modifications,
+          to compare changes to your system. Notes for each loss page can be added in the right tab (NOTES), these will be added to your final report.
+          Data will be copied from your current baseline condition. You will not be able to add or remove losses after creating a modification.
+        </p>
       </div>
     </div>
     <!--end row-->

--- a/src/app/phast/losses/opening-losses/opening-losses-form/opening-losses-form.component.html
+++ b/src/app/phast/losses/opening-losses/opening-losses-form/opening-losses-form.component.html
@@ -5,7 +5,7 @@
       <select name="{{'openingType_'+lossIndex}}" class="form-control" formControlName="openingType" id="openingType" (change)="getArea()"
         (focus)="focusField('openingType')" (blur)="focusOut()" [ngClass]="{'indicate-different': compareOpeningType()}">
         <option>Round</option>
-        <option>Rectangular (Square)</option>
+        <option>Rectangular (or Square)</option>
       </select>
     </div>
 

--- a/src/app/psat/psat.component.html
+++ b/src/app/psat/psat.component.html
@@ -109,9 +109,9 @@
     </div>
     <div class="pull-right" *ngIf="mainTab == 'system-setup' && mainTab != 'assessment'">
       <button class="btn btn-primary" [disabled]="!getCanContinue()" (click)="continue()">Next</button>
-    </div>    
+    </div>
     <div class="pull-right" *ngIf="mainTab == 'assessment'">
-        <button class="btn btn-primary" (click)="goToReport()">Go To Report</button>
+        <button class="btn btn-primary" (click)="goToReport()">View Report</button>
       </div>
   </div>
   <!--end footer-->


### PR DESCRIPTION
connect #1493 
connect #1485 
connect #1401 
connect #1498 
connect #1441 

- Verbiage changes for added help text and buttons / dropdown choices
- Baseline losses forms are now disabled in explore opportunities, preventing the user from changing their baseline setup via explore ops