### PR TITLE
fix 2954

### DIFF
--- a/src/app/calculator/utilities/compressed-air-reduction/compressed-air-reduction.service.ts
+++ b/src/app/calculator/utilities/compressed-air-reduction/compressed-air-reduction.service.ts
@@ -189,11 +189,19 @@ export class CompressedAirReductionService {
       annualConsumptionReduction: annualConsumptionReduction
     }
     if (modificationResults) {
+      if (baselineInpCpy[0].utilityType == 0) {
+        //use consumption reduction to energy use..
+        compressedAirReductionResults.baselineResults.energyUse = compressedAirReductionResults.baselineResults.consumption;
+        compressedAirReductionResults.modificationResults.energyUse = compressedAirReductionResults.modificationResults.consumption;
+      }
+
       compressedAirReductionResults.annualEnergySavings = baselineResults.energyUse - modificationResults.energyUse;
       compressedAirReductionResults.annualCostSavings = baselineResults.energyCost - modificationResults.energyCost;
       compressedAirReductionResults.annualFlowRateReduction = baselineResults.flowRate - modificationResults.flowRate;
       compressedAirReductionResults.annualConsumptionReduction = baselineResults.consumption - modificationResults.consumption;
     }
+
+
     return compressedAirReductionResults;
   }
 

--- a/src/app/treasure-hunt/treasure-chest/compressed-air-reduction-card/compressed-air-reduction-card.component.html
+++ b/src/app/treasure-hunt/treasure-chest/compressed-air-reduction-card/compressed-air-reduction-card.component.html
@@ -23,8 +23,10 @@
               </span>
             </a><br>
             <span>Annual Cost Savings: {{compressedAirReductionResults.annualCostSavings | currency:'USD'}}</span><br>
-            <span>Annual Compressed Air Savings: {{compressedAirReductionResults.annualEnergySavings | number:'1.0-0'}}
-              kWh
+            <span>Annual {{energyType}} Savings: {{compressedAirReductionResults.annualEnergySavings | number:'1.0-0'}}
+              <span *ngIf="energyType == 'Electricity'">kWh</span>
+              <span *ngIf="energyType == 'Compressed Air' && settings.unitsOfMeasure == 'Imperial'">kSCF</span>
+              <span *ngIf="energyType == 'Compressed Air' && settings.unitsOfMeasure == 'Metric'">Nm<sup>3</sup></span>
             </span>
           </div>
         </div>

--- a/src/app/treasure-hunt/treasure-chest/compressed-air-reduction-card/compressed-air-reduction-card.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/compressed-air-reduction-card/compressed-air-reduction-card.component.ts
@@ -39,6 +39,7 @@ export class CompressedAirReductionCardComponent implements OnInit {
 
   ngOnInit() {
     this.compressedAirReductionResults = this.compressedAirReductionService.getResults(this.settings, this.compressedAirReduction.baseline, this.compressedAirReduction.modification);
+    console.log(this.compressedAirReductionResults)
     this.percentSavings = (this.compressedAirReductionResults.annualCostSavings / this.treasureHunt.currentEnergyUsage.compressedAirCosts) * 100;
     //electricity utility
     if (this.compressedAirReduction.baseline[0].utilityType == 1) {

--- a/src/app/treasure-hunt/treasure-hunt-report/executive-summary/executive-summary.component.html
+++ b/src/app/treasure-hunt/treasure-hunt-report/executive-summary/executive-summary.component.html
@@ -231,7 +231,7 @@
             Compressed Air
           </td>
           <td *ngIf="showFullSummary">
-            <span *ngIf="settings.unitsOfMeasure == 'Imperial'">SCF</span>
+            <span *ngIf="settings.unitsOfMeasure == 'Imperial'">kSCF</span>
             <span *ngIf="settings.unitsOfMeasure == 'Metric'">Nm<sup>3</sup></span>
           </td>
           <td *ngIf="showFullSummary">

--- a/src/app/treasure-hunt/treasure-hunt-report/opportunity-summary/opportunity-summary.component.html
+++ b/src/app/treasure-hunt/treasure-hunt-report/opportunity-summary/opportunity-summary.component.html
@@ -75,7 +75,7 @@
           <span *ngIf="opportunity.utilityType == 'Electricity'">kWh</span>
 
           <span *ngIf="opportunity.utilityType == 'Compressed Air'">
-            <span *ngIf="settings.unitsOfMeasure == 'Imperial'">SCF</span>
+            <span *ngIf="settings.unitsOfMeasure == 'Imperial'">kSCF</span>
             <span *ngIf="settings.unitsOfMeasure == 'Metric'">Nm<sup>3</sup></span>
           </span>
 


### PR DESCRIPTION
Using consumption for energy use results when calculating compressed air reduction for utility type "Compressed Air"

connects #2954 