### PR TITLE
Fixed Calculator typos and punctuation issues+ added CCI participants heading to Acknowledgements page+my name

### DIFF
--- a/src/app/acknowledgments-page/acknowledgments-page.component.html
+++ b/src/app/acknowledgments-page/acknowledgments-page.component.html
@@ -68,6 +68,13 @@
           <br> Ben Rappoport
           <br> Raul Rios
           <br>
+          <br>
+          <h4>
+          <u>Community College Internship Participants</u>
+          </h4>
+          Allie Ledbetter
+          <br>
+          <br>
         </div>
       </div>
     </div>

--- a/src/app/calculator/compressed-air/pipe-sizing/pipe-sizing.component.html
+++ b/src/app/calculator/compressed-air/pipe-sizing/pipe-sizing.component.html
@@ -32,8 +32,7 @@
           Pipe Sizing Help
           <br>
           <small class="text-muted"> This calculator helps in finding the pipe diameter, when the volumetric flow
-            velocity, pressure, and design velocity
-            are known.
+            velocity, pressure, and design velocity are known.
           </small>
         </h5>
         <hr class="my-1 hr-spacer">

--- a/src/app/calculator/compressed-air/pneumatic-air/pneumatic-air.component.html
+++ b/src/app/calculator/compressed-air/pneumatic-air/pneumatic-air.component.html
@@ -32,10 +32,8 @@
           Pneumatic Air Help
           <br>
           <small class="text-muted"> This calculator helps in computing the quantity of air required by a specific
-            single acting or a double acting
-            piston cylinder compressor. The design specs of the compressor are entered in the calculator and the
-            quantity
-            of air needed is generated.
+            single acting or a double acting piston cylinder compressor. The design specs of the compressor are entered in the calculator and the
+            quantity of air needed is generated.
           </small>
         </h5>
         <hr class="my-1 hr-spacer">

--- a/src/app/calculator/compressed-air/system-capacity/system-capacity.component.html
+++ b/src/app/calculator/compressed-air/system-capacity/system-capacity.component.html
@@ -31,11 +31,9 @@
           System Capacity Help
           <br>
           <small class="text-muted"> This is used to find the total air quantity that the compressed air system can
-            contain
-            at any instant of time, including the air in the pipes and receivers. The total capacity of the compressed
-            air
-            system can be obtained by adding the volumes of pipes and receivers.
-            <hr> Pipe sizes used are nominal schedule 40 pipe sizes
+            contain at any instant of time, including the air in the pipes and receivers. The total capacity of the compressed
+            air system can be obtained by adding the volumes of pipes and receivers.
+            <hr> Pipe sizes used are nominal schedule 40 pipe sizes.
 
           </small>
         </h5>

--- a/src/app/calculator/fans/fans.component.html
+++ b/src/app/calculator/fans/fans.component.html
@@ -14,8 +14,7 @@
             <a class="click-item" (click)="showTool('fsat-203')">Fan Analysis</a>
             <p>
               This calculator lets the user determine the power, flow rate, pressure and fan efficiency at set
-              operating points. It also
-              helps the user perform a pitot tube analysis for the determination of flow rate and pressure.
+              operating points. It also helps the user perform a pitot tube analysis for the determination of flow rate and pressure.
             </p>
           </div>
         </div>
@@ -41,8 +40,7 @@
           <div class="d-flex flex-fill flex-column justify-content-center">
             <a class="click-item" (click)="showTool('pump-curve')">Fan Curve</a>
             <p>Use fan curve calculator to develop a fan curve and explore the effects of changes in head, flow, fan
-              speed and
-              impeller diameter</p>
+              speed and impeller diameter.</p>
           </div>
         </div>
         <div class="d-flex calc-item-row w-100">

--- a/src/app/calculator/fans/fsat-203/operating-points-help/fan-data-help/fan-data-help.component.html
+++ b/src/app/calculator/fans/fsat-203/operating-points-help/fan-data-help/fan-data-help.component.html
@@ -48,7 +48,7 @@
       <hr> Plane 4
       <br>
       <small class="text-muted">
-        Plane 4 is a plane upstream of fan used to establish fan inlet Plane Static Pressure
+        Plane 4 is a plane upstream of fan used to establish fan inlet Plane Static Pressure.
       </small>
     </span>
 
@@ -56,7 +56,7 @@
       <hr> Plane 5
       <br>
       <small class="text-muted">
-        Plane 5 is a plane downstream of fan used to establish fan outlet Plane 2 Static Pressure
+        Plane 5 is a plane downstream of fan used to establish fan outlet Plane 2 Static Pressure.
       </small>
     </span>
   </h5>

--- a/src/app/calculator/fans/fsat-203/operating-points-help/fan-shaft-power-help/fan-shaft-power-help.component.html
+++ b/src/app/calculator/fans/fsat-203/operating-points-help/fan-shaft-power-help/fan-shaft-power-help.component.html
@@ -155,7 +155,7 @@
       VFD Efficiency
       <br>
       <small class="text-muted">
-        If fan is equipped with a VFD, input the VFD efficiency (%)
+        If fan is equipped with a VFD, input the VFD efficiency (%).
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/fans/fsat-203/operating-points-help/fsat-basics-help/fsat-basics-help.component.html
+++ b/src/app/calculator/fans/fsat-203/operating-points-help/fsat-basics-help/fsat-basics-help.component.html
@@ -88,7 +88,8 @@
       Number of Traverse Planes
       <br>
       <small class="text-muted">
-        1 is the default setting, but if more than one traverse plane is required to capture the total flow of the fan, then select 2 or 3 (more than 3 is rare and thus not included).        <hr>
+        1 is the default setting, but if more than one traverse plane is required to capture the total flow of the fan, 
+        then select 2 or 3 (more than 3 is rare and thus not included).<hr>
       </small>
     </h6>
   </div>

--- a/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement-help/efficiency-improvement-help.component.html
+++ b/src/app/calculator/furnaces/efficiency-improvement/efficiency-improvement-help/efficiency-improvement-help.component.html
@@ -1,6 +1,6 @@
 <div class="p-4 pt-2 d-flex flex-column help-info">
   <h5>
-    Efficiency Improvement Calculater Help
+    Efficiency Improvement Calculator Help
     <br>
     <small class="text-muted"> Use the Efficiency Improvement calculator to explore potential fuel savings from adjusting burner operating conditions
       (Flue gas oxygen levels and temperature and combustion temperature).

--- a/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-help/energy-equivalency-help.component.html
+++ b/src/app/calculator/furnaces/energy-equivalency/energy-equivalency-help/energy-equivalency-help.component.html
@@ -1,6 +1,6 @@
 <div class="p-4 pt-2 d-flex flex-column help-info">
   <h5>
-    Energy Equivalency Calculater Help
+    Energy Equivalency Calculator Help
     <br>
     <small class="text-muted">Provides calculations for converting values of energy input requirements when the heat source is changed from fuel-firing
       (Btu/hr or kJ/hr) to electricity (kW), or vice versa.
@@ -73,7 +73,7 @@
       Electrically Heated Efficiency (Fuel)
       <br>
       <small class="text-muted">
-        Furnace efficiency of the baseline (electric furnace)
+        Furnace efficiency of the baseline (electric furnace).
         <hr>
       </small>
     </h6>
@@ -97,7 +97,7 @@
     <h6> Fuel-Fired Efficiency (Fuel)
       <br>
       <small class="text-muted">
-        Furnace efficiency of the alternate (fuel-fired furance)
+        Furnace efficiency of the alternate (fuel-fired furance).
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/furnaces/energy-use/energy-use-help/energy-use-help.component.html
+++ b/src/app/calculator/furnaces/energy-use/energy-use-help/energy-use-help.component.html
@@ -38,7 +38,7 @@
       Inside Pipe Diameter
       <br>
       <small class="text-muted">
-        Inside diameter of pipe
+        Inside diameter of pipe.
         <hr>
       </small>
     </h6>
@@ -59,7 +59,7 @@
       Operating Time
       <br>
       <small class="text-muted">
-        Total time for flow / heating
+        Total time for flow / heating.
         <hr>
       </small>
     </h6>
@@ -69,7 +69,7 @@
       Type of Orifice
       <br>
       <small class="text-muted">
-        Type of orifice. Changing this automatically changes the field "Coefficient of Discharge"
+        Type of orifice. Changing this automatically changes the field "Coefficient of Discharge".
         <hr>
       </small>
     </h6>
@@ -107,7 +107,7 @@
       Gas Temperature
       <br>
       <small class="text-muted">
-        Temperature of the gas entering the orifice
+        Temperature of the gas entering the orifice.
         <hr>
       </small>
     </h6>
@@ -117,7 +117,7 @@
       Gas Pressure
       <br>
       <small class="text-muted">
-        Pressure of the gas entering the orifice
+        Pressure of the gas entering the orifice.
         <hr>
       </small>
     </h6>
@@ -193,7 +193,7 @@
       Specific Gravity
       <br>
       <small class="text-muted">
-        Specific gravity of the gas relative to air (density of gas / density of air) at standard temperature and pressure
+        Specific gravity of the gas relative to air (density of gas / density of air) at standard temperature and pressure.
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-help/o2-enrichment-help.component.html
@@ -80,7 +80,7 @@
       Fuel Consumption
       <br>
       <small class="text-muted">
-        Energy of consumed fuel
+        Energy of consumed fuel.
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-help/lighting-replacement-help.component.html
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-help/lighting-replacement-help.component.html
@@ -84,7 +84,7 @@
       Number of Fixtures
       <small class="text-muted">
         <br>
-        Total number of fixtures
+        Total number of fixtures.
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/motors/motor-performance/motor-performance-help/motor-performance-help.component.html
+++ b/src/app/calculator/motors/motor-performance/motor-performance-help/motor-performance-help.component.html
@@ -2,7 +2,7 @@
   <h5>
     Motor Performance
     <br>
-    <small class="text-muted"> Plots current, efficiency, power factor vs motor shaft load for a given motor description
+    <small class="text-muted"> Plots current, efficiency, power factor vs motor shaft load for a given motor description.
 
     </small>
   </h5>

--- a/src/app/calculator/motors/motors.component.html
+++ b/src/app/calculator/motors/motors.component.html
@@ -39,7 +39,7 @@
           <div class="d-flex flex-fill flex-column justify-content-center">
             <a (click)="showTool('percent-load-estimation')"> Percent Load Estimation</a>
             <p>
-              Calculates Percent Load Estimation
+              Calculates Percent Load Estimation.
             </p>
           </div>
         </div>

--- a/src/app/calculator/motors/nema-energy-efficiency/nema-energy-efficiency-help/nema-energy-efficiency-help.component.html
+++ b/src/app/calculator/motors/nema-energy-efficiency/nema-energy-efficiency-help/nema-energy-efficiency-help.component.html
@@ -47,7 +47,7 @@
       <br>
       <small class="text-muted">
         The energy efficiency of electric motors is defined in the international standard on efficiency classes for motors: IEC 60034
-        Part 30 - Efficiency classes of line operated AC motors (IE code)
+        Part 30 - Efficiency classes of line operated AC motors (IE code).
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/pumps/pumps.component.html
+++ b/src/app/calculator/pumps/pumps.component.html
@@ -55,8 +55,7 @@
             <a class="click-item" (click)="showTool('achievable-efficiency')">Pump Efficiency Curves</a>
             <p>
               Determine the achievable pump efficiency for various pump styles which are based on the Hydraulic
-              Institute (HI) standard
-              ANSI/HI 1.3-2000
+              Institute (HI) standard ANSI/HI 1.3-2000.
             </p>
           </div>
         </div>
@@ -69,8 +68,7 @@
           <div class="d-flex flex-fill flex-column justify-content-center">
             <a class="click-item" (click)="showTool('pump-curve')">Pump Curve</a>
             <p>Use pump curve calculator to develop a pump curve and explore the effects of changes in head, flow, pump
-              speed
-              and impeller diameter</p>
+              speed and impeller diameter.</p>
           </div>
         </div>
       </div>

--- a/src/app/calculator/steam/stack-loss/stack-loss-help/stack-loss-help.component.html
+++ b/src/app/calculator/steam/stack-loss/stack-loss-help/stack-loss-help.component.html
@@ -242,18 +242,18 @@
       Savings Suggestions
       <br>
       <small class="text-muted">
-        Maintain appropriate level of oxygen in stack gases by controlling air-fuel ratio for the burners
-        <hr> Maintain and control burner operations to eliminate formation of soot or combustible gases such as carbon monoxide
-        and hydrogen in stack gases
+        Maintain appropriate level of oxygen in stack gases by controlling air-fuel ratio for the burners.
+        <hr> Maintain and control burner operations to eliminate formation of soot or combustible gases such as carbon monoxide.
+        and hydrogen in stack gases.
         <hr> Consider use of heat recovery from stack gases. Consider use of various methods of heat recovery to reduce stack
-        gas temperature leaving the heating system
-        <hr> Use preheated combustion air through use of recuperators or regenerators
-        <hr> Where appropriate, consider use of oxygen enrichment of combustion air to reduce mass of stack gases
+        gas temperature leaving the heating system.
+        <hr> Use preheated combustion air through use of recuperators or regenerators.
+        <hr> Where appropriate, consider use of oxygen enrichment of combustion air to reduce mass of stack gases.
         <hr> Review process temperature settings and lower it where possible during part-load operations. This can reduce flustacke
-        gas temperature leaving the heating system
+        gas temperature leaving the heating system.
         <hr> Note: These energy saving measures are for guidance only. Not all measures are applicable under all operating conditions.
         There may additional measures when considering specific situations and the user is encouraged to review and apply
-        the appropriate measures
+        the appropriate measures.
       </small>
     </h6>
   </div>

--- a/src/app/calculator/utilities/cash-flow/cash-flow-help/cash-flow-help.component.html
+++ b/src/app/calculator/utilities/cash-flow/cash-flow-help/cash-flow-help.component.html
@@ -11,7 +11,7 @@
       Lifetime
       <br>
       <small class="text-muted">
-        Expected Lifetime of the equipment/modification (years)
+        Expected Lifetime of the equipment/modification (years).
         <hr>
       </small>
     </h6>
@@ -23,7 +23,7 @@
       <br>
       <small class="text-muted">
         Annual expected savings resulting from the new process modification equipment (if the modification includes any savings beyond
-        energy, could also include this here)
+        energy, could also include this here).
         <hr>
       </small>
     </h6>
@@ -70,7 +70,7 @@
       <br>
       <small class="text-muted">
         Annual Fuel costs for the equipment or increase in fuel costs with the new equipment. (If there is a fuel savings, that should
-        be include in "Annual Energy Savings")
+        be include in "Annual Energy Savings").
         <hr>
       </small>
     </h6>

--- a/src/app/calculator/utilities/combined-heat-power/combined-heat-power-help/combined-heat-power-help.component.html
+++ b/src/app/calculator/utilities/combined-heat-power/combined-heat-power-help/combined-heat-power-help.component.html
@@ -17,7 +17,7 @@
       Annual Operating Hours
       <br>
       <small class="text-muted">
-        Annual operating hours with loads facilitating CHP
+        Annual operating hours with loads facilitating CHP.
         <hr>
       </small>
     </h6>


### PR DESCRIPTION
Fixed Calculator Misspelling in:

*Efficiency Improvement Help
*Energy Equivalency Help

Fixed punctuation missing from:
*Cash Flow Help
*Heat and Power Calculator Help
*Motor Performance Help
*Stack Loss Help
*Compressed Air- System Capacity Help
*Nema Energy Efficiency Help
*Lighting Replacement Help
*Energy Use Help
*O2 Enrichment Help
*Fan Shaft Power Help

Fixed punctuation on all calculators menu for these calculators:
*Percent Load Estimation
*Pump Efficiency curves
*Pump Curves
*Fan Curve

Added heading "Community College Internship Participants" to the Acknowledgements page
Added my name under CCI header
Cleaned up portions of code to make it more readable