### PR TITLE
disable baseline fields in explore opportunities for PSAT

### DIFF
--- a/src/app/psat/explore-opportunities/explore-opportunities-form/pump-data-form/pump-data-form.component.html
+++ b/src/app/psat/explore-opportunities/explore-opportunities-form/pump-data-form/pump-data-form.component.html
@@ -15,7 +15,7 @@
     <form *ngIf="showPumpType">
       <div class="form-group">
         <label for="baselinePumpType">Baseline Pump Type</label>
-        <select class="form-control" name="pumpType" id="pumpType" (change)="setPumpTypes()" (focus)="focusField('pumpType')" [(ngModel)]="tmpBaselinePumpType">
+        <select class="form-control" name="pumpType" [disabled]="true" id="pumpType" (change)="setPumpTypes()" (focus)="focusField('pumpType')" [(ngModel)]="tmpBaselinePumpType">
           <option *ngFor="let pumpType of pumpTypes" [ngValue]="pumpType">{{pumpType}}</option>
         </select>
       </div>
@@ -68,7 +68,7 @@
     <form *ngIf="showMotorDrive">
       <div class="form-group">
         <label for="baselineMotorDrive">Baseline Motor Drive</label>
-        <select class="form-control" name="drive" id="drive" (change)="setMotorDrive()" (focus)="focusField('drive')" [(ngModel)]="tmpBaselineMotorDrive">
+        <select class="form-control" name="drive" [disabled]="true" id="drive" (change)="setMotorDrive()" (focus)="focusField('drive')" [(ngModel)]="tmpBaselineMotorDrive">
           <option *ngFor="let drive of drives" [ngValue]="drive">{{drive}}</option>
         </select>
       </div>

--- a/src/app/psat/explore-opportunities/explore-opportunities-form/rated-motor-form/rated-motor-form.component.html
+++ b/src/app/psat/explore-opportunities/explore-opportunities-form/rated-motor-form/rated-motor-form.component.html
@@ -13,7 +13,7 @@
       <form *ngIf="showRatedMotorPower">
         <div class="form-group">
           <label for="baselineMotorRatedPower">Baseline Rated Motor Power</label>
-          <select name="baselineMotorRatedPower" class="form-control number-input-field" id="baselineMotorRatedPower" (focus)="focusField('motorRatedPower')"
+          <select name="baselineMotorRatedPower" [disabled]="true" class="form-control number-input-field" id="baselineMotorRatedPower" (focus)="focusField('motorRatedPower')"
             (change)="checkRatedPower(1)" [(ngModel)]="psat.inputs.motor_rated_power">
                                         <option  *ngFor="let option of options" [ngValue]="option">{{option}} {{settings.powerMeasurement}}</option>
                                     </select>
@@ -40,7 +40,7 @@
       <form *ngIf="showEfficiencyClass">
         <div class="form-group">
           <label for="oldEfficiencyClass">Baseline Efficiency Class</label>
-          <select name="oldEfficiencyClass" class="form-control select-input-field" (change)="setEfficiencyClasses()" id="oldEfficiencyClass"
+          <select name="oldEfficiencyClass" [disabled]="true" class="form-control select-input-field" (change)="setEfficiencyClasses()" id="oldEfficiencyClass"
             (focus)="focusField('efficiencyClass')" [(ngModel)]="tmpBaselineEfficiencyClass">
                                           <option *ngFor="let efficiencyClass of efficiencyClasses" [ngValue]="efficiencyClass">{{efficiencyClass}}</option>
                                     </select>
@@ -64,7 +64,7 @@
         <div class="form-group">
           <label for="baselineMotorEfficiency">Baseline Motor Efficiency</label>
           <div class="input-group">
-            <input name="baselineMotorEfficiency" [disabled]="tmpBaselineEfficiencyClass != 'Specified'" type="number" step="any" id="baselineMotorEfficiency"
+            <input name="baselineMotorEfficiency" [disabled]="true" type="number" step="any" id="baselineMotorEfficiency"
               class="form-control" (focus)="focusField('motorEfficiency')" (input)="checkEfficiency(psat.inputs.efficiency, 1)"
               [(ngModel)]="psat.inputs.efficiency" />
             <span class="input-group-addon units">(%)</span>

--- a/src/app/psat/explore-opportunities/explore-opportunities-form/system-data-form/system-data-form.component.html
+++ b/src/app/psat/explore-opportunities/explore-opportunities-form/system-data-form/system-data-form.component.html
@@ -16,7 +16,7 @@
             <div class="form-group">
                 <label for="baselineCost">Baseline Cost</label>
                 <div class="input-group">
-                    <input name="baselineCost" type="number" step="any" id="baselineCost" class="form-control" (focus)="focusField('modifyCost')"
+                    <input name="baselineCost" [disabled]="true" type="number" step="any" id="baselineCost" class="form-control" (focus)="focusField('modifyCost')"
                         (input)="checkCost(1)" [(ngModel)]="psat.inputs.cost_kw_hour" />
                     <span class="input-group-addon units">$/kWH</span>
                 </div>
@@ -25,7 +25,7 @@
             <div class="form-group">
                 <label for="modificationCost">Modification Cost</label>
                 <div class="input-group">
-                    <input name="modificationCost" type="number" step="any" id="modificationCost" class="form-control" (focus)="focusField('modifyCost')"
+                    <input name="modificationCost" type="number" step="0.01" min="0" id="modificationCost" class="form-control" (focus)="focusField('modifyCost')"
                         [(ngModel)]="psat.modifications[exploreModIndex].psat.inputs.cost_kw_hour" (input)="checkCost(2)" />
                     <span class="input-group-addon units">$/kWh</span>
                 </div>
@@ -44,7 +44,7 @@
             <div class="form-group">
                 <label for="baselineFlowRate">Baseline Flow Rate</label>
                 <div class="input-group">
-                    <input name="baselineFlowRate" type="number" step="any" id="baselineFlowRate" class="form-control" (focus)="focusField('flowRate')"
+                    <input name="baselineFlowRate" [disabled]="true" type="number" step="any" id="baselineFlowRate" class="form-control" (focus)="focusField('flowRate')"
                         (input)="checkFlowRate(1)" [(ngModel)]="psat.inputs.flow_rate" />
                     <span class="input-group-addon units" [innerHTML]="getUnit(settings.flowMeasurement)"></span>
                     <!--<span class="input-group-addon units">{{settings.flowMeasurement}}</span>-->
@@ -74,7 +74,7 @@
             <div class="form-group">
                 <label for="baselineHead">Baseline head</label>
                 <div class="input-group">
-                    <input name="baselineHead" type="number" step="any" id="baselineHead" class="form-control" (focus)="focusField('head')" (input)="calculate()"
+                    <input name="baselineHead" [disabled]="true" type="number" step="any" id="baselineHead" class="form-control" (focus)="focusField('head')" (input)="calculate()"
                         [(ngModel)]="psat.inputs.head" />
                     <span class="input-group-addon units" [innerHTML]="getUnit(settings.distanceMeasurement)"></span>
 
@@ -100,13 +100,13 @@
         <form *ngIf="showOperatingFraction">
             <div class="form-group">
                 <label for="baselineOperatingFraction">Baseline operating fractiong</label>
-                <input name="baselineOperatingFraction" type="number" step="any" id="baselineOperatingFraction" class="form-control" (focus)="focusField('operatingFraction')"
+                <input name="baselineOperatingFraction" [disabled]="true" type="number" step="any" id="baselineOperatingFraction" class="form-control" (focus)="focusField('operatingFraction')"
                     (input)="checkOpFraction(1)" [(ngModel)]="psat.inputs.operating_fraction" />
                 <span class="alert-danger pull-right small" *ngIf="opFractionError1 !== null">{{opFractionError1}}</span>
             </div>
             <div class="form-group">
                 <label for="modificationOperatingFraction">Modification operating fraction</label>
-                <input name="modificationOperatingFraction" type="number" step="any" id="modificationOperatingFraction" class="form-control"
+                <input name="modificationOperatingFraction" type="number" step="0.1" min="0" max="1" id="modificationOperatingFraction" class="form-control"
                     (focus)="focusField('operatingFraction')" (input)="checkOpFraction(2)" [(ngModel)]="psat.modifications[exploreModIndex].psat.inputs.operating_fraction"
                 />
                 <span class="alert-danger pull-right small" *ngIf="opFractionError2 !== null">{{opFractionError2}}</span>


### PR DESCRIPTION
connects #1493 

- Disables baseline fields when using PSAT's explore opportunities forms