### PR TITLE
Unit fixes in settings menu

### DIFF
--- a/src/app/calculator/steam/steam-properties/steam-properties-form/steam-properties-form.component.ts
+++ b/src/app/calculator/steam/steam-properties/steam-properties-form/steam-properties-form.component.ts
@@ -30,10 +30,10 @@ export class SteamPropertiesFormComponent implements OnInit {
   readonly checkQuantity: Array<TemperatureProperties | SpecificEnthalpyProperties | SpecificEntropyProperties | Properties> = [
     {
       'F': {
-        min: 32, max: 1472, type: 'Temperature', displayUnits: 'Fahrenheit'
+        min: 32, max: 1472, type: 'Temperature', displayUnits: '&#x2109;'
       },
       'C': {
-        min: 0, max: 800, type: 'Temperature', displayUnits: 'Celsius'
+        min: 0, max: 800, type: 'Temperature', displayUnits: '&#x2103;'
       }
     },
     {

--- a/src/app/settings/psat-settings/psat-settings.component.html
+++ b/src/app/settings/psat-settings/psat-settings.component.html
@@ -2,31 +2,31 @@
   <div class="form-group">
     <label for="distanceMeasurement">Head Measurement</label>
     <select class="form-control" formControlName="distanceMeasurement" id="distanceMeasurement" (change)="setCustom()">
-        <option *ngFor="let measurement of distanceMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} )</option>
+        <option *ngFor="let measurement of distanceMeasurements" [ngValue]="measurement.unit">{{measurement.display}} <span [innerHTML]="getUnitDisplay(measurement.unit)"></span></option>
     </select>
   </div>
   <div class="form-group">
     <label for="flowMeasurement">Flow Measurement</label>
     <select class="form-control" formControlName="flowMeasurement" id="flowMeasurement" (change)="setCustom()">
-        <option *ngFor="let measurement of flowMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} )</option>
+        <option *ngFor="let measurement of flowMeasurements" [ngValue]="measurement.unit">{{measurement.display}} <span [innerHTML]="getUnitDisplay(measurement.unit)"></span></option>
     </select>
   </div>
   <div class="form-group">
     <label for="powerMeasurement">Power Measurement</label>
     <select class="form-control" formControlName="powerMeasurement" id="powerMeasurement" (change)="setCustom()">
-        <option *ngFor="let measurement of powerMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} )</option>
+        <option *ngFor="let measurement of powerMeasurements" [ngValue]="measurement.unit">{{measurement.display}} <span [innerHTML]="getUnitDisplay(measurement.unit)"></span></option>
     </select>
   </div>
   <div class="form-group">
     <label for="pressureMeasurement">Pressure Measurement</label>
     <select class="form-control" formControlName="pressureMeasurement" id="pressureMeasurement" (change)="setCustom()">
-        <option *ngFor="let measurement of pressureMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} ) </option>
+        <option *ngFor="let measurement of pressureMeasurements" [ngValue]="measurement.unit">{{measurement.display}} <span [innerHTML]="getUnitDisplay(measurement.unit)"></span></option>
     </select>
   </div>
   <div class="form-group">
     <label for="temperatureMeasurement">Temperature Measurement</label>
     <select class="form-control" formControlName="temperatureMeasurement" id="temperatureMeasurement" (change)="setCustom()">
-        <option *ngFor="let measurement of temperatureMeasurements" [ngValue]="measurement.unit">{{measurement.display}} ( {{measurement.unit}} ) </option>
+        <option *ngFor="let measurement of temperatureMeasurements" [ngValue]="measurement.unit">{{measurement.display}} <span [innerHTML]="getUnitDisplay(measurement.unit)"></span></option>
     </select>
   </div>
     <!--<div class="form-group">

--- a/src/app/settings/psat-settings/psat-settings.component.ts
+++ b/src/app/settings/psat-settings/psat-settings.component.ts
@@ -130,6 +130,12 @@ export class PsatSettingsComponent implements OnInit {
     }
   }
 
+  getUnitDisplay(unit: any){
+    if(unit){
+      return this.convertUnitsService.getUnit(unit).unit.name.display;
+    }
+  }
+
   setCustom() {
     this.settingsForm.patchValue({
       unitsOfMeasure: 'Custom'

--- a/src/app/settings/steam-settings/steam-settings.component.html
+++ b/src/app/settings/steam-settings/steam-settings.component.html
@@ -3,17 +3,17 @@
     <label for="pressureMeasurement">Pressure Measurement</label>
     <select class="form-control" formControlName="steamPressureMeasurement" id="pressureMeasurement" (change)="save()">
       <!--<option value='mPa'>MPa</option>-->
-      <option value='kPa'>Kilopascals ( kPa )</option>
-      <option value='psi'>Pounds per Square Inch ( psi )</option>
-      <option value='bar'>Bar ( bar )</option>
+      <option value='kPa'>Kilopascals (kPa)</option>
+      <option value='psi'>Pounds per Square Inch (psi)</option>
+      <option value='bar'>Bar (bar)</option>
     </select>
   </div>
 
   <div class="form-group">
     <label for="temperatureMeasurement">Temperature Measurement</label>
     <select class="form-control" formControlName="steamTemperatureMeasurement" id="temperatureMeasurement" (change)="save()">
-      <option value='F'>Degrees Fahrenheit ( F )</option>
-      <option value='C'>Degrees Celsius ( C )</option>
+      <option value='F'>Degrees Fahrenheit (&#x2109;)</option>
+      <option value='C'>Degrees Celsius (&#x2103;)</option>
     </select>
   </div>
 
@@ -21,8 +21,8 @@
     <label for="steamSpecificEnthalpyMeasurement">Specific Enthalpy</label>
     <div class="input-group calc-addon-group">
       <select name="steamSpecificEnthalpyMeasurement" class="form-control" formControlName="steamSpecificEnthalpyMeasurement" id="steamSpecificEnthalpyMeasurement" (change)="save()" autofocus>
-        <option value='btulb'>British thermal units per Pound ( Btu/lb )</option>
-        <option value='kJkg'>Kilojoules per Kilogram ( kJ/kg )</option>
+        <option value='btulb'>British thermal units per Pound (Btu/lb)</option>
+        <option value='kJkg'>Kilojoules per Kilogram (kJ/kg)</option>
       </select>
     </div>
   </div>
@@ -31,8 +31,8 @@
     <label for="steamSpecificEntropyMeasurement">Specific Entropy</label>
     <div class="input-group calc-addon-group">
       <select name="steamSpecificEntropyMeasurement" class="form-control" formControlName="steamSpecificEntropyMeasurement" id="steamSpecificEntropyMeasurement" (change)="save()" autofocus>
-        <option value='btulbF'>British thermal units per Pound Fahrenheit ( Btu/lb-F )</option>
-        <option value='kJkgK'>Kilojoules per Kilogram Kelvin ( kJ/kg/K )</option>
+        <option value='btulbF'>British thermal units per Pound Fahrenheit (Btu/lb-&#x2109;)</option>
+        <option value='kJkgK'>Kilojoules per Kilogram Kelvin (kJ/kg/K)</option>
       </select>
     </div>
   </div>
@@ -41,9 +41,9 @@
   <label for="steamSpecificVolumeMeasurement">Specific Volume</label>
   <div class="input-group calc-addon-group">
     <select name="steamSpecificVolumeMeasurement" class="form-control" formControlName="steamSpecificVolumeMeasurement" id="steamSpecificVolumeMeasurement" (change)="save()" autofocus>
-      <option value='ft3lb'>Standard Cubic Foot per Pound ( ft<sup>3</sup>/lb )</option>
-      <option value='m3kg'>Normal Cubic Meter per Kilogram ( m<sup>3</sup>/kg )</option>
-      <option value='m3g'>Normal Cubic Meter per Kilogram ( m<sup>3</sup>/g )</option>
+      <option value='ft3lb'>Standard Cubic Foot per Pound (ft&#x00B3;/lb)</option>
+      <option value='m3kg'>Normal Cubic Meter per Kilogram (m&#x00B3;/kg)</option>
+      <option value='m3g'>Normal Cubic Meter per Kilogram (m&#x00B3;/g)</option>
     </select>
   </div>
 </div>
@@ -53,7 +53,7 @@
   <div class="input-group calc-addon-group">
     <select name="steamMassFlowMeasurement" class="form-control" formControlName="steamMassFlowMeasurement" id="steamMassFlowMeasurement" (change)="save()" autofocus>
       <option value='lbhr'>Pound per Hour (lb/hr)</option>
-      <option value='kghr'>Kilogram per Hour ( kg/hr )</option>
+      <option value='kghr'>Kilogram per Hour (kg/hr)</option>
     </select>
   </div>
 </div>

--- a/src/app/shared/convert-units/definitions/specificHeat.ts
+++ b/src/app/shared/convert-units/definitions/specificHeat.ts
@@ -33,7 +33,7 @@ export const specificHeat = {
       name: {
         singular: 'British Thermal Unit per Pound Fahrenheit'
         , plural: 'British Thermal Units per Pound Fahrenheit',
-        display: '(Btu/lb-F)'
+        display: '(Btu/lb-&#x2109;)'
       }
       , to_anchor: 1
     }

--- a/src/app/shared/convert-units/definitions/temperature.ts
+++ b/src/app/shared/convert-units/definitions/temperature.ts
@@ -4,7 +4,7 @@ export const temperature = {
             name: {
                 singular: 'Degree Celsius'
                 , plural: 'Degrees Celsius' ,
-                 display:  '(C)'
+                 display:  '(&#x2103;)'
             }
             , to_anchor: 1
             , anchor_shift: 0
@@ -24,7 +24,7 @@ export const temperature = {
             name: {
                 singular: 'Degree Fahrenheit'
                 , plural: 'Degrees Fahrenheit' ,
-                 display:  '(F)'
+                 display:  '(&#x2109;)'
             }
             , to_anchor: 1
         }

--- a/src/app/shared/convert-units/definitions/volumetricHeat.ts
+++ b/src/app/shared/convert-units/definitions/volumetricHeat.ts
@@ -22,7 +22,7 @@ export const volumetricHeat = {
       name: {
         singular: 'Kilocalorie per Cubic Meter Celsius'
         , plural: 'Kilocalorie per Cubic Meter Celsius',
-        display: '(kcal/m&#x00B3;-C)'
+        display: '(kcal/m&#x00B3;-&#x2103;)'
       }
       , to_anchor: 0.238845897
     },
@@ -30,7 +30,7 @@ export const volumetricHeat = {
       name: {
         singular: 'Btu per Standard Cubic Foot Fahrenheit'
         , plural: 'Btu per Standard Cubic Feet Fahrenheit',
-        display: '(Btu/SCF - F)'
+        display: '(Btu/SCF - &#x2109;)'
       }
       , to_anchor: 1/14.921
     }


### PR DESCRIPTION
Changes: in settings dropdown menus added degree symbols to temperature units; some units were formatted ( unit ) and other were (unit), consolidated all formatting into (unit) i.e. no spaces; corrected specific volume units under steam settings to have superscript 3

connect #1738 