### PR TITLE
Fixed issue

### DIFF
--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -184,7 +184,7 @@ export class SettingsService {
         phastRollupSteamUnit: 'MMBtu',
         densityMeasurement: 'lbscf',
         fanFlowRate: 'ft3/min',
-        fanPressureMeasurement: 'in H&#x2082;O'
+        fanPressureMeasurement: 'inH2o'
         // currentMeasurement: 'A',
         // viscosityMeasurement: 'cST',
         // voltageMeasurement: 'V'


### PR DESCRIPTION
connect #1940 
"switching units of measure to imperial (if already on imperial, switching to metric and back) clears units for Pressure Measurement without assigning new ones."