### PR TITLE
issue 1599 - renaming Premium to Premium Efficient

### DIFF
--- a/src/app/calculator/motors/motor-performance/motor-performance-form/motor-performance-form.component.ts
+++ b/src/app/calculator/motors/motor-performance/motor-performance-form/motor-performance-form.component.ts
@@ -34,7 +34,7 @@ export class MotorPerformanceFormComponent implements OnInit {
   efficiencyClasses: Array<string> = [
     'Standard Efficiency',
     'Energy Efficient',
-    'Premium',
+    'Premium Efficient',
     'Specified'
   ];
   efficiencyError: string = null;

--- a/src/app/calculator/motors/nema-energy-efficiency/nema-energy-efficiency-form/nema-energy-efficiency-form.component.ts
+++ b/src/app/calculator/motors/nema-energy-efficiency/nema-energy-efficiency-form/nema-energy-efficiency-form.component.ts
@@ -29,7 +29,7 @@ export class NemaEnergyEfficiencyFormComponent implements OnInit {
   efficiencyClasses: Array<string> = [
     'Standard Efficiency',
     'Energy Efficient',
-    'Premium',
+    'Premium Efficient',
     'Specified'
   ];
   efficiencyError: string = null;

--- a/src/app/psat/motor/motor.component.ts
+++ b/src/app/psat/motor/motor.component.ts
@@ -37,7 +37,7 @@ export class MotorComponent implements OnInit {
   efficiencyClasses: Array<string> = [
     'Standard Efficiency',
     'Energy Efficient',
-    'Premium',
+    'Premium Efficient',
     'Specified'
   ];
 

--- a/src/app/psat/psat.service.ts
+++ b/src/app/psat/psat.service.ts
@@ -593,7 +593,7 @@ export class PsatService {
       effEnum = 0;
     } else if (effClass === 'Energy Efficient') {
       effEnum = 1;
-    } else if (effClass === 'Premium') {
+    } else if (effClass === 'Premium Efficient' || effClass === 'Premium') {
       effEnum = 2;
     } else if (effClass === 'Specified') {
       effEnum = 3;
@@ -607,7 +607,7 @@ export class PsatService {
     } else if (num === 1) {
       effClass = 'Energy Efficient';
     } else if (num === 2) {
-      effClass = 'Premium';
+      effClass = 'Premium Efficient';
     } else if (num === 3) {
       effClass = 'Specified';
     }
@@ -687,7 +687,7 @@ export class PsatService {
       efficiency = 0;
     } else if (form.controls.efficiencyClass.value == 'Energy Efficient') {
       efficiency = 1;
-    } else if (form.controls.efficiencyClass.value === 'Premium') {
+    } else if (form.controls.efficiencyClass.value === 'Premium Efficient' || form.controls.efficiencyClass.value === 'Premium') {
       efficiency = 2;
     } else if (form.controls.efficiencyClass.value == 'Specified') {
       efficiency = form.controls.efficiency.value;


### PR DESCRIPTION
Changed option in Efficiency Class dropdown from Premium to Premium Efficient in 3 places;
Nema energy calc, Motor perf. calc, and PSAT assessment field data tab

connect #1599 