### PR TITLE
Air Capacity relocation

### DIFF
--- a/src/app/calculator/compressed-air/receiver-tank/air-capacity-help/air-capacity-help.component.html
+++ b/src/app/calculator/compressed-air/receiver-tank/air-capacity-help/air-capacity-help.component.html
@@ -1,12 +1,11 @@
 <div class="tab-content">
-  <p>Compute the quantity of compressed air that is actually available for use. When air receivers are installed, the system’s
-    pressure profile and lack of storage, limit the effectiveness of compressed air energy storage. Hence this calculator
-    proves useful in such a context.
+  <p>Usable Air Capacity computes the quantity of compressed air that is actually available for use. When air receivers are installed,
+    the system’s pressure profile and lack of storage limit the effectiveness of compressed air energy storage.
   </p>
   <div class="help-content">
     <div class="card">
       <div class="card-header">
-        Reciever Tank Size
+        Receiver Tank Size
       </div>
       <div class="card-block">
         <p>Quantity of air receiver tank could hold.</p>

--- a/src/app/calculator/compressed-air/receiver-tank/receiver-tank.component.html
+++ b/src/app/calculator/compressed-air/receiver-tank/receiver-tank.component.html
@@ -20,11 +20,22 @@
               <app-dedicated-storage-form *ngIf="method == 1"></app-dedicated-storage-form>
               <app-metered-storage-form *ngIf="method == 2"></app-metered-storage-form>
               <app-delay-method-form *ngIf="method == 3"></app-delay-method-form>
-              <app-air-capacity-form *ngIf="method == 4"></app-air-capacity-form>
+            </form>
+          </div>
+        </div>
+
+        <div class="header">
+          <h3>Usable Air Capacity Calculations</h3>
+        </div>
+        <div class="row">
+          <div class="col-12 tab-content">
+            <form>
+              <app-air-capacity-form></app-air-capacity-form>
             </form>
           </div>
         </div>
       </div>
+
       <div class="col-6 align-top">
         <div class="help-panel">
           <div class="header">
@@ -35,7 +46,9 @@
             <app-dedicated-storage-help *ngIf="method == 1"></app-dedicated-storage-help>
             <app-metered-storage-help *ngIf="method == 2"></app-metered-storage-help>
             <app-delay-method-help *ngIf="method == 3"></app-delay-method-help>
-            <app-air-capacity-help *ngIf="method == 4"></app-air-capacity-help>
+          </div>
+          <div class="tab-content">
+            <app-air-capacity-help></app-air-capacity-help>
           </div>
         </div>
       </div>

--- a/src/app/calculator/compressed-air/receiver-tank/receiver-tank.component.ts
+++ b/src/app/calculator/compressed-air/receiver-tank/receiver-tank.component.ts
@@ -23,11 +23,7 @@ export class ReceiverTankComponent implements OnInit {
     {
       name: 'Bridging Compressor Reaction Delay',
       value: 3
-    },
-    {
-      name: 'Usable Air Capacity',
-      value: 4
-    },
+    }
   ];
   method: number = 0;
 


### PR DESCRIPTION
connects #1450 

Moves the air capacity calculator to be shown by default under the receiver tank page.