### PR TITLE
fix psat motor rpm range issue, and two other quick issues

### DIFF
--- a/src/app/calculator/furnaces/energy-use/energy-use.component.ts
+++ b/src/app/calculator/furnaces/energy-use/energy-use.component.ts
@@ -32,7 +32,7 @@ export class EnergyUseComponent implements OnInit {
     // 1 is sharp edge
     sectionType: 1,
     dischargeCoefficient: 0.6,
-    gasHeatingValue: 22031,
+    gasHeatingValue: 1032.44,
     gasTemperature: 85,
     gasPressure: 85,
     orificePressureDrop: 10,
@@ -106,7 +106,7 @@ export class EnergyUseComponent implements OnInit {
         // 1 is sharp edge
         sectionType: 1,
         dischargeCoefficient: 0.6,
-        gasHeatingValue: 22031,
+        gasHeatingValue: 1032.44,
         gasTemperature: 85,
         gasPressure: 85,
         orificePressureDrop: 10,

--- a/src/app/phast/losses/losses-help/wall-losses-help/wall-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/wall-losses-help/wall-losses-help.component.html
@@ -77,7 +77,7 @@
       <label><u><strong>Description</strong></u></label>
       <p>
         Type of wall surface. To add a new surface, click “Add New Surface”.  You can “start with existing surface”
-        and edit the Surface Shape / Orientation or add a completely new surface.  You cannot use the name of a surface already in the database.
+        and edit the Surface Shape / Orientation Factor or add a completely new surface.  You cannot use the name of a surface already in the database.
       </p>
     </div>
   </div>

--- a/src/app/psat/psat.service.ts
+++ b/src/app/psat/psat.service.ts
@@ -724,8 +724,7 @@ export class PsatService {
       'measuredVoltage': ['', Validators.required],
       'optimizeCalculation': [''],
       'implementationCosts': ['']
-    })
-  }
+    })}
 
   getFormFromPsat(psatInputs: PsatInputs): FormGroup {
     if (!psatInputs.fixed_speed) {
@@ -751,7 +750,7 @@ export class PsatService {
       'fixedSpeed': [fixedSpeed, Validators.required],
       'frequency': [lineFreq, Validators.required],
       'horsePower': [psatInputs.motor_rated_power, Validators.required],
-      'motorRPM': [psatInputs.motor_rated_speed, Validators.required],
+      'motorRPM': [psatInputs.motor_rated_speed, (Validators.required, Validators.min(1))],
       'efficiencyClass': [effClass, Validators.required],
       'efficiency': [psatInputs.efficiency],
       'motorVoltage': [psatInputs.motor_rated_voltage, Validators.required],
@@ -773,7 +772,7 @@ export class PsatService {
   }
 
   getPsatInputsFromForm(form: FormGroup): PsatInputs {
-    
+
     let efficiency = this.getEfficiencyFromForm(form);
     let lineFreqEnum = this.getLineFreqEnum(form.controls.frequency.value);
     let pumpStyleEnum = this.getPumpStyleEnum(form.controls.pumpType.value);
@@ -978,8 +977,8 @@ export class PsatService {
 
   getMotorRpmMinMax(lineFreqEnum: number, effClass: number) {
     let rpmRange = {
-      min: 0,
-      max: 0
+      min: 1,
+      max: 3600
     }
     if (lineFreqEnum == 0 && (effClass == 0 || effClass == 1 )) { // if 60Hz and Standard or Energy Efficiency
       rpmRange.min = 540;
@@ -993,8 +992,6 @@ export class PsatService {
     } else if (lineFreqEnum == 1 && effClass == 2) { // if 50Hz and Premium Efficiency
       rpmRange.min = 900;
       rpmRange.max = 3000;
-    } else if (effClass === 3) {
-      return {min: 1, max: 3600}; // specified case
     }
     return rpmRange;
   }

--- a/src/app/suiteDb/wall-losses-surface/wall-losses-surface.component.html
+++ b/src/app/suiteDb/wall-losses-surface/wall-losses-surface.component.html
@@ -31,7 +31,7 @@
               <span class="alert-warning pull-right small" *ngIf="nameError !== null">{{nameError}}</span>
             </div>
             <div class="form-group" *ngIf="settings">
-              <label class="small" for="conditionFactor">Surface Shape / Orientation</label>
+              <label class="small" for="conditionFactor">Surface Shape / Orientation Factor</label>
               <input type="number" id="conditionFactor" name="conditionFactor" class="form-control" [(ngModel)]="newMaterial.conditionFactor"
                (focus)="focusField('conditionFactor')"/>
             </div>


### PR DESCRIPTION
connects #1649 
connects #1638 
connects https://github.com/ORNL-AMO/AMO-Tools-Suite/issues/224

- min rpm for psat motors is now 1
- add the word factor to surface shape / orientation
- change default natural gas heating value