### PR TITLE
Possible fix for issue-2682

### DIFF
--- a/src/app/fsat/explore-opportunities/explore-opportunities.component.ts
+++ b/src/app/fsat/explore-opportunities/explore-opportunities.component.ts
@@ -26,7 +26,7 @@ export class ExploreOpportunitiesComponent implements OnInit {
   @Input()
   exploreModIndex: number;
   @Output('emitSave')
-  emitSave = new EventEmitter<FSAT>();
+  emitSave = new EventEmitter<boolean>();
   @Output('emitAddNewMod')
   emitAddNewMod = new EventEmitter<boolean>();
   @Output('exploreOppsToast')
@@ -66,11 +66,11 @@ export class ExploreOpportunitiesComponent implements OnInit {
     }
   }
 
-  ngOnDestroy(){
+  ngOnDestroy() {
     this.exploreOppsToast.emit(false);
-    if(this.fsat.modifications[this.exploreModIndex] && !this.fsat.modifications[this.exploreModIndex].fsat.name){
+    if(this.fsat.modifications[this.exploreModIndex] && !this.fsat.modifications[this.exploreModIndex].fsat.name) {
       this.fsat.modifications[this.exploreModIndex].fsat.name = 'Opportunities Modification';
-      this.emitSave.emit();
+      this.emitSave.emit(true);
   }
 }
 
@@ -97,7 +97,7 @@ export class ExploreOpportunitiesComponent implements OnInit {
   }
 
   save() {
-    this.emitSave.emit(this.assessment.fsat);
+    this.emitSave.emit(true);
   }
 
   getContainerHeight() {

--- a/src/app/fsat/explore-opportunities/explore-opportunities.component.ts
+++ b/src/app/fsat/explore-opportunities/explore-opportunities.component.ts
@@ -23,6 +23,8 @@ export class ExploreOpportunitiesComponent implements OnInit {
   modificationIndex: number;
   @Input()
   modificationExists: boolean;
+  @Input()
+  exploreModIndex: number;
   @Output('emitSave')
   emitSave = new EventEmitter<FSAT>();
   @Output('emitAddNewMod')
@@ -66,7 +68,11 @@ export class ExploreOpportunitiesComponent implements OnInit {
 
   ngOnDestroy(){
     this.exploreOppsToast.emit(false);
+    if(this.fsat.modifications[this.exploreModIndex] && !this.fsat.modifications[this.exploreModIndex].fsat.name){
+      this.fsat.modifications[this.exploreModIndex].fsat.name = 'Opportunities Modification';
+      this.emitSave.emit();
   }
+}
 
   ngAfterViewInit() {
     setTimeout(() => {
@@ -118,7 +124,7 @@ export class ExploreOpportunitiesComponent implements OnInit {
       if (!this.fsat.modifications[this.modificationIndex].exploreOpportunities) {
         this.exploreOppsToast.emit(true);
         let toastOptions: ToastOptions = {
-          title: 'Explore Opportunites',
+          title: 'Explore Opportunities',
           msg: 'The selected modification was created using the expert view. There may be changes to the modification that are not visible from this screen.',
           showClose: true,
           timeout: 10000000,

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.ts
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.ts
@@ -44,7 +44,6 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
   modExists: boolean = false;
   selectModificationSubscription: Subscription;
   toastId: any;
-  emitSave: any;
   constructor(private lossesService: LossesService, private toastyService: ToastyService,
     private toastyConfig: ToastyConfig,
   ) {
@@ -62,7 +61,7 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
     this.exploreOppsToast.emit(false);
       if(this.phast.modifications[this.exploreModIndex] && !this.phast.modifications[this.exploreModIndex].phast.name){
         this.phast.modifications[this.exploreModIndex].phast.name = 'Opportunities Modification';
-        this.emitSave.emit(true);
+        this.save.emit(true);
       }
     }
 

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.ts
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.ts
@@ -59,7 +59,7 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
   ngOnDestroy() {
     this.toastyService.clearAll();
     this.exploreOppsToast.emit(false);
-      if(this.phast.modifications[this.exploreModIndex] && !this.phast.modifications[this.exploreModIndex].phast.name){
+      if (this.phast.modifications[this.exploreModIndex] && !this.phast.modifications[this.exploreModIndex].phast.name){
         this.phast.modifications[this.exploreModIndex].phast.name = 'Opportunities Modification';
         this.save.emit(true);
       }
@@ -93,7 +93,7 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
           showClose: true,
           timeout: 10000000,
           theme: 'default'
-        }
+        };
         this.toastyService.warning(toastOptions);
       } else {
         this.exploreOppsToast.emit(false);

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.ts
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities.component.ts
@@ -44,6 +44,7 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
   modExists: boolean = false;
   selectModificationSubscription: Subscription;
   toastId: any;
+  emitSave: any;
   constructor(private lossesService: LossesService, private toastyService: ToastyService,
     private toastyConfig: ToastyConfig,
   ) {
@@ -59,7 +60,11 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
   ngOnDestroy() {
     this.toastyService.clearAll();
     this.exploreOppsToast.emit(false);
-  }
+      if(this.phast.modifications[this.exploreModIndex] && !this.phast.modifications[this.exploreModIndex].phast.name){
+        this.phast.modifications[this.exploreModIndex].phast.name = 'Opportunities Modification';
+        this.emitSave.emit(true);
+      }
+    }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.exploreModIndex) {
@@ -84,7 +89,7 @@ export class ExplorePhastOpportunitiesComponent implements OnInit {
       if (!this.phast.modifications[this.exploreModIndex].exploreOpportunities) {
         this.exploreOppsToast.emit(true);
         let toastOptions: ToastOptions = {
-          title: 'Explore Opportunites',
+          title: 'Explore Opportunities',
           msg: 'The selected modification was created using the expert view. There may be changes to the modification that are not visible from this screen.',
           showClose: true,
           timeout: 10000000,

--- a/src/app/psat/explore-opportunities/explore-opportunities-form/explore-opportunities-form.component.ts
+++ b/src/app/psat/explore-opportunities/explore-opportunities-form/explore-opportunities-form.component.ts
@@ -74,6 +74,13 @@ export class ExploreOpportunitiesFormComponent implements OnInit {
     }
   }
 
+  ngOnDestroy(){
+    if(!this.psat.modifications[this.exploreModIndex].psat.name){
+      this.psat.modifications[this.exploreModIndex].psat.name = 'Opportunities Modification';
+      this.emitSave.emit(true);
+    }
+  }
+
   initForms() {
     this.baselineMotorForm = this.motorService.getFormFromObj(this.psat.inputs);
     this.baselineMotorForm.disable();

--- a/src/app/psat/explore-opportunities/explore-opportunities-form/explore-opportunities-form.component.ts
+++ b/src/app/psat/explore-opportunities/explore-opportunities-form/explore-opportunities-form.component.ts
@@ -75,7 +75,7 @@ export class ExploreOpportunitiesFormComponent implements OnInit {
   }
 
   ngOnDestroy(){
-    if(!this.psat.modifications[this.exploreModIndex].psat.name){
+    if(this.psat.modifications[this.exploreModIndex] && !this.psat.modifications[this.exploreModIndex].psat.name){
       this.psat.modifications[this.exploreModIndex].psat.name = 'Opportunities Modification';
       this.emitSave.emit(true);
     }

--- a/src/app/psat/explore-opportunities/explore-opportunities.component.ts
+++ b/src/app/psat/explore-opportunities/explore-opportunities.component.ts
@@ -104,9 +104,7 @@ export class ExploreOpportunitiesComponent implements OnInit {
 
   save() {
     //this.assessment.psat = this.psat;
-    if (!this.psat.modifications[this.modificationIndex].psat.name) {
-      this.psat.modifications[this.modificationIndex].psat.name = 'Opportunities Modification';
-    }
+ 
     this.saved.emit(true);
   }
   setTab(str: string) {

--- a/src/app/psat/explore-opportunities/explore-opportunities.component.ts
+++ b/src/app/psat/explore-opportunities/explore-opportunities.component.ts
@@ -29,9 +29,13 @@ export class ExploreOpportunitiesComponent implements OnInit {
   @Input()
   modificationIndex: number;
   @Input()
+  exploreModIndex: number;
+  @Input()
   modificationExists: boolean;
   @Output('emitAddNewMod')
   emitAddNewMod = new EventEmitter<boolean>();
+  @Output('exploreOppsToast')
+  exploreOppsToast = new EventEmitter<boolean>();
 
 
   @ViewChild('resultTabs') resultTabs: ElementRef;
@@ -79,6 +83,13 @@ export class ExploreOpportunitiesComponent implements OnInit {
     }
   }
 
+  ngOnDestroy() {
+    this.exploreOppsToast.emit(false);
+    if(this.psat.modifications[this.exploreModIndex] && !this.psat.modifications[this.exploreModIndex].psat.name) {
+      this.psat.modifications[this.exploreModIndex].psat.name = 'Opportunities Modification';
+      this.saved.emit(true)
+  }
+}
   getContainerHeight() {
     if (this.containerHeight && this.resultTabs) {
       let tabHeight = this.resultTabs.nativeElement.clientHeight;

--- a/src/app/ssmt/explore-opportunities/explore-opportunities-form/explore-opportunities-form.component.ts
+++ b/src/app/ssmt/explore-opportunities/explore-opportunities-form/explore-opportunities-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, SimpleChanges } from '@angular/core';
 import { Settings } from '../../../shared/models/settings';
 import { SSMT } from '../../../shared/models/steam/ssmt';
 import { SsmtService } from '../../ssmt.service';
@@ -23,6 +23,13 @@ export class ExploreOpportunitiesFormComponent implements OnInit {
 
   showSizeMargin: boolean;
   constructor(private ssmtService: SsmtService) { }
+
+  ngOnDestroy(){
+    if(this.ssmt.modifications[this.exploreModIndex] && !this.ssmt.modifications[this.exploreModIndex].ssmt.name){
+      this.ssmt.modifications[this.exploreModIndex].ssmt.name = 'Opportunities Modification';
+      //this.emitSave.emit(true);
+    }
+  }
 
   ngOnInit() {
   }

--- a/src/app/ssmt/explore-opportunities/explore-opportunities.component.ts
+++ b/src/app/ssmt/explore-opportunities/explore-opportunities.component.ts
@@ -23,11 +23,13 @@ export class ExploreOpportunitiesComponent implements OnInit {
   @Input()
   modificationExists: boolean;
   @Output('emitSave')
-  emitSave = new EventEmitter<SSMT>();
+  emitSave = new EventEmitter<boolean>();
   @Output('emitAddNewMod')
   emitAddNewMod = new EventEmitter<boolean>();
   @Output('exploreOppsToast')
   exploreOppsToast = new EventEmitter<boolean>();
+  @Input()
+  exploreModIndex: number;
 
   @ViewChild('resultTabs') resultTabs: ElementRef;
 
@@ -63,6 +65,10 @@ export class ExploreOpportunitiesComponent implements OnInit {
 
   ngOnDestroy(){
     //this.exploreOppsToast.emit(false);
+    if(this.ssmt.modifications[this.exploreModIndex] && !this.ssmt.modifications[this.exploreModIndex].ssmt.name) {
+      this.ssmt.modifications[this.exploreModIndex].ssmt.name = 'Opportunities Modification';
+      this.emitSave.emit(true);
+    }
   }
 
   ngAfterViewInit() {
@@ -89,7 +95,7 @@ export class ExploreOpportunitiesComponent implements OnInit {
 
   save(newSSMT: SSMT) {
     this.assessment.ssmt = newSSMT;
-    this.emitSave.emit(this.assessment.ssmt);
+    this.emitSave.emit(true);
   }
 
   getContainerHeight() {
@@ -111,7 +117,7 @@ export class ExploreOpportunitiesComponent implements OnInit {
   //     if (!this.ssmt.modifications[this.modificationIndex].exploreOpportunities) {
   //       this.exploreOppsToast.emit(true);
   //       let toastOptions: ToastOptions = {
-  //         title: 'Explore Opportunites',
+  //         title: 'Explore Opportunities',
   //         msg: 'The selected modification was created using the expert view. There may be changes to the modification that are not visible from this screen.',
   //         showClose: true,
   //         timeout: 10000000,


### PR DESCRIPTION
connects #2682 

Please check to confirm this is fixed, Looks like this code was causing the text to return when backspaced:
``if (!this.psat.modifications[this.modificationIndex].psat.name) {
      this.psat.modifications[this.modificationIndex].psat.name = 'Opportunities Modification';
    }``
Also, removing this code didn't seem to break anything, as it wasn't in the code for the other assessments, which seems to be why it wasn't happening there too.
 
I was able to stop the bug from happening when a new assessment is added. When the default "Scenerio1" text is deleted via backspace, "Opportunities Modification" no longer appears, also tested with adding other scenarios as well.