### PR TITLE
Issue 3575

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_install:
 install: travis_retry npm install
 
 script:
-  - npm run ng-high-memory
+  - npm run build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,5 @@ install:
 build_script:
 - cmd: >-
     npm install
-    npm run ng-high-memory
+    npm run build
 test: off

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -1,4 +1,4 @@
-import { Routes, RouterModule } from '@angular/router';
+import { Routes, RouterModule, ExtraOptions } from '@angular/router';
 import { ModuleWithProviders } from '@angular/core';
 import { CoreComponent } from './core/core.component';
 import { coreRoutes } from './core/core.routing';
@@ -13,4 +13,10 @@ const appRoutes: Routes = [
 
 export const appRoutingProviders: any[] = [
 ];
-export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes);
+const routerOptions: ExtraOptions = {
+  anchorScrolling: 'enabled',
+  onSameUrlNavigation: 'reload',
+  scrollPositionRestoration: 'enabled',
+  // paramsInheritanceStrategy: 'always'
+};
+export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes, routerOptions);

--- a/src/app/core/core.routing.ts
+++ b/src/app/core/core.routing.ts
@@ -73,6 +73,7 @@ import { StackLossComponent } from '../calculator/steam/stack-loss/stack-loss.co
 import { SteamPropertiesComponent } from '../calculator/steam/steam-properties/steam-properties.component';
 import { TurbineComponent } from '../calculator/steam/turbine/turbine.component';
 import { TankInsulationReductionComponent } from '../calculator/utilities/tank-insulation-reduction/tank-insulation-reduction.component';
+import { AssessmentReportsComponent } from '../report-rollup/assessment-reports/assessment-reports.component';
 
 export const coreRoutes: Routes = [
   {
@@ -396,6 +397,17 @@ export const coreRoutes: Routes = [
   },
   {
     path: 'report-rollup',
-    component: ReportRollupComponent
+    component: ReportRollupComponent,
+    children: [
+      // {
+      //   path: '',
+      //   pathMatch: 'full',
+      //   redirectTo: 'assessment-reports'
+      // },
+      {
+        path: '',
+        component: AssessmentReportsComponent
+      }
+    ]
   }
 ];

--- a/src/app/psat/psat-report/output-summary/output-summary.component.ts
+++ b/src/app/psat/psat-report/output-summary/output-summary.component.ts
@@ -18,8 +18,6 @@ export class OutputSummaryComponent implements OnInit {
   settings: Settings;
   @Input()
   inRollup: boolean;
-  @Output('selectModification')
-  selectModification = new EventEmitter<any>();
   @Input()
   assessment: Assessment;
 

--- a/src/app/psat/psat-report/psat-report.component.html
+++ b/src/app/psat/psat-report/psat-report.component.html
@@ -101,8 +101,7 @@
         <div class="results scroll-item print-height" [ngClass]="{'hide-print': !printResults}"
             *ngIf="currentTab == 'results' || (showPrint && printResults)"
             [ngStyle]="{'height.px':reportContainerHeight}">
-            <app-output-summary [psat]="psat" [settings]="settings" [inRollup]="inRollup" [assessment]="assessment"
-                (selectModification)="useModification($event)">
+            <app-output-summary [psat]="psat" [settings]="settings" [inRollup]="inRollup" [assessment]="assessment">
             </app-output-summary>
         </div>
         <div class="results scroll-item print-height" [ngClass]="{'hide-print': !printReportGraphs}"

--- a/src/app/psat/psat-report/psat-report.component.ts
+++ b/src/app/psat/psat-report/psat-report.component.ts
@@ -30,8 +30,6 @@ export class PsatReportComponent implements OnInit {
   exportData = new EventEmitter<boolean>();
   @Input()
   inRollup: boolean;
-  @Output('selectModification')
-  selectModification = new EventEmitter<any>();
   @Input()
   quickReport: boolean;
   @Input()
@@ -162,11 +160,6 @@ export class PsatReportComponent implements OnInit {
   exportToCsv() {
     this.exportData.emit(true);
   }
-
-  useModification(event: any) {
-    this.selectModification.emit(event);
-  }
-
 
   initPrintLogic() {
     if (!this.inRollup) {

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.css
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.css
@@ -1,0 +1,3 @@
+.assessment-item{
+    margin-bottom: 2rem;
+}

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.html
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.html
@@ -1,5 +1,3 @@
-
-
 <!-- NOT PRINT -->
 <div *ngIf="!printView">
     <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
@@ -36,7 +34,7 @@
 <div class="print-container" *ngIf="printView">
     <div *ngIf="_psatAssessments.length > 0 && rollupPrintOptions.printPsatRollup" class="row print-break-before">
         <div class="col-12">
-            <app-psat-rollup-print [settings]="settings"></app-psat-rollup-print>
+            <app-psat-rollup-print [settings]="settings" [calculators]="selectedPsatCalcs"></app-psat-rollup-print>
         </div>
     </div>
     <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item row">
@@ -49,9 +47,9 @@
         </div>
     </div>
 
-    <div *ngIf="_phastAssessments.length > 0 && printPhastRollup" class="row print-break-before">
+    <div *ngIf="_phastAssessments.length > 0 && rollupPrintOptions.printPhastRollup" class="row print-break-before">
         <div class="col-12">
-            <app-phast-rollup-print [settings]="settings" [calculators]="selectedCalcs">
+            <app-phast-rollup-print [settings]="settings" [calculators]="selectedPhastCalcs">
             </app-phast-rollup-print>
         </div>
     </div>
@@ -72,7 +70,7 @@
     <div *ngIf="_fsatAssessments.length > 0 && rollupPrintOptions.printFsatRollup" class="row print-break-before">
         <div class="col-12">
             <!--fsat print-->
-            <app-fsat-rollup-print [settings]="settings"></app-fsat-rollup-print>
+            <app-fsat-rollup-print [settings]="settings" [calculators]="selectedFsatCalcs"></app-fsat-rollup-print>
         </div>
     </div>
     <div class="assessment-item row" *ngFor="let item of _fsatAssessments" id="{{'assessment_'+item.assessment.id}}">
@@ -103,7 +101,8 @@
         </div>
     </div>
 
-    <div *ngIf="_treasureHuntAssessments.length > 0 && rollupPrintOptions.printTreasureHuntRollup" class="row print-break-before">
+    <div *ngIf="_treasureHuntAssessments.length > 0 && rollupPrintOptions.printTreasureHuntRollup"
+        class="row print-break-before">
         <div class="col-12">
             <!--treasure hunt print-->
             <!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> -->

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.html
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.html
@@ -86,11 +86,11 @@
         </div>
     </div>
 
-    <div *ngIf="_ssmtAssessments.length > 0 && rollupPrintOptions.printSsmtRollup" class="row print-break-before">
+    <!-- <div *ngIf="_ssmtAssessments.length > 0 && rollupPrintOptions.printSsmtRollup" class="row print-break-before">
         <div class="col-12">
             <app-ssmt-rollup-print [settings]="settings"></app-ssmt-rollup-print>
         </div>
-    </div>
+    </div> -->
     <div class="assessment-item row" *ngFor="let item of _ssmtAssessments" id="{{'assessment_'+item.assessment.id}}">
         <div class="col-12">
             <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment" [settings]="item.settings"

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.html
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.html
@@ -1,97 +1,10 @@
-<!-- <div class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline"
-    [ngStyle]="{'height.px': sidebarHeight}" (scroll)="checkActiveAssessment($event)"> -->
-<!-- print layout -->
-<!-- <div class="print-container" *ngIf="printView">
-        <div *ngIf="_psatAssessments.length > 0 && printPsatRollup" class="row print-break-before">
-            <div class="col-12">
-                <app-psat-rollup-print [settings]="settings"></app-psat-rollup-print>
-            </div>
-        </div>
-        <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}"
-            class="assessment-item row">
-            <div class="col-12">
-                <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
-                    [printView]="printView" (selectModification)="updateSummary($event)" [settings]="item.settings"
-                    [printInputData]="printInputData" [printReportGraphs]="printReportGraphs"
-                    [printReportSankey]="printReportSankey" [printResults]="printResults">
-                </app-psat-report>
-            </div>
-        </div>
 
-        <div *ngIf="_phastAssessments.length > 0 && printPhastRollup" class="row"
-            [ngClass]="{'print-break-before' : (printPsatRollup && _psatAssessments.length > 0)}">
-            <div class="col-12">
-                <app-phast-rollup-print [settings]="settings" [calculators]="selectedCalcs">
-                </app-phast-rollup-print>
-            </div>
-        </div>
-        <div *ngFor="let item of _phastAssessments" id="{{'assessment_'+item.assessment.id}}"
-            class="assessment-item row">
-            <div class="col-12">
-                <app-phast-report *ngIf="item.assessment.phast" [phast]="item.assessment.phast"
-                    [assessment]="item.assessment" [inRollup]="true" [settings]="item.settings" [printView]="printView"
-                    [printInputSummary]="printInputData" [printResultsData]="printResults"
-                    [printReportGraphs]="printReportGraphs" [printReportSankey]="printReportSankey"
-                    [printEnergyUsed]="printEnergyUsed" [printExecutiveSummary]="printExecutiveSummary">
-                </app-phast-report>
-            </div>
-        </div>
 
-        <div *ngIf="_fsatAssessments.length > 0 && printFsatRollup" class="row print-break-before">
-            <div class="col-12">
-                <!--fsat print--
-                <app-fsat-rollup-print [settings]="settings"></app-fsat-rollup-print>
-            </div>
-        </div>
-        <div class="assessment-item row" *ngFor="let item of _fsatAssessments"
-            id="{{'assessment_'+item.assessment.id}}">
-            <div class="col-12">
-                <app-fsat-report *ngIf="item.assessment.fsat" [fsat]="item.assessment.fsat"
-                    [assessment]="item.assessment" [settings]="item.settings" [inRollup]="true" [printView]="printView"
-                    [printInputData]="printInputData" [printReportGraphs]="printReportGraphs"
-                    [printReportSankey]="printReportSankey" [printResults]="printResults"></app-fsat-report>
-            </div>
-        </div>
-
-        <!-- <div *ngIf="_ssmtAssessments.length > 0 && printSsmtRollup" class="row print-break-before">
-                    <div class="col-12">
-                        <app-ssmt-rollup-print [settings]="settings"></app-ssmt-rollup-print>
-                    </div>
-                </div> --
-        <div class="assessment-item row" *ngFor="let item of _ssmtAssessments"
-            id="{{'assessment_'+item.assessment.id}}">
-            <div class="col-12">
-                <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment" [settings]="item.settings"
-                    [inRollup]="true" [printView]="printView" [printExecutiveSummary]="printExecutiveSummary"
-                    [printEnergySummary]="printEnergySummary" [printLossesSummary]="printLossesSummary"
-                    [printInputData]="printInputData" [printReportGraphs]="printReportGraphs"></app-ssmt-report>
-            </div>
-        </div>
-
-        <div *ngIf="_treasureHuntAssessments.length > 0 && printTreasureHuntRollup" class="row print-break-before">
-            <div class="col-12">
-                <!--treasure hunt print-->
-<!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> --
-            </div>
-        </div>
-        <div class="assessment-item row" *ngFor="let item of _treasureHuntAssessments"
-            id="{{'assessment_'+item.assessment.id}}">
-            <div class="col-12">
-                <app-treasure-hunt-report *ngIf="item.assessment.treasureHunt" [assessment]="item.assessment"
-                    [settings]="item.settings" [inRollup]="true" [printView]="printView"
-                    [printReportGraphs]="printReportGraphs" [printExecutiveSummary]="printExecutiveSummary"
-                    [printReportOpportunityPayback]="printReportOpportunityPayback"
-                    [printReportOpportunitySummary]="printReportOpportunitySummary">
-                </app-treasure-hunt-report>
-            </div>
-        </div>
-    </div> -->
-
-<!-- app layout -->
-<div *ngIf="!printView" (scroll)="checkActiveAssessment($event)">
+<!-- NOT PRINT -->
+<div *ngIf="!printView">
     <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
         <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
-            (selectModification)="updateSummary($event)" [settings]="item.settings">
+            [settings]="item.settings">
         </app-psat-report>
     </div>
 
@@ -117,5 +30,95 @@
         </app-treasure-hunt-report>
     </div>
 </div>
-<!-- End .content -->
-<!-- </div> -->
+<!--END NOT PRINT-->
+
+<!-- PRINT!! -->
+<div class="print-container" *ngIf="printView">
+    <div *ngIf="_psatAssessments.length > 0 && rollupPrintOptions.printPsatRollup" class="row print-break-before">
+        <div class="col-12">
+            <app-psat-rollup-print [settings]="settings"></app-psat-rollup-print>
+        </div>
+    </div>
+    <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item row">
+        <div class="col-12">
+            <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
+                [printView]="printView" [settings]="item.settings" [printInputData]="printInputData"
+                [printReportGraphs]="rollupPrintOptions.printReportGraphs" [printReportSankey]="printReportSankey"
+                [printResults]="rollupPrintOptions.printResults">
+            </app-psat-report>
+        </div>
+    </div>
+
+    <div *ngIf="_phastAssessments.length > 0 && printPhastRollup" class="row print-break-before">
+        <div class="col-12">
+            <app-phast-rollup-print [settings]="settings" [calculators]="selectedCalcs">
+            </app-phast-rollup-print>
+        </div>
+    </div>
+    <div *ngFor="let item of _phastAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item row">
+        <div class="col-12">
+            <app-phast-report *ngIf="item.assessment.phast" [phast]="item.assessment.phast"
+                [assessment]="item.assessment" [inRollup]="true" [settings]="item.settings" [printView]="printView"
+                [printInputSummary]="rollupPrintOptions.printInputData"
+                [printResultsData]="rollupPrintOptions.printResults"
+                [printReportGraphs]="rollupPrintOptions.printReportGraphs"
+                [printReportSankey]="rollupPrintOptions.printReportSankey"
+                [printEnergyUsed]="rollupPrintOptions.printEnergyUsed"
+                [printExecutiveSummary]="rollupPrintOptions.printExecutiveSummary">
+            </app-phast-report>
+        </div>
+    </div>
+
+    <div *ngIf="_fsatAssessments.length > 0 && rollupPrintOptions.printFsatRollup" class="row print-break-before">
+        <div class="col-12">
+            <!--fsat print-->
+            <app-fsat-rollup-print [settings]="settings"></app-fsat-rollup-print>
+        </div>
+    </div>
+    <div class="assessment-item row" *ngFor="let item of _fsatAssessments" id="{{'assessment_'+item.assessment.id}}">
+        <div class="col-12">
+            <app-fsat-report *ngIf="item.assessment.fsat" [fsat]="item.assessment.fsat" [assessment]="item.assessment"
+                [settings]="item.settings" [inRollup]="true" [printView]="printView"
+                [printInputData]="rollupPrintOptions.printInputData"
+                [printReportGraphs]="rollupPrintOptions.printReportGraphs"
+                [printReportSankey]="rollupPrintOptions.printReportSankey"
+                [printResults]="rollupPrintOptions.printResults"></app-fsat-report>
+        </div>
+    </div>
+
+    <div *ngIf="_ssmtAssessments.length > 0 && rollupPrintOptions.printSsmtRollup" class="row print-break-before">
+        <div class="col-12">
+            <app-ssmt-rollup-print [settings]="settings"></app-ssmt-rollup-print>
+        </div>
+    </div>
+    <div class="assessment-item row" *ngFor="let item of _ssmtAssessments" id="{{'assessment_'+item.assessment.id}}">
+        <div class="col-12">
+            <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment" [settings]="item.settings"
+                [inRollup]="true" [printView]="printView"
+                [printExecutiveSummary]="rollupPrintOptions.printExecutiveSummary"
+                [printEnergySummary]="rollupPrintOptions.printEnergySummary"
+                [printLossesSummary]="rollupPrintOptions.printLossesSummary"
+                [printInputData]="rollupPrintOptions.printInputData"
+                [printReportGraphs]="rollupPrintOptions.printReportGraphs"></app-ssmt-report>
+        </div>
+    </div>
+
+    <div *ngIf="_treasureHuntAssessments.length > 0 && rollupPrintOptions.printTreasureHuntRollup" class="row print-break-before">
+        <div class="col-12">
+            <!--treasure hunt print-->
+            <!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> -->
+        </div>
+    </div>
+    <div class="assessment-item row" *ngFor="let item of _treasureHuntAssessments"
+        id="{{'assessment_'+item.assessment.id}}">
+        <div class="col-12">
+            <app-treasure-hunt-report *ngIf="item.assessment.treasureHunt" [assessment]="item.assessment"
+                [settings]="item.settings" [inRollup]="true" [printView]="printView"
+                [printReportGraphs]="rollupPrintOptions.printReportGraphs"
+                [printExecutiveSummary]="rollupPrintOptions.printExecutiveSummary"
+                [printReportOpportunityPayback]="rollupPrintOptions.printReportOpportunityPayback"
+                [printReportOpportunitySummary]="rollupPrintOptions.printReportOpportunitySummary">
+            </app-treasure-hunt-report>
+        </div>
+    </div>
+</div>

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.html
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.html
@@ -1,0 +1,121 @@
+<!-- <div class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline"
+    [ngStyle]="{'height.px': sidebarHeight}" (scroll)="checkActiveAssessment($event)"> -->
+    <!-- print layout -->
+    <!-- <div class="print-container" *ngIf="printView">
+        <div *ngIf="_psatAssessments.length > 0 && printPsatRollup" class="row print-break-before">
+            <div class="col-12">
+                <app-psat-rollup-print [settings]="settings"></app-psat-rollup-print>
+            </div>
+        </div>
+        <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}"
+            class="assessment-item row">
+            <div class="col-12">
+                <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
+                    [printView]="printView" (selectModification)="updateSummary($event)" [settings]="item.settings"
+                    [printInputData]="printInputData" [printReportGraphs]="printReportGraphs"
+                    [printReportSankey]="printReportSankey" [printResults]="printResults">
+                </app-psat-report>
+            </div>
+        </div>
+
+        <div *ngIf="_phastAssessments.length > 0 && printPhastRollup" class="row"
+            [ngClass]="{'print-break-before' : (printPsatRollup && _psatAssessments.length > 0)}">
+            <div class="col-12">
+                <app-phast-rollup-print [settings]="settings" [calculators]="selectedCalcs">
+                </app-phast-rollup-print>
+            </div>
+        </div>
+        <div *ngFor="let item of _phastAssessments" id="{{'assessment_'+item.assessment.id}}"
+            class="assessment-item row">
+            <div class="col-12">
+                <app-phast-report *ngIf="item.assessment.phast" [phast]="item.assessment.phast"
+                    [assessment]="item.assessment" [inRollup]="true" [settings]="item.settings" [printView]="printView"
+                    [printInputSummary]="printInputData" [printResultsData]="printResults"
+                    [printReportGraphs]="printReportGraphs" [printReportSankey]="printReportSankey"
+                    [printEnergyUsed]="printEnergyUsed" [printExecutiveSummary]="printExecutiveSummary">
+                </app-phast-report>
+            </div>
+        </div>
+
+        <div *ngIf="_fsatAssessments.length > 0 && printFsatRollup" class="row print-break-before">
+            <div class="col-12">
+                <!--fsat print--
+                <app-fsat-rollup-print [settings]="settings"></app-fsat-rollup-print>
+            </div>
+        </div>
+        <div class="assessment-item row" *ngFor="let item of _fsatAssessments"
+            id="{{'assessment_'+item.assessment.id}}">
+            <div class="col-12">
+                <app-fsat-report *ngIf="item.assessment.fsat" [fsat]="item.assessment.fsat"
+                    [assessment]="item.assessment" [settings]="item.settings" [inRollup]="true" [printView]="printView"
+                    [printInputData]="printInputData" [printReportGraphs]="printReportGraphs"
+                    [printReportSankey]="printReportSankey" [printResults]="printResults"></app-fsat-report>
+            </div>
+        </div>
+
+        <!-- <div *ngIf="_ssmtAssessments.length > 0 && printSsmtRollup" class="row print-break-before">
+                    <div class="col-12">
+                        <app-ssmt-rollup-print [settings]="settings"></app-ssmt-rollup-print>
+                    </div>
+                </div> --
+        <div class="assessment-item row" *ngFor="let item of _ssmtAssessments"
+            id="{{'assessment_'+item.assessment.id}}">
+            <div class="col-12">
+                <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment" [settings]="item.settings"
+                    [inRollup]="true" [printView]="printView" [printExecutiveSummary]="printExecutiveSummary"
+                    [printEnergySummary]="printEnergySummary" [printLossesSummary]="printLossesSummary"
+                    [printInputData]="printInputData" [printReportGraphs]="printReportGraphs"></app-ssmt-report>
+            </div>
+        </div>
+
+        <div *ngIf="_treasureHuntAssessments.length > 0 && printTreasureHuntRollup" class="row print-break-before">
+            <div class="col-12">
+                <!--treasure hunt print-->
+    <!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> --
+            </div>
+        </div>
+        <div class="assessment-item row" *ngFor="let item of _treasureHuntAssessments"
+            id="{{'assessment_'+item.assessment.id}}">
+            <div class="col-12">
+                <app-treasure-hunt-report *ngIf="item.assessment.treasureHunt" [assessment]="item.assessment"
+                    [settings]="item.settings" [inRollup]="true" [printView]="printView"
+                    [printReportGraphs]="printReportGraphs" [printExecutiveSummary]="printExecutiveSummary"
+                    [printReportOpportunityPayback]="printReportOpportunityPayback"
+                    [printReportOpportunitySummary]="printReportOpportunitySummary">
+                </app-treasure-hunt-report>
+            </div>
+        </div>
+    </div> -->
+
+    <!-- app layout -->
+    <!-- <div *ngIf="!printView"> -->
+    <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
+        <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
+            (selectModification)="updateSummary($event)" [settings]="item.settings">
+        </app-psat-report>
+    </div>
+
+    <div *ngFor="let item of _phastAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
+        <app-phast-report *ngIf="item.assessment.phast" [phast]="item.assessment.phast" [assessment]="item.assessment"
+            [inRollup]="true" [settings]="item.settings">
+        </app-phast-report>
+    </div>
+    <div *ngFor="let item of _fsatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
+        <app-fsat-report *ngIf="item.assessment.fsat" [fsat]="item.assessment.fsat" [assessment]="item.assessment"
+            [inRollup]="true" [settings]="item.settings">
+        </app-fsat-report>
+    </div>
+    <div *ngFor="let item of _ssmtAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
+        <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment" [settings]="item.settings"
+            [inRollup]="true">
+        </app-ssmt-report>
+    </div>
+    <div class="assessment-item" *ngFor="let item of _treasureHuntAssessments"
+        id="{{'assessment_'+item.assessment.id}}">
+        <app-treasure-hunt-report *ngIf="item.assessment.treasureHunt" [assessment]="item.assessment"
+            [settings]="item.settings" [inRollup]="true">
+        </app-treasure-hunt-report>
+    </div>
+    <!-- </div> -->
+    <!-- End .content -->
+<!-- </div> -->

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.html
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.html
@@ -1,7 +1,7 @@
 <!-- <div class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline"
     [ngStyle]="{'height.px': sidebarHeight}" (scroll)="checkActiveAssessment($event)"> -->
-    <!-- print layout -->
-    <!-- <div class="print-container" *ngIf="printView">
+<!-- print layout -->
+<!-- <div class="print-container" *ngIf="printView">
         <div *ngIf="_psatAssessments.length > 0 && printPsatRollup" class="row print-break-before">
             <div class="col-12">
                 <app-psat-rollup-print [settings]="settings"></app-psat-rollup-print>
@@ -71,7 +71,7 @@
         <div *ngIf="_treasureHuntAssessments.length > 0 && printTreasureHuntRollup" class="row print-break-before">
             <div class="col-12">
                 <!--treasure hunt print-->
-    <!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> --
+<!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> --
             </div>
         </div>
         <div class="assessment-item row" *ngFor="let item of _treasureHuntAssessments"
@@ -87,8 +87,8 @@
         </div>
     </div> -->
 
-    <!-- app layout -->
-    <!-- <div *ngIf="!printView"> -->
+<!-- app layout -->
+<div *ngIf="!printView" (scroll)="checkActiveAssessment($event)">
     <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}" class="assessment-item">
         <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
             (selectModification)="updateSummary($event)" [settings]="item.settings">
@@ -116,6 +116,6 @@
             [settings]="item.settings" [inRollup]="true">
         </app-treasure-hunt-report>
     </div>
-    <!-- </div> -->
-    <!-- End .content -->
+</div>
+<!-- End .content -->
 <!-- </div> -->

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.spec.ts
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AssessmentReportsComponent } from './assessment-reports.component';
+
+describe('AssessmentReportsComponent', () => {
+  let component: AssessmentReportsComponent;
+  let fixture: ComponentFixture<AssessmentReportsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AssessmentReportsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AssessmentReportsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.ts
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.ts
@@ -2,9 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { ReportItem } from '../report-rollup-models';
 import { ReportRollupService } from '../report-rollup.service';
-import { Router, Scroll } from '@angular/router';
-import { ViewportScroller } from '@angular/common';
-import { filter } from 'rxjs/operators';
+import { RollupPrintService, RollupPrintOptions } from '../rollup-print.service';
 
 @Component({
   selector: 'app-assessment-reports',
@@ -23,7 +21,11 @@ export class AssessmentReportsComponent implements OnInit {
   psatAssessmentSub: Subscription;
   ssmtAssessmentsSub: Subscription;
   treasureHuntAssesmentsSub: Subscription;
-  constructor(private reportRollupService: ReportRollupService, private router: Router, private viewportScroller: ViewportScroller) { }
+  printView: boolean;
+  printViewSub: Subscription;
+  rollupPrintOptions: RollupPrintOptions;
+  rollupPrintOptionsSub: Subscription;
+  constructor(private reportRollupService: ReportRollupService, private rollupPrintService: RollupPrintService) { }
 
   ngOnInit(): void {
     this.psatAssessmentSub = this.reportRollupService.psatAssessments.subscribe(items => {
@@ -55,20 +57,13 @@ export class AssessmentReportsComponent implements OnInit {
       }
     });
 
-    // this.router.events.pipe(filter(e => e instanceof Scroll)).subscribe((e: any) => {
-    //   console.log(e);
+    this.printViewSub = this.rollupPrintService.showPrintView.subscribe(val => {
+      this.printView = val;
+    });
 
-    //   // this is fix for dynamic generated(loaded..?) content
-    //   setTimeout(() => {
-    //     if (e.position) {
-    //       this.viewportScroller.scrollToPosition(e.position);
-    //     } else if (e.anchor) {
-    //       this.viewportScroller.scrollToAnchor(e.anchor);
-    //     } else {
-    //       this.viewportScroller.scrollToPosition([0, 0]);
-    //     }
-    //   });
-    // });
+    this.rollupPrintOptionsSub = this.rollupPrintService.rollupPrintOptions.subscribe(val => {
+      this.rollupPrintOptions = val;
+    });
   }
 
   ngOnDestroy() {
@@ -77,5 +72,6 @@ export class AssessmentReportsComponent implements OnInit {
     this.psatAssessmentSub.unsubscribe();
     this.ssmtAssessmentsSub.unsubscribe();
     this.treasureHuntAssesmentsSub.unsubscribe();
+    this.printViewSub.unsubscribe();
   }
 }

--- a/src/app/report-rollup/assessment-reports/assessment-reports.component.ts
+++ b/src/app/report-rollup/assessment-reports/assessment-reports.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ReportItem } from '../report-rollup-models';
+import { ReportRollupService } from '../report-rollup.service';
+import { Router, Scroll } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
+import { filter } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-assessment-reports',
+  templateUrl: './assessment-reports.component.html',
+  styleUrls: ['./assessment-reports.component.css']
+})
+export class AssessmentReportsComponent implements OnInit {
+
+  _phastAssessments: Array<ReportItem>;
+  _psatAssessments: Array<ReportItem>;
+  _fsatAssessments: Array<ReportItem>;
+  _ssmtAssessments: Array<ReportItem>;
+  _treasureHuntAssessments: Array<ReportItem>;
+  phastAssessmentsSub: Subscription;
+  fsatAssessmentsSub: Subscription;
+  psatAssessmentSub: Subscription;
+  ssmtAssessmentsSub: Subscription;
+  treasureHuntAssesmentsSub: Subscription;
+  constructor(private reportRollupService: ReportRollupService, private router: Router, private viewportScroller: ViewportScroller) { }
+
+  ngOnInit(): void {
+    this.psatAssessmentSub = this.reportRollupService.psatAssessments.subscribe(items => {
+      if (items) {
+        this._psatAssessments = items;
+      }
+    });
+    this.phastAssessmentsSub = this.reportRollupService.phastAssessments.subscribe(items => {
+      if (items) {
+        this._phastAssessments = items;
+      }
+    });
+
+    this.fsatAssessmentsSub = this.reportRollupService.fsatAssessments.subscribe(items => {
+      if (items) {
+        this._fsatAssessments = items;
+      }
+    });
+
+    this.ssmtAssessmentsSub = this.reportRollupService.ssmtAssessments.subscribe(items => {
+      if (items) {
+        this._ssmtAssessments = items;
+      }
+    });
+
+    this.treasureHuntAssesmentsSub = this.reportRollupService.treasureHuntAssessments.subscribe(items => {
+      if (items) {
+        this._treasureHuntAssessments = items;
+      }
+    });
+
+    // this.router.events.pipe(filter(e => e instanceof Scroll)).subscribe((e: any) => {
+    //   console.log(e);
+
+    //   // this is fix for dynamic generated(loaded..?) content
+    //   setTimeout(() => {
+    //     if (e.position) {
+    //       this.viewportScroller.scrollToPosition(e.position);
+    //     } else if (e.anchor) {
+    //       this.viewportScroller.scrollToAnchor(e.anchor);
+    //     } else {
+    //       this.viewportScroller.scrollToPosition([0, 0]);
+    //     }
+    //   });
+    // });
+  }
+
+  ngOnDestroy() {
+    this.phastAssessmentsSub.unsubscribe();
+    this.fsatAssessmentsSub.unsubscribe();
+    this.psatAssessmentSub.unsubscribe();
+    this.ssmtAssessmentsSub.unsubscribe();
+    this.treasureHuntAssesmentsSub.unsubscribe();
+  }
+}

--- a/src/app/report-rollup/fsat-rollup/fsat-rollup-print/fsat-rollup-print.component.html
+++ b/src/app/report-rollup/fsat-rollup/fsat-rollup-print/fsat-rollup-print.component.html
@@ -5,6 +5,10 @@
             <h3>Fan Assessment Rollup Report</h3>
         </div>
     </div>
+    <!-- <div class="row justify-content-center print-avoid-break" *ngFor="let calculator of calculators">
+        <app-pre-assessment-print [calculator]="calculator" [settings]="settings">
+        </app-pre-assessment-print>
+    </div> -->
     <div class="print-avoid-break">
         <div class="row justify-content-center">
             <div class="col-12 header text-center">

--- a/src/app/report-rollup/fsat-rollup/fsat-rollup-print/fsat-rollup-print.component.ts
+++ b/src/app/report-rollup/fsat-rollup/fsat-rollup-print/fsat-rollup-print.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Settings } from '../../../shared/models/settings';
+import { Calculator } from '../../../shared/models/calculators';
 
 @Component({
   selector: 'app-fsat-rollup-print',
@@ -9,7 +10,9 @@ import { Settings } from '../../../shared/models/settings';
 export class FsatRollupPrintComponent implements OnInit {
   @Input()
   settings: Settings;
-
+  @Input()
+  calculators: Array<Calculator>;
+  
   constructor() { }
 
   ngOnInit() {

--- a/src/app/report-rollup/phast-rollup/phast-rollup-print/phast-rollup-print.component.html
+++ b/src/app/report-rollup/phast-rollup/phast-rollup-print/phast-rollup-print.component.html
@@ -6,44 +6,10 @@
     </div>
   </div>
 
-  <div class="row justify-content-center print-avoid-break" *ngFor="let calculator of calculators; let i = index">
-    <div *ngIf="calculator.preAssessments">
-      <div class="col-12">
-        <div class="row">
-          <div class="col-12 header text-center">
-            <h5>Pre Assessment Summary</h5>
-          </div>
-        </div>
-        <div class="row justify-content-center">
-          <div class="col-12 text-center">
-            Energy Use
-          </div>
-        </div>
-        <div class="row justify-content-center">
-          <div class="col-12 print-rollup-pie-container">
-            <app-pre-assessment-graph [printView]="true" [settings]="settings" [preAssessments]="calculator.preAssessments" [inRollup]="true"
-              [resultType]="'value'"></app-pre-assessment-graph>
-          </div>
-        </div>
-        <div class="row justify-content-center">
-          <div class="col-12 text-center">
-            Energy Cost
-          </div>
-        </div>
-        <div class="row justify-content-center">
-          <div class="col-12 print-rollup-pie-container">
-            <app-pre-assessment-graph [printView]="true" [settings]="settings" [preAssessments]="calculator.preAssessments" [inRollup]="true"
-              [resultType]="'energyCost'"></app-pre-assessment-graph>
-          </div>
-        </div>
-        <div class="row justify-content-center">
-          <div class="col-12">
-            <app-pre-assessment-table [printView]="true" [settings]="settings" [calculator]="calculator"></app-pre-assessment-table>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <!-- <div class="row justify-content-center print-avoid-break" *ngFor="let calculator of calculators">
+    <app-pre-assessment-print [calculator]="calculator" [settings]="settings">
+    </app-pre-assessment-print>
+  </div> -->
 
   <div class="row print-avoid-break">
     <div class="col-12">

--- a/src/app/report-rollup/phast-rollup/phast-rollup-print/phast-rollup-print.component.ts
+++ b/src/app/report-rollup/phast-rollup/phast-rollup-print/phast-rollup-print.component.ts
@@ -16,6 +16,8 @@ export class PhastRollupPrintComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
+    console.log('PRINT PHAST ROLLUP')
+    console.log(this.calculators);
   }
 
 }

--- a/src/app/report-rollup/pre-assessment-print/pre-assessment-print.component.html
+++ b/src/app/report-rollup/pre-assessment-print/pre-assessment-print.component.html
@@ -1,0 +1,37 @@
+<div class="col-12">
+    <div class="row">
+        <div class="col-12 header text-center">
+            <h5>Pre Assessment Summary</h5>
+        </div>
+    </div>
+    <div class="row justify-content-center">
+        <div class="col-12 text-center">
+            Energy Use
+        </div>
+    </div>
+    <div class="row justify-content-center">
+        <div class="col-12 print-rollup-pie-container">
+            <app-pre-assessment-graph [printView]="true" [settings]="settings"
+                [preAssessments]="calculator.preAssessments" [inRollup]="true" [resultType]="'value'">
+            </app-pre-assessment-graph>
+        </div>
+    </div>
+    <div class="row justify-content-center">
+        <div class="col-12 text-center">
+            Energy Cost
+        </div>
+    </div>
+    <div class="row justify-content-center">
+        <div class="col-12 print-rollup-pie-container">
+            <app-pre-assessment-graph [printView]="true" [settings]="settings"
+                [preAssessments]="calculator.preAssessments" [inRollup]="true" [resultType]="'energyCost'">
+            </app-pre-assessment-graph>
+        </div>
+    </div>
+    <div class="row justify-content-center">
+        <div class="col-12">
+            <app-pre-assessment-table [printView]="true" [settings]="settings" [calculator]="calculator">
+            </app-pre-assessment-table>
+        </div>
+    </div>
+</div>

--- a/src/app/report-rollup/pre-assessment-print/pre-assessment-print.component.spec.ts
+++ b/src/app/report-rollup/pre-assessment-print/pre-assessment-print.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PreAssessmentPrintComponent } from './pre-assessment-print.component';
+
+describe('PreAssessmentPrintComponent', () => {
+  let component: PreAssessmentPrintComponent;
+  let fixture: ComponentFixture<PreAssessmentPrintComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PreAssessmentPrintComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PreAssessmentPrintComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/report-rollup/pre-assessment-print/pre-assessment-print.component.ts
+++ b/src/app/report-rollup/pre-assessment-print/pre-assessment-print.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Calculator } from '../../shared/models/calculators';
+import { Settings } from '../../shared/models/settings';
+
+@Component({
+  selector: 'app-pre-assessment-print',
+  templateUrl: './pre-assessment-print.component.html',
+  styleUrls: ['./pre-assessment-print.component.css']
+})
+export class PreAssessmentPrintComponent implements OnInit {
+  @Input()
+  calculator: Calculator;
+  @Input()
+  settings: Settings;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    console.log('INIT!');
+  }
+
+}

--- a/src/app/report-rollup/psat-rollup/psat-rollup-print/psat-rollup-print.component.html
+++ b/src/app/report-rollup/psat-rollup/psat-rollup-print/psat-rollup-print.component.html
@@ -5,6 +5,10 @@
             <h3>Pump Assessment Rollup Report</h3>
         </div>
     </div>
+    <!-- <div class="row justify-content-center print-avoid-break" *ngFor="let calculator of calculators">
+        <app-pre-assessment-print [calculator]="calculator" [settings]="settings">
+        </app-pre-assessment-print>
+    </div> -->
     <div class="print-avoid-break">
         <div class="row justify-content-center">
             <div class="col-12 header text-center">

--- a/src/app/report-rollup/psat-rollup/psat-rollup-print/psat-rollup-print.component.ts
+++ b/src/app/report-rollup/psat-rollup/psat-rollup-print/psat-rollup-print.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Settings } from '../../../shared/models/settings';
+import { Calculator } from '../../../shared/models/calculators';
 
 @Component({
   selector: 'app-psat-rollup-print',
@@ -9,7 +10,8 @@ import { Settings } from '../../../shared/models/settings';
 export class PsatRollupPrintComponent implements OnInit {
   @Input()
   settings: Settings;
-  
+  @Input()
+  calculators: Array<Calculator>;
   constructor() { }
 
   ngOnInit() {

--- a/src/app/report-rollup/report-banner/report-banner.component.css
+++ b/src/app/report-rollup/report-banner/report-banner.component.css
@@ -30,3 +30,8 @@
 @media print {
 
 }
+
+
+.modal-open{
+    z-index: initial !important;
+}

--- a/src/app/report-rollup/report-banner/report-banner.component.html
+++ b/src/app/report-rollup/report-banner/report-banner.component.html
@@ -6,7 +6,7 @@
 			<button class="btn btn-secondary" (click)="showUnitsModal()">Units</button>
 		</div>
 		<div class="btn-group mr-2" role="group">
-			<button class="btn btn-secondary" (click)="print()">Print</button>
+			<button class="btn btn-secondary" (click)="showPrintModal()">Print</button>
 			<!-- <button class="btn btn-secondary" [disabled]="true" (click)="exportToCsv()">Export to CSV</button> -->
 		</div>
 		<div class="btn-group" role="group">
@@ -14,3 +14,5 @@
 		</div>
 	</div>
 </div>
+
+

--- a/src/app/report-rollup/report-banner/report-banner.component.ts
+++ b/src/app/report-rollup/report-banner/report-banner.component.ts
@@ -14,12 +14,10 @@ import { ReportRollupService } from '../report-rollup.service';
 export class ReportBannerComponent implements OnInit {
   // @Output('emitExport')
   // emitExport = new EventEmitter<boolean>();
-  @Output('emitShowUnitModal')
-  emitShowUnitModal = new EventEmitter<boolean>();
 
 
   constructor(private directoryDashboardService: DirectoryDashboardService, private router: Router,
-    private rollupPrintService: RollupPrintService) { }
+    private rollupPrintService: RollupPrintService, private reportRollupService: ReportRollupService) { }
 
   ngOnInit() {
   }
@@ -34,7 +32,7 @@ export class ReportBannerComponent implements OnInit {
   }
 
   showUnitsModal() {
-    this.emitShowUnitModal.emit(true);
+    this.reportRollupService.showSummaryModal.next('unitsModal');
   }
 
 }

--- a/src/app/report-rollup/report-banner/report-banner.component.ts
+++ b/src/app/report-rollup/report-banner/report-banner.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit, EventEmitter, Output } from '@angular/core';
 import { DirectoryDashboardService } from '../../dashboard/directory-dashboard/directory-dashboard.service';
 import { Router } from '@angular/router';
+import { RollupPrintService, RollupPrintOptions } from '../rollup-print.service';
+import { Subscription } from 'rxjs';
+import { WindowRefService } from '../../indexedDb/window-ref.service';
+import { ReportRollupService } from '../report-rollup.service';
 
 @Component({
   selector: 'app-report-banner',
@@ -8,14 +12,14 @@ import { Router } from '@angular/router';
   styleUrls: ['./report-banner.component.css']
 })
 export class ReportBannerComponent implements OnInit {
-  @Output('emitExport')
-  emitExport = new EventEmitter<boolean>();
-  @Output('emitPrint')
-  emitPrint = new EventEmitter<boolean>();
+  // @Output('emitExport')
+  // emitExport = new EventEmitter<boolean>();
   @Output('emitShowUnitModal')
   emitShowUnitModal = new EventEmitter<boolean>();
 
-  constructor(private directoryDashboardService: DirectoryDashboardService, private router: Router) { }
+
+  constructor(private directoryDashboardService: DirectoryDashboardService, private router: Router,
+    private rollupPrintService: RollupPrintService) { }
 
   ngOnInit() {
   }
@@ -25,12 +29,8 @@ export class ReportBannerComponent implements OnInit {
     this.router.navigateByUrl('/directory-dashboard/' + directoryId);
   }
 
-  exportToCsv() {
-    this.emitExport.emit(true);
-  }
-
-  print() {
-    this.emitPrint.emit(true);
+  showPrintModal() {
+    this.rollupPrintService.showPrintOptionsModal.next(true);
   }
 
   showUnitsModal() {

--- a/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.css
+++ b/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.css
@@ -1,0 +1,35 @@
+.phast .modal-dialog,
+.psat .modal-dialog,
+.fsat .modal-dialog,
+.ssmt .modal-dialog{
+    top: 0px;
+    max-width: none;
+    margin: 10px;
+}
+
+.phast .modal-header{
+    background-color: #BF3D00;
+    color: #fff;
+}
+
+.psat .modal-header{
+    background-color: #2980b9;
+    color: #fff;
+}
+
+.fsat .modal-header{
+    background-color: #FFE400;
+    color: black;
+}
+
+.ssmt .modal-header{
+    background-color: #F39C12;
+    color: #fff;
+}
+
+.phast .modal-body,
+.psat .modal-body,
+.fsat .modal-body,
+.ssmt .modal-body{
+    height: 85vh;
+}

--- a/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.html
+++ b/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.html
@@ -14,3 +14,108 @@
     [printSsmtRollup]="rollupPrintOptions.printSsmtRollup" (emitClosePrintMenu)="closePrintModal($event)"
     (emitTogglePrint)="togglePrint($event)" (emitPrint)="setPrintViewThenPrint()">
 </app-print-options-menu>
+
+
+<!--psat rollup modal -->
+<div bsModal #assessmentRollupModal="bs-modal" class="modal fade" tabindex="-1" role="dialog"
+    aria-labelledby="assessmentRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}"
+    [ngClass]="assessmentModalType">
+    <div class="modal-dialog">
+        <div class="modal-content" *ngIf="assessmentModalType != undefined">
+            <div class="modal-header">
+                <!-- <h5>Pump Assessment Rollup</h5> -->
+                {{assessmentModalLabel}}
+                <button class="close" aria-label="Close" (click)="hideAssessmentRollupModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container scroll-item">
+                <app-psat-rollup *ngIf="assessmentModalType == 'psat'" [settings]="settings"
+                    [calculators]="selectedCalculators"></app-psat-rollup>
+                <app-phast-rollup *ngIf="assessmentModalType == 'phast'" [settings]="settings"
+                    [calculators]="selectedCalculators"></app-phast-rollup>
+                <app-fsat-rollup *ngIf="assessmentModalType == 'fsat'" [settings]="settings"
+                    [calculators]="selectedCalculators"></app-fsat-rollup>
+                <app-ssmt-rollup *ngIf="assessmentModalType == 'ssmt'" [settings]="settings"></app-ssmt-rollup>
+                <app-report-rollup-units *ngIf="assessmentModalType == 'unitsModal'" [settings]="settings"
+                    (closeUnitModal)="hideAssessmentRollupModal()">
+                </app-report-rollup-units>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!--phast rollup modal--
+<div bsModal #phastRollupModal="bs-modal" class="phast-modal modal fade phast" tabindex="-1" role="dialog"
+    aria-labelledby="phastRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Process Heating Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hidePhastModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container phast scroll-item">
+                <app-phast-rollup [settings]="settings" [calculators]="selectedPhastCalcs"></app-phast-rollup>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!--fsat rollup modal --
+<div bsModal #fsatRollupModal="bs-modal" class="fsat-modal modal fade fsat" tabindex="-1" role="dialog"
+    aria-labelledby="fsatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Fan Assessment Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hideFsatModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container fsat scroll-item">
+                <app-fsat-rollup [settings]="settings" [calculators]="selectedFsatCalcs"></app-fsat-rollup>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!--ssmt rollup modal --
+<div bsModal #ssmtRollupModal="bs-modal" class="ssmt-modal modal fade ssmt" tabindex="-1" role="dialog"
+    aria-labelledby="ssmtRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Steam Assessment Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hideSsmtModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container ssmt scroll-item">
+                <app-ssmt-rollup [settings]="settings"></app-ssmt-rollup>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+<!--units modal--
+<div bsModal #unitModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="unitModal"
+    aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Report Units</h5>
+                <button class="close" aria-label="Close" (click)="hideUnitModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <app-report-rollup-units *ngIf="settings" [settings]="settings" (closeUnitModal)="hideUnitModal()">
+                </app-report-rollup-units>
+            </div>
+        </div>
+    </div>
+</div>-->

--- a/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.html
+++ b/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.html
@@ -1,0 +1,16 @@
+<app-print-options-menu *ngIf="showPrintMenu" [showRollupReportOptions]="true"
+    [showPsatReportOptions]="showPsatReportOptions" [showFsatReportOptions]="showFsatReportOptions"
+    [showPhastReportOptions]="showPhastReportOptions" [showTHReportOptions]="showTHReportOptions"
+    [showSsmtReportOptions]="showSsmtReportOptions" [selectAll]="rollupPrintOptions.selectAll"
+    [printReportGraphs]="rollupPrintOptions.printReportGraphs"
+    [printReportSankey]="rollupPrintOptions.printReportSankey" [printResults]="rollupPrintOptions.printResults"
+    [printInputData]="rollupPrintOptions.printInputData" [printEnergyUsed]="rollupPrintOptions.printEnergyUsed"
+    [printExecutiveSummary]="rollupPrintOptions.printExecutiveSummary"
+    [printEnergySummary]="rollupPrintOptions.printEnergySummary"
+    [printLossesSummary]="rollupPrintOptions.printLossesSummary" [printPsatRollup]="rollupPrintOptions.printPsatRollup"
+    [printFsatRollup]="rollupPrintOptions.printFsatRollup" [printPhastRollup]="rollupPrintOptions.printPhastRollup"
+    [printReportOpportunityPayback]="rollupPrintOptions.printReportOpportunityPayback"
+    [printReportOpportunitySummary]="rollupPrintOptions.printReportOpportunitySummary"
+    [printSsmtRollup]="rollupPrintOptions.printSsmtRollup" (emitClosePrintMenu)="closePrintModal($event)"
+    (emitTogglePrint)="togglePrint($event)" (emitPrint)="setPrintViewThenPrint()">
+</app-print-options-menu>

--- a/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.spec.ts
+++ b/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReportRollupModalsComponent } from './report-rollup-modals.component';
+
+describe('ReportRollupModalsComponent', () => {
+  let component: ReportRollupModalsComponent;
+  let fixture: ComponentFixture<ReportRollupModalsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ReportRollupModalsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ReportRollupModalsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.ts
+++ b/src/app/report-rollup/report-rollup-modals/report-rollup-modals.component.ts
@@ -1,0 +1,84 @@
+import { Component, OnInit } from '@angular/core';
+import { RollupPrintService, RollupPrintOptions } from '../rollup-print.service';
+import { Subscription } from 'rxjs';
+import { WindowRefService } from '../../indexedDb/window-ref.service';
+import { ReportRollupService } from '../report-rollup.service';
+
+@Component({
+  selector: 'app-report-rollup-modals',
+  templateUrl: './report-rollup-modals.component.html',
+  styleUrls: ['./report-rollup-modals.component.css']
+})
+export class ReportRollupModalsComponent implements OnInit {
+
+  showPrintMenu: boolean = false;
+  rollupPrintOptions: RollupPrintOptions;
+  rollupPrintOptionsSub: Subscription;
+  showPsatReportOptions: boolean;
+  showFsatReportOptions: boolean;
+  showSsmtReportOptions: boolean;
+  showPhastReportOptions: boolean;
+  showTHReportOptions: boolean;
+  showPrintOptionsModalSub: Subscription;
+  constructor(private rollupPrintService: RollupPrintService, private windowRefService: WindowRefService, private reportRollupService: ReportRollupService) { }
+
+  ngOnInit(): void {
+    this.rollupPrintOptionsSub = this.rollupPrintService.rollupPrintOptions.subscribe(val => {
+      this.rollupPrintOptions = val;
+    });
+
+    this.showPrintOptionsModalSub = this.rollupPrintService.showPrintOptionsModal.subscribe(val => {
+      console.log(this.showPrintMenu);
+      console.log(val);
+      if (val == true) {
+        this.showPrintModal();
+      }
+    });
+  }
+
+  ngOnDestroy(){
+    this.rollupPrintOptionsSub.unsubscribe();
+    this.showPrintOptionsModalSub.unsubscribe();
+  }
+
+  showPrintModal() {
+    this.showPsatReportOptions = this.reportRollupService.numPsats != 0;
+    this.showFsatReportOptions = this.reportRollupService.numFsats != 0;
+    this.showSsmtReportOptions = this.reportRollupService.numSsmt != 0;
+    this.showPhastReportOptions = this.reportRollupService.numPhasts != 0;
+    this.showTHReportOptions = this.reportRollupService.numTreasureHunt != 0;
+    this.showPrintMenu = true;
+    console.log(this.showPrintMenu);
+  }
+
+  closePrintModal() {
+    this.showPrintMenu = false;
+    this.rollupPrintService.showPrintOptionsModal.next(false);
+  }
+
+  togglePrint(section: string): void {
+    this.rollupPrintService.toggleSection(section);
+  }
+
+  setPrintViewThenPrint() {
+    this.rollupPrintService.showPrintView.next(true);
+    let tmpPrintBuildTime = 100;
+    if (this.reportRollupService.numSsmt > 0) {
+      tmpPrintBuildTime += (500 * this.reportRollupService.numSsmt);
+    }
+    setTimeout(() => {
+      this.print();
+    }, tmpPrintBuildTime);
+  }
+
+  print() {
+    this.showPrintMenu = false;
+    //set timeout for delay to print call. May want to do this differently later but for now should work
+    setTimeout(() => {
+      let win = this.windowRefService.nativeWindow;
+      win.print();
+      //after printing hide content again
+      this.rollupPrintService.showPrintView.next(false);
+    }, 5000);
+  }
+}

--- a/src/app/report-rollup/report-rollup.component.css
+++ b/src/app/report-rollup/report-rollup.component.css
@@ -149,43 +149,6 @@
     }
 }
 
-.phast-modal .modal-dialog,
-.psat-modal .modal-dialog,
-.fsat-modal .modal-dialog,
-.ssmt-modal .modal-dialog{
-    top: 0px;
-    max-width: none;
-    margin: 10px;
-}
-
-.phast-modal .modal-header{
-    background-color: #BF3D00;
-    color: #fff;
-}
-
-.psat-modal .modal-header{
-    background-color: #2980b9;
-    color: #fff;
-}
-
-.fsat-modal .modal-header{
-    background-color: #FFE400;
-    color: black;
-}
-
-.ssmt-modal .modal-header{
-    background-color: #F39C12;
-    color: #fff;
-}
-
-.phast-modal .modal-body,
-.psat-modal .modal-body,
-.fsat-modal .modal-body,
-.ssmt-modal .modal-body{
-    height: 85vh;
-}
-
-
 .assessment-reports{
     padding-left: 50px;
     padding-right: 50px;

--- a/src/app/report-rollup/report-rollup.component.html
+++ b/src/app/report-rollup/report-rollup.component.html
@@ -11,33 +11,21 @@
     <p class="report-notes">{{reportNotes}}</p>
 </div>
 
-<div class="row sticky-top no-gutters" id="reportHeader" *ngIf="printView && settings">
+<!-- <div class="row sticky-top no-gutters" id="reportHeader" *ngIf="printView && settings">
     <div class="col-12">
         <div class="report-header hide-print">
             <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()"
                 (emitPrint)="showPrintModal()" (emitShowUnitModal)="showUnitModal()">
             </app-report-banner>
-            <app-report-summary id="reportSummary" [settings]="settings" [numPhasts]="numPhasts" [numPsats]="numPsats"
-                [numFsats]="numFsats" [numTreasureHunt]="numTreasureHunt" (showPhastModal)="showPhastModal()"
+            <app-report-summary id="reportSummary" [settings]="settings" (showPhastModal)="showPhastModal()"
                 (showPsatModal)="showPsatModal();" (hideSummary)="setSidebarHeight()" (showFsatModal)="showFsatModal()">
             </app-report-summary>
         </div>
     </div>
-</div>
+</div> -->
 <!--END PRINT-->
 
 <div *ngIf="settings && !gatheringAssessments">
-
-    <div class="report-cover" *ngIf="!printView">
-        <img src="assets/images/DOE-banner-color.png" class="doe-logo">
-
-        <div class="report-title">
-            <h4>Efficiency Report:</h4>
-            <h5>{{createdDate| date:'medium'}}</h5>
-        </div>
-
-        <p class="report-notes">{{reportNotes}}</p>
-    </div>
     <div #reportHeader class="row sticky-top no-gutters" id="reportHeader" *ngIf="!printView">
         <div class="col-12">
             <div class="report-header hide-print">
@@ -46,160 +34,142 @@
                     <!-- <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()" (emitPrint)="setPrintViewThenPrint()"
                     (emitShowUnitModal)="showUnitModal()"> -->
                 </app-report-banner>
-                <app-report-summary id="reportSummary" [settings]="settings" [numPhasts]="numPhasts"
-                    [numFsats]="numFsats" [numPsats]="numPsats" [numTreasureHunt]="numTreasureHunt" [numSsmt]="numSsmt"
-                    (showPhastModal)="showPhastModal()" (showPsatModal)="showPsatModal()"
-                    (hideSummary)="setSidebarHeight()" (showFsatModal)="showFsatModal()"
-                    (showSsmtModal)="showSsmtModal()"></app-report-summary>
+                <app-report-summary id="reportSummary" [settings]="settings" (showPhastModal)="showPhastModal()"
+                    (showPsatModal)="showPsatModal()" (hideSummary)="setSidebarHeight()"
+                    (showFsatModal)="showFsatModal()" (showSsmtModal)="showSsmtModal()"></app-report-summary>
             </div>
         </div>
     </div>
     <!-- End .report-header -->
-
     <div class="d-flex">
-
         <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight"></app-sidebar>
-        <!-- End .sidebar -->
-
         <div #assessmentReportsDiv class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline">
             <router-outlet></router-outlet>
         </div>
-        <!-- End .report-container -->
     </div>
+</div>
 
-    <div *ngIf="!assessmentsGathered"
-        class="gathering-assessments d-flex justify-content-center align-items-center skyline">
-        <div class="main-content">
-            <div class="spinner text-center">
-                <div class="bounce1"></div>
-                <div class="bounce2"></div>
-                <div class="bounce3"></div>
-            </div>
-            <h1 *ngIf="gatheringAssessments">Gathering Assessments</h1>
-            <h1 *ngIf="!gatheringAssessments">Calculating Results</h1>
+<div *ngIf="!assessmentsGathered"
+    class="gathering-assessments d-flex justify-content-center align-items-center skyline">
+    <div class="main-content">
+        <div class="spinner text-center">
+            <div class="bounce1"></div>
+            <div class="bounce2"></div>
+            <div class="bounce3"></div>
         </div>
+        <h1 *ngIf="gatheringAssessments">Gathering Assessments</h1>
+        <h1 *ngIf="!gatheringAssessments">Calculating Results</h1>
     </div>
+</div>
 
-    <div class="print-notification hide-print" *ngIf="printView">
-        <div class="col-12 mx-auto">
-            <div class="print-div row justify-content-center align-items-center">
-                <div class="print-col">
-                    <h4>Building Print View</h4>
-                    <h5>One Moment Please</h5>
-                    <span class="fa fa-print"></span>
-                    <div class="spinner">
-                        <div class="bounce1"></div>
-                        <div class="bounce2"></div>
-                        <div class="bounce3"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!--psat rollup modal -->
-    <div bsModal #psatRollupModal="bs-modal" class="psat-modal modal fade psat" tabindex="-1" role="dialog"
-        aria-labelledby="psatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5>Pump assessment Rollup</h5>
-                    <button class="close" aria-label="Close" (click)="hidePsatModal()">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body panel-container psat scroll-item">
-                    <app-psat-rollup [settings]="settings" [calculators]="selectedPsatCalcs"></app-psat-rollup>
+<div class="print-notification hide-print" *ngIf="printView">
+    <div class="col-12 mx-auto">
+        <div class="print-div row justify-content-center align-items-center">
+            <div class="print-col">
+                <h4>Building Print View</h4>
+                <h5>One Moment Please</h5>
+                <span class="fa fa-print"></span>
+                <div class="spinner">
+                    <div class="bounce1"></div>
+                    <div class="bounce2"></div>
+                    <div class="bounce3"></div>
                 </div>
             </div>
         </div>
     </div>
+</div>
 
-    <!--phast rollup modal-->
-    <div bsModal #phastRollupModal="bs-modal" class="phast-modal modal fade phast" tabindex="-1" role="dialog"
-        aria-labelledby="phastRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}"
-        *ngIf="assessmentsGathered">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5>Process Heating Rollup</h5>
-                    <button class="close" aria-label="Close" (click)="hidePhastModal()">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body panel-container phast scroll-item">
-                    <app-phast-rollup [settings]="settings" [calculators]="selectedPhastCalcs"></app-phast-rollup>
-                </div>
+<app-report-rollup-modals></app-report-rollup-modals>
+
+<!--psat rollup modal -->
+<div bsModal #psatRollupModal="bs-modal" class="psat-modal modal fade psat" tabindex="-1" role="dialog"
+    aria-labelledby="psatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Pump assessment Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hidePsatModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container psat scroll-item">
+                <app-psat-rollup [settings]="settings" [calculators]="selectedPsatCalcs"></app-psat-rollup>
             </div>
         </div>
     </div>
+</div>
 
-    <!--fsat rollup modal -->
-    <div bsModal #fsatRollupModal="bs-modal" class="fsat-modal modal fade fsat" tabindex="-1" role="dialog"
-        aria-labelledby="fsatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5>Fan Assessment Rollup</h5>
-                    <button class="close" aria-label="Close" (click)="hideFsatModal()">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body panel-container fsat scroll-item">
-                    <app-fsat-rollup [settings]="settings" [calculators]="selectedFsatCalcs"></app-fsat-rollup>
-                </div>
+<!--phast rollup modal-->
+<div bsModal #phastRollupModal="bs-modal" class="phast-modal modal fade phast" tabindex="-1" role="dialog"
+    aria-labelledby="phastRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Process Heating Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hidePhastModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container phast scroll-item">
+                <app-phast-rollup [settings]="settings" [calculators]="selectedPhastCalcs"></app-phast-rollup>
             </div>
         </div>
     </div>
+</div>
 
-    <!--ssmt rollup modal -->
-    <div bsModal #ssmtRollupModal="bs-modal" class="ssmt-modal modal fade ssmt" tabindex="-1" role="dialog"
-        aria-labelledby="ssmtRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5>Steam Assessment Rollup</h5>
-                    <button class="close" aria-label="Close" (click)="hideSsmtModal()">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body panel-container ssmt scroll-item">
-                    <app-ssmt-rollup [settings]="settings"></app-ssmt-rollup>
-                </div>
+<!--fsat rollup modal -->
+<div bsModal #fsatRollupModal="bs-modal" class="fsat-modal modal fade fsat" tabindex="-1" role="dialog"
+    aria-labelledby="fsatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Fan Assessment Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hideFsatModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container fsat scroll-item">
+                <app-fsat-rollup [settings]="settings" [calculators]="selectedFsatCalcs"></app-fsat-rollup>
             </div>
         </div>
     </div>
+</div>
 
-
-
-    <!--units modal-->
-    <div bsModal #unitModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="unitModal"
-        aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5>Report Units</h5>
-                    <button class="close" aria-label="Close" (click)="hideUnitModal()">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <app-report-rollup-units *ngIf="settings" [settings]="settings" (closeUnitModal)="hideUnitModal()">
-                    </app-report-rollup-units>
-                </div>
+<!--ssmt rollup modal -->
+<div bsModal #ssmtRollupModal="bs-modal" class="ssmt-modal modal fade ssmt" tabindex="-1" role="dialog"
+    aria-labelledby="ssmtRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Steam Assessment Rollup</h5>
+                <button class="close" aria-label="Close" (click)="hideSsmtModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body panel-container ssmt scroll-item">
+                <app-ssmt-rollup [settings]="settings"></app-ssmt-rollup>
             </div>
         </div>
     </div>
+</div>
 
 
-    <app-print-options-menu *ngIf="showPrintMenu" [showRollupReportOptions]="showRollupReportOptions"
-        [showPsatReportOptions]="showPsatReportOptions" [showFsatReportOptions]="showFsatReportOptions"
-        [showPhastReportOptions]="showPhastReportOptions" [showTHReportOptions]="showTreasureHuntReportOptions"
-        [showSsmtReportOptions]="showSsmtReportOptions" [selectAll]="selectAll" [printReportGraphs]="printReportGraphs"
-        [printReportSankey]="printReportSankey" [printResults]="printResults" [printInputData]="printInputData"
-        [printEnergyUsed]="printEnergyUsed" [printExecutiveSummary]="printExecutiveSummary"
-        [printEnergySummary]="printEnergySummary" [printLossesSummary]="printLossesSummary"
-        [printPsatRollup]="printPsatRollup" [printFsatRollup]="printFsatRollup" [printPhastRollup]="printPhastRollup"
-        (emitClosePrintModal)="closePrintModal($event)" (emitTogglePrint)="togglePrint($event)"
-        (emitPrint)="setPrintViewThenPrint()">
-    </app-print-options-menu>
+
+<!--units modal-->
+<div bsModal #unitModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="unitModal"
+    aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5>Report Units</h5>
+                <button class="close" aria-label="Close" (click)="hideUnitModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <app-report-rollup-units *ngIf="settings" [settings]="settings" (closeUnitModal)="hideUnitModal()">
+                </app-report-rollup-units>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/report-rollup/report-rollup.component.html
+++ b/src/app/report-rollup/report-rollup.component.html
@@ -11,7 +11,7 @@
     <p class="report-notes">{{reportNotes}}</p>
 </div>
 
-<div class="row sticky-top" id="reportHeader" *ngIf="printView && settings">
+<div class="row sticky-top no-gutters" id="reportHeader" *ngIf="printView && settings">
     <div class="col-12">
         <div class="report-header hide-print">
             <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()"
@@ -38,7 +38,7 @@
 
         <p class="report-notes">{{reportNotes}}</p>
     </div>
-    <div #reportHeader class="row sticky-top" id="reportHeader" *ngIf="!printView">
+    <div #reportHeader class="row sticky-top no-gutters" id="reportHeader" *ngIf="!printView">
         <div class="col-12">
             <div class="report-header hide-print">
                 <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()"
@@ -58,217 +58,12 @@
 
     <div class="d-flex">
 
-        <div class="sidebar hide-print scroll-item" id="sidebar"
-            [ngStyle]="{'height.px': sidebarHeight, 'top.px':bannerHeight}"
-            [ngClass]="{'set-width': !sidebarCollapsed}">
-            <ul id="sidebar-list">
-                <li class="collapse-option">
-                    <div class="d-flex align-items-center" (click)="collapseSidebar()">
-                        <div class="p-1 d-flex text-center">
-                            <span *ngIf="!sidebarCollapsed" class="fa fa-chevron-left"></span>
-                            <span *ngIf="sidebarCollapsed" class="fa fa-chevron-right pr-2 pl-2"></span>
-                        </div>
-                        <div class="p-0" [ngClass]="{'collapse': sidebarCollapsed}">
-                            Collapse Sidebar
-                        </div>
-                    </div>
-                </li>
-                <li *ngFor="let item of _psatAssessments"
-                    [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
-                    <div class="d-flex align-items-center psat">
-                        <span class="p-1 d-flex align-items-center justify-content-center icon-image">
-                            <img class="icon" src="assets/images/ico-psat-diagram.png">
-                        </span>
-                        <span class="p-1">
-                            <a class="click-link" href="#{{'assessment_'+item.assessment.id}}"
-                                (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
-                        </span>
-                    </div>
-                </li>
-                <li *ngFor="let item of _phastAssessments"
-                    [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
-                    <div class="d-flex align-items-center phast">
-                        <span class="p-1 d-flex align-items-center justify-content-center icon-image">
-                            <img class="icon" src="assets/images/ico-phast-diagram.png">
-                        </span>
-                        <span class="p-1">
-                            <a class="click-link" href="#{{'assessment_'+item.assessment.id}}"
-                                (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
-                        </span>
-                    </div>
-                </li>
-                <li *ngFor="let item of _fsatAssessments"
-                    [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
-                    <div class="d-flex align-items-center fsat">
-                        <span class="p-1 d-flex align-items-center justify-content-center icon-image">
-                            <img class="icon" src="assets/images/ico-fsat-diagram.png">
-                        </span>
-                        <span class="p-1">
-                            <a class="click-link" href="#{{'assessment_'+item.assessment.id}}"
-                                (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
-                        </span>
-                    </div>
-                </li>
-                <li *ngFor="let item of _ssmtAssessments"
-                    [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
-                    <div class="d-flex align-items-center ssmt">
-                        <span class="p-1 d-flex align-items-center justify-content-center icon-image">
-                            <img class="icon" src="assets/images/ico-ssmt-diagram.png">
-                        </span>
-                        <span class="p-1">
-                            <a class="click-link" href="#{{'assessment_'+item.assessment.id}}"
-                                (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
-                        </span>
-                    </div>
-                </li>
-                <li *ngFor="let item of _treasureHuntAssessments"
-                    [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
-                    <div class="d-flex align-items-center ssmt">
-                        <span class="p-1 d-flex align-items-center justify-content-center icon-image">
-                            <img class="icon" src="assets/images/treasure-hunt.png">
-                        </span>
-                        <span class="p-1">
-                            <a class="click-link" href="#{{'assessment_'+item.assessment.id}}"
-                                (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
-                        </span>
-                    </div>
-                </li>
-            </ul>
-        </div>
+        <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight"></app-sidebar>
         <!-- End .sidebar -->
 
-
         <div class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline"
-            [ngStyle]="{'height.px': sidebarHeight}" (scroll)="checkActiveAssessment($event)">
-            <!-- print layout -->
-            <div class="print-container" *ngIf="printView">
-                <div *ngIf="_psatAssessments.length > 0 && printPsatRollup" class="row print-break-before">
-                    <div class="col-12">
-                        <app-psat-rollup-print [settings]="settings"></app-psat-rollup-print>
-                    </div>
-                </div>
-                <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}"
-                    class="assessment-item row">
-                    <div class="col-12">
-                        <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
-                            [printView]="printView" (selectModification)="updateSummary($event)"
-                            [settings]="item.settings" [printInputData]="printInputData"
-                            [printReportGraphs]="printReportGraphs" [printReportSankey]="printReportSankey"
-                            [printResults]="printResults">
-                        </app-psat-report>
-                    </div>
-                </div>
-
-                <div *ngIf="_phastAssessments.length > 0 && printPhastRollup" class="row"
-                    [ngClass]="{'print-break-before' : (printPsatRollup && _psatAssessments.length > 0)}">
-                    <div class="col-12">
-                        <app-phast-rollup-print [settings]="settings" [calculators]="selectedCalcs">
-                        </app-phast-rollup-print>
-                    </div>
-                </div>
-                <div *ngFor="let item of _phastAssessments" id="{{'assessment_'+item.assessment.id}}"
-                    class="assessment-item row">
-                    <div class="col-12">
-                        <app-phast-report *ngIf="item.assessment.phast" [phast]="item.assessment.phast"
-                            [assessment]="item.assessment" [inRollup]="true" [settings]="item.settings"
-                            [printView]="printView" [printInputSummary]="printInputData"
-                            [printResultsData]="printResults" [printReportGraphs]="printReportGraphs"
-                            [printReportSankey]="printReportSankey" [printEnergyUsed]="printEnergyUsed"
-                            [printExecutiveSummary]="printExecutiveSummary">
-                        </app-phast-report>
-                    </div>
-                </div>
-
-                <div *ngIf="_fsatAssessments.length > 0 && printFsatRollup" class="row print-break-before">
-                    <div class="col-12">
-                        <!--fsat print-->
-                        <app-fsat-rollup-print [settings]="settings"></app-fsat-rollup-print>
-                    </div>
-                </div>
-                <div class="assessment-item row" *ngFor="let item of _fsatAssessments"
-                    id="{{'assessment_'+item.assessment.id}}">
-                    <div class="col-12">
-                        <app-fsat-report *ngIf="item.assessment.fsat" [fsat]="item.assessment.fsat"
-                            [assessment]="item.assessment" [settings]="item.settings" [inRollup]="true"
-                            [printView]="printView" [printInputData]="printInputData"
-                            [printReportGraphs]="printReportGraphs" [printReportSankey]="printReportSankey"
-                            [printResults]="printResults"></app-fsat-report>
-                    </div>
-                </div>
-
-                <!-- <div *ngIf="_ssmtAssessments.length > 0 && printSsmtRollup" class="row print-break-before">
-                    <div class="col-12">
-                        <app-ssmt-rollup-print [settings]="settings"></app-ssmt-rollup-print>
-                    </div>
-                </div> -->
-                <div class="assessment-item row" *ngFor="let item of _ssmtAssessments"
-                    id="{{'assessment_'+item.assessment.id}}">
-                    <div class="col-12">
-                        <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment"
-                            [settings]="item.settings" [inRollup]="true" [printView]="printView"
-                            [printExecutiveSummary]="printExecutiveSummary" [printEnergySummary]="printEnergySummary"
-                            [printLossesSummary]="printLossesSummary" [printInputData]="printInputData"
-                            [printReportGraphs]="printReportGraphs"></app-ssmt-report>
-                    </div>
-                </div>
-
-                <div *ngIf="_treasureHuntAssessments.length > 0 && printTreasureHuntRollup"
-                    class="row print-break-before">
-                    <div class="col-12">
-                        <!--treasure hunt print-->
-                        <!-- <app-treasure-hunt-rollup-print [settings]="settings"></app-treasure-hunt-rollup-print> -->
-                    </div>
-                </div>
-                <div class="assessment-item row" *ngFor="let item of _treasureHuntAssessments"
-                    id="{{'assessment_'+item.assessment.id}}">
-                    <div class="col-12">
-                        <app-treasure-hunt-report *ngIf="item.assessment.treasureHunt" [assessment]="item.assessment"
-                            [settings]="item.settings" [inRollup]="true" [printView]="printView"
-                            [printReportGraphs]="printReportGraphs" [printExecutiveSummary]="printExecutiveSummary"
-                            [printReportOpportunityPayback]="printReportOpportunityPayback"
-                            [printReportOpportunitySummary]="printReportOpportunitySummary">
-                        </app-treasure-hunt-report>
-                    </div>
-                </div>
-            </div>
-
-            <!-- app layout -->
-            <div>
-                <div *ngIf="!printView">
-                    <div *ngFor="let item of _psatAssessments" id="{{'assessment_'+item.assessment.id}}"
-                        class="assessment-item">
-                        <app-psat-report *ngIf="item.assessment.psat" [assessment]="item.assessment" [inRollup]="true"
-                            (selectModification)="updateSummary($event)" [settings]="item.settings">
-                        </app-psat-report>
-                    </div>
-
-                    <div *ngFor="let item of _phastAssessments" id="{{'assessment_'+item.assessment.id}}"
-                        class="assessment-item">
-                        <app-phast-report *ngIf="item.assessment.phast" [phast]="item.assessment.phast"
-                            [assessment]="item.assessment" [inRollup]="true" [settings]="item.settings">
-                        </app-phast-report>
-                    </div>
-                    <div *ngFor="let item of _fsatAssessments" id="{{'assessment_'+item.assessment.id}}"
-                        class="assessment-item">
-                        <app-fsat-report *ngIf="item.assessment.fsat" [fsat]="item.assessment.fsat"
-                            [assessment]="item.assessment" [inRollup]="true" [settings]="item.settings">
-                        </app-fsat-report>
-                    </div>
-                    <div *ngFor="let item of _ssmtAssessments" id="{{'assessment_'+item.assessment.id}}"
-                        class="assessment-item">
-                        <app-ssmt-report *ngIf="item.assessment.ssmt" [assessment]="item.assessment"
-                            [settings]="item.settings" [inRollup]="true">
-                        </app-ssmt-report>
-                    </div>
-                    <div class="assessment-item" *ngFor="let item of _treasureHuntAssessments"
-                        id="{{'assessment_'+item.assessment.id}}">
-                        <app-treasure-hunt-report *ngIf="item.assessment.treasureHunt" [assessment]="item.assessment"
-                            [settings]="item.settings" [inRollup]="true">
-                        </app-treasure-hunt-report>
-                    </div>
-                </div>
-            </div>
-            <!-- End .content -->
+            (scroll)="checkActiveAssessment($event)">
+            <router-outlet></router-outlet>
         </div>
         <!-- End .report-container -->
     </div>

--- a/src/app/report-rollup/report-rollup.component.html
+++ b/src/app/report-rollup/report-rollup.component.html
@@ -58,7 +58,7 @@
 
     <div class="d-flex">
 
-        <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight" [focusedAssessment]="focusedAssessment"></app-sidebar>
+        <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight"></app-sidebar>
         <!-- End .sidebar -->
 
         <div #assessmentReportsDiv class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline">

--- a/src/app/report-rollup/report-rollup.component.html
+++ b/src/app/report-rollup/report-rollup.component.html
@@ -1,4 +1,4 @@
-<!--PRINT-->
+<!--PRINT TITLE PAGE-->
 <div class="report-cover" *ngIf="printView && settings">
     <img src="assets/images/DOE-banner-color.png" class="doe-logo">
 
@@ -10,37 +10,21 @@
 
     <p class="report-notes">{{reportNotes}}</p>
 </div>
-
-<!-- <div class="row sticky-top no-gutters" id="reportHeader" *ngIf="printView && settings">
-    <div class="col-12">
-        <div class="report-header hide-print">
-            <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()"
-                (emitPrint)="showPrintModal()" (emitShowUnitModal)="showUnitModal()">
-            </app-report-banner>
-            <app-report-summary id="reportSummary" [settings]="settings" (showPhastModal)="showPhastModal()"
-                (showPsatModal)="showPsatModal();" (hideSummary)="setSidebarHeight()" (showFsatModal)="showFsatModal()">
-            </app-report-summary>
-        </div>
-    </div>
-</div> -->
 <!--END PRINT-->
 
+<!--CONTENT-->
 <div *ngIf="settings && !gatheringAssessments">
+    <!--TOP BANNER (NOT PRINT)-->
     <div #reportHeader class="row sticky-top no-gutters" id="reportHeader" *ngIf="!printView">
         <div class="col-12">
             <div class="report-header hide-print">
-                <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()"
-                    (emitPrint)="showPrintModal()" (emitShowUnitModal)="showUnitModal()">
-                    <!-- <app-report-banner (emitCloseReport)="closeReport()" (emitExport)="exportToCsv()" (emitPrint)="setPrintViewThenPrint()"
-                    (emitShowUnitModal)="showUnitModal()"> -->
-                </app-report-banner>
-                <app-report-summary id="reportSummary" [settings]="settings" (showPhastModal)="showPhastModal()"
-                    (showPsatModal)="showPsatModal()" (hideSummary)="setSidebarHeight()"
-                    (showFsatModal)="showFsatModal()" (showSsmtModal)="showSsmtModal()"></app-report-summary>
+                <app-report-banner></app-report-banner>
+                <app-report-summary id="reportSummary" [settings]="settings" (hideSummary)="setSidebarHeight()">
+                </app-report-summary>
             </div>
         </div>
     </div>
-    <!-- End .report-header -->
+    <!-- SIDEBAR AND REPORTS -->
     <div class="d-flex">
         <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight"></app-sidebar>
         <div #assessmentReportsDiv class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline">
@@ -49,6 +33,7 @@
     </div>
 </div>
 
+<!--GATHERING ASSESSMENTS-->
 <div *ngIf="!assessmentsGathered"
     class="gathering-assessments d-flex justify-content-center align-items-center skyline">
     <div class="main-content">
@@ -62,6 +47,7 @@
     </div>
 </div>
 
+<!--BUILDING PRINT VIEW-->
 <div class="print-notification hide-print" *ngIf="printView">
     <div class="col-12 mx-auto">
         <div class="print-div row justify-content-center align-items-center">
@@ -79,97 +65,5 @@
     </div>
 </div>
 
-<app-report-rollup-modals></app-report-rollup-modals>
-
-<!--psat rollup modal -->
-<div bsModal #psatRollupModal="bs-modal" class="psat-modal modal fade psat" tabindex="-1" role="dialog"
-    aria-labelledby="psatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5>Pump assessment Rollup</h5>
-                <button class="close" aria-label="Close" (click)="hidePsatModal()">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body panel-container psat scroll-item">
-                <app-psat-rollup [settings]="settings" [calculators]="selectedPsatCalcs"></app-psat-rollup>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!--phast rollup modal-->
-<div bsModal #phastRollupModal="bs-modal" class="phast-modal modal fade phast" tabindex="-1" role="dialog"
-    aria-labelledby="phastRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5>Process Heating Rollup</h5>
-                <button class="close" aria-label="Close" (click)="hidePhastModal()">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body panel-container phast scroll-item">
-                <app-phast-rollup [settings]="settings" [calculators]="selectedPhastCalcs"></app-phast-rollup>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!--fsat rollup modal -->
-<div bsModal #fsatRollupModal="bs-modal" class="fsat-modal modal fade fsat" tabindex="-1" role="dialog"
-    aria-labelledby="fsatRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5>Fan Assessment Rollup</h5>
-                <button class="close" aria-label="Close" (click)="hideFsatModal()">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body panel-container fsat scroll-item">
-                <app-fsat-rollup [settings]="settings" [calculators]="selectedFsatCalcs"></app-fsat-rollup>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!--ssmt rollup modal -->
-<div bsModal #ssmtRollupModal="bs-modal" class="ssmt-modal modal fade ssmt" tabindex="-1" role="dialog"
-    aria-labelledby="ssmtRollupModal" aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5>Steam Assessment Rollup</h5>
-                <button class="close" aria-label="Close" (click)="hideSsmtModal()">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body panel-container ssmt scroll-item">
-                <app-ssmt-rollup [settings]="settings"></app-ssmt-rollup>
-            </div>
-        </div>
-    </div>
-</div>
-
-
-
-<!--units modal-->
-<div bsModal #unitModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="unitModal"
-    aria-hidden="true" [config]="{backdrop: 'fixed'}" *ngIf="assessmentsGathered">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5>Report Units</h5>
-                <button class="close" aria-label="Close" (click)="hideUnitModal()">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <app-report-rollup-units *ngIf="settings" [settings]="settings" (closeUnitModal)="hideUnitModal()">
-                </app-report-rollup-units>
-            </div>
-        </div>
-    </div>
-</div>
+<!--MODALS-->
+<app-report-rollup-modals [settings]="settings"></app-report-rollup-modals>

--- a/src/app/report-rollup/report-rollup.component.html
+++ b/src/app/report-rollup/report-rollup.component.html
@@ -58,11 +58,10 @@
 
     <div class="d-flex">
 
-        <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight"></app-sidebar>
+        <app-sidebar [sidebarHeight]="sidebarHeight" [bannerHeight]="bannerHeight" [focusedAssessment]="focusedAssessment"></app-sidebar>
         <!-- End .sidebar -->
 
-        <div class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline"
-            (scroll)="checkActiveAssessment($event)">
+        <div #assessmentReportsDiv class="assessment-padding d-flex flex-column scroll-item print-height w-100 skyline">
             <router-outlet></router-outlet>
         </div>
         <!-- End .report-container -->

--- a/src/app/report-rollup/report-rollup.component.ts
+++ b/src/app/report-rollup/report-rollup.component.ts
@@ -3,7 +3,6 @@ import { Assessment } from '../shared/models/assessment';
 import { ReportRollupService } from './report-rollup.service';
 import { WindowRefService } from '../indexedDb/window-ref.service';
 import { Settings } from '../shared/models/settings';
-import { ModalDirective } from 'ngx-bootstrap';
 import { Calculator } from '../shared/models/calculators';
 import { Subscription } from 'rxjs';
 import { SettingsDbService } from '../indexedDb/settings-db.service';
@@ -19,44 +18,21 @@ import { RollupPrintService } from './rollup-print.service';
 })
 export class ReportRollupComponent implements OnInit {
 
-
-
-  @Output('emitCloseReport')
-  emitCloseReport = new EventEmitter<boolean>();
-  @ViewChild('reportTemplate', { static: false }) reportTemplate: TemplateRef<any>;
   _reportAssessments: Array<ReportItem>;
   _phastAssessments: Array<ReportItem>;
   _psatAssessments: Array<ReportItem>;
   _fsatAssessments: Array<ReportItem>;
   _ssmtAssessments: Array<ReportItem>;
   _treasureHuntAssessments: Array<ReportItem>;
-  // focusedAssessment: Assessment;
-  //debug
-  selectedPhastCalcs: Array<Calculator>;
-  selectedPsatCalcs: Array<Calculator>;
-  selectedFsatCalcs: Array<Calculator>;
   bannerHeight: number;
   assessmentsGathered: boolean = false;
   createdDate: Date;
   settings: Settings;
-  @ViewChild('psatRollupModal', { static: false }) public psatRollupModal: ModalDirective;
-  @ViewChild('unitModal', { static: false }) public unitModal: ModalDirective;
-  @ViewChild('phastRollupModal', { static: false }) public phastRollupModal: ModalDirective;
-  @ViewChild('fsatRollupModal', { static: false }) public fsatRollupModal: ModalDirective;
-  @ViewChild('ssmtRollupModal', { static: false }) public ssmtRollupModal: ModalDirective;
 
   @ViewChild('reportHeader', { static: false }) reportHeader: ElementRef;
   @ViewChild('assessmentReportsDiv', { static: false }) assessmentReportsDiv: ElementRef;
-  // @ViewChild('printMenuModal') public printMenuModal: ModalDirective;
-
-  // numPhasts: number = 0;
-  // numPsats: number = 0;
-  // numFsats: number = 0;
-  // numSsmt: number = 0;
-  // numTreasureHunt: number = 0;
   sidebarHeight: number = 0;
   printView: boolean = false;
-  // reportAssessmentsSub: Subscription;
   phastAssessmentsSub: Subscription;
   fsatAssessmentsSub: Subscription;
   allPhastSub: Subscription;
@@ -78,12 +54,8 @@ export class ReportRollupComponent implements OnInit {
     this._fsatAssessments = new Array<ReportItem>();
     this._ssmtAssessments = new Array<ReportItem>();
     this._treasureHuntAssessments = new Array<ReportItem>();
-
-    this.selectedPhastCalcs = new Array<Calculator>();
-    this.selectedPsatCalcs = new Array<Calculator>();
-    this.selectedFsatCalcs = new Array<Calculator>();
-
     this.getSettings();
+
     setTimeout(() => {
       this.gatheringAssessments = false;
       this.cd.detectChanges();
@@ -160,36 +132,16 @@ export class ReportRollupComponent implements OnInit {
         this.reportRollupService.numTreasureHunt = 0;
       }
     });
-
-    //gets calculators for pre assessment rollup
-    this.selectedCalcsSub = this.reportRollupService.selectedCalcs.subscribe(items => {
-      if (items) {
-        if (items.length !== 0) {
-          items.forEach(item => {
-            if (item.type === 'furnace') {
-              this.selectedPhastCalcs.push(item);
-            } else if (item.type === 'pump') {
-              this.selectedPsatCalcs.push(item);
-            } else if (item.type === 'fan') {
-              this.selectedFsatCalcs.push(item);
-            }
-          });
-        }
-      }
-    });
-
   }
 
 
   ngOnDestroy() {
     this.reportRollupService.initSummary();
-    // if (this.reportAssessmentsSub) this.reportAssessmentsSub.unsubscribe();
     if (this.showPrintSub) this.showPrintSub.unsubscribe();
     if (this.phastAssessmentsSub) this.phastAssessmentsSub.unsubscribe();
     if (this.allPhastSub) this.allPhastSub.unsubscribe();
     if (this.selectedPhastSub) this.selectedPhastSub.unsubscribe();
     if (this.psatAssessmentSub) this.psatAssessmentSub.unsubscribe();
-    if (this.selectedCalcsSub) this.selectedCalcsSub.unsubscribe();
     if (this.fsatAssessmentsSub) this.fsatAssessmentsSub.unsubscribe();
     if (this.ssmtAssessmentsSub) this.ssmtAssessmentsSub.unsubscribe();
     if (this.treasureHuntAssesmentsSub) this.treasureHuntAssesmentsSub.unsubscribe();
@@ -221,32 +173,6 @@ export class ReportRollupComponent implements OnInit {
     }
   }
 
-  exportToCsv() {
-    // let tmpDataArr = new Array();
-    // this.exportReports.forEach(report => {
-    //   let tmpData = this.jsonToCsvService.getPsatCsvData(report.assessment, report.settings, report.assessment.psat);
-    //   tmpDataArr.push(tmpData);
-    //   if (report.assessment.psat.modifications) {
-    //     report.assessment.psat.modifications.forEach(mod => {
-    //       tmpData = this.jsonToCsvService.getPsatCsvData(report.assessment, report.settings, mod.psat);
-    //       tmpDataArr.push(tmpData);
-    //     })
-    //   }
-    // })
-    // this.jsonToCsvService.downloadData(tmpDataArr, 'psatRollup');
-  }
-
-
-
-
-  closeReport() {
-    this.emitCloseReport.emit(true);
-  }
-
-  // setFocused(assessment: Assessment) {
-  //   this.focusedAssessment = assessment;
-  // }
-
   setSidebarHeight() {
     let window = this.windowRefService.nativeWindow;
     let wndHeight = window.innerHeight;
@@ -254,57 +180,4 @@ export class ReportRollupComponent implements OnInit {
     this.sidebarHeight = wndHeight - this.bannerHeight;
     this.viewportScroller.setOffset([0, this.bannerHeight + 15]);
   }
-
-
-
-  showPhastModal() {
-    this.phastRollupModal.show();
-  }
-
-  hidePhastModal() {
-    this.phastRollupModal.hide();
-  }
-
-  showUnitModal() {
-    this.unitModal.show();
-  }
-
-  hideUnitModal() {
-    this.unitModal.hide();
-  }
-
-  showPsatModal() {
-    this.psatRollupModal.show();
-  }
-
-  hidePsatModal() {
-    this.psatRollupModal.hide();
-  }
-
-  showFsatModal() {
-    this.fsatRollupModal.show();
-  }
-
-  hideFsatModal() {
-    this.fsatRollupModal.hide();
-  }
-
-  showSsmtModal() {
-    this.ssmtRollupModal.show();
-  }
-
-  hideSsmtModal() {
-    this.ssmtRollupModal.hide();
-  }
-
-  // showPrintModal(): void {
-  //   this.showPrintMenu = true;
-  // }
-
-  // closePrintMenu(reset: boolean): void {
-  //   if (reset) {
-  //     this.initPrintLogic();
-  //   }
-  //   this.showPrintMenu = false;
-  // }
 }

--- a/src/app/report-rollup/report-rollup.component.ts
+++ b/src/app/report-rollup/report-rollup.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, ViewChild, TemplateRef, ElementRef, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, ViewChild, TemplateRef, ElementRef, ChangeDetectorRef, HostListener } from '@angular/core';
 import { Assessment } from '../shared/models/assessment';
 import { ReportRollupService } from './report-rollup.service';
 import { WindowRefService } from '../indexedDb/window-ref.service';
@@ -17,6 +17,11 @@ import { ViewportScroller } from '@angular/common';
 })
 export class ReportRollupComponent implements OnInit {
 
+  @HostListener("window:scroll", [])
+  onWindowScroll() {
+    this.checkActiveAssessment();
+  }
+
   @Output('emitCloseReport')
   emitCloseReport = new EventEmitter<boolean>();
   @ViewChild('reportTemplate', { static: false }) reportTemplate: TemplateRef<any>;
@@ -26,7 +31,7 @@ export class ReportRollupComponent implements OnInit {
   _fsatAssessments: Array<ReportItem>;
   _ssmtAssessments: Array<ReportItem>;
   _treasureHuntAssessments: Array<ReportItem>;
-  // focusedAssessment: Assessment;
+  focusedAssessment: Assessment;
   //debug
   selectedPhastCalcs: Array<Calculator>;
   selectedPsatCalcs: Array<Calculator>;
@@ -44,6 +49,7 @@ export class ReportRollupComponent implements OnInit {
   @ViewChild('ssmtRollupModal', { static: false }) public ssmtRollupModal: ModalDirective;
 
   @ViewChild('reportHeader', { static: false }) reportHeader: ElementRef;
+  @ViewChild('assessmentReportsDiv', {static: false}) assessmentReportsDiv: ElementRef;
   // @ViewChild('printMenuModal') public printMenuModal: ModalDirective;
 
   numPhasts: number = 0;
@@ -470,19 +476,18 @@ export class ReportRollupComponent implements OnInit {
     let wndHeight = window.innerHeight;
     this.bannerHeight = this.reportHeader.nativeElement.clientHeight;
     this.sidebarHeight = wndHeight - this.bannerHeight;
-    
     this.viewportScroller.setOffset([0, this.bannerHeight + 15]);
   }
 
-  checkActiveAssessment($event) {
-    let scrollAmount = $event.target.scrollTop;
+  checkActiveAssessment() {
+    let scrollAmount = this.windowRefService.nativeWindow.pageYOffset;
     if (this.reportHeader && scrollAmount) {
       this._reportAssessments.forEach(item => {
         let doc = this.windowRefService.getDoc();
         let element = doc.getElementById('assessment_' + item.assessment.id);
-        let diff = Math.abs(Math.abs(this.reportHeader.nativeElement.clientHeight - element.offsetTop) - scrollAmount);
+        let diff = Math.abs(Math.abs(this.bannerHeight - element.offsetTop) - scrollAmount);
         if (diff > 0 && diff < 50) {
-          // this.focusedAssessment = item.assessment;
+          this.focusedAssessment = item.assessment;
         }
       });
     }

--- a/src/app/report-rollup/report-rollup.component.ts
+++ b/src/app/report-rollup/report-rollup.component.ts
@@ -9,6 +9,8 @@ import { Subscription } from 'rxjs';
 import { SettingsDbService } from '../indexedDb/settings-db.service';
 import { ReportItem } from './report-rollup-models';
 import { ViewportScroller } from '@angular/common';
+import { DirectoryDashboardService } from '../dashboard/directory-dashboard/directory-dashboard.service';
+import { RollupPrintService } from './rollup-print.service';
 
 @Component({
   selector: 'app-report-rollup',
@@ -33,10 +35,8 @@ export class ReportRollupComponent implements OnInit {
   selectedPhastCalcs: Array<Calculator>;
   selectedPsatCalcs: Array<Calculator>;
   selectedFsatCalcs: Array<Calculator>;
-  directoryIds: Array<number>;
   bannerHeight: number;
   assessmentsGathered: boolean = false;
-  isSummaryVisible: boolean = true;
   createdDate: Date;
   settings: Settings;
   @ViewChild('psatRollupModal', { static: false }) public psatRollupModal: ModalDirective;
@@ -46,14 +46,14 @@ export class ReportRollupComponent implements OnInit {
   @ViewChild('ssmtRollupModal', { static: false }) public ssmtRollupModal: ModalDirective;
 
   @ViewChild('reportHeader', { static: false }) reportHeader: ElementRef;
-  @ViewChild('assessmentReportsDiv', {static: false}) assessmentReportsDiv: ElementRef;
+  @ViewChild('assessmentReportsDiv', { static: false }) assessmentReportsDiv: ElementRef;
   // @ViewChild('printMenuModal') public printMenuModal: ModalDirective;
 
-  numPhasts: number = 0;
-  numPsats: number = 0;
-  numFsats: number = 0;
-  numSsmt: number = 0;
-  numTreasureHunt: number = 0;
+  // numPhasts: number = 0;
+  // numPsats: number = 0;
+  // numFsats: number = 0;
+  // numSsmt: number = 0;
+  // numTreasureHunt: number = 0;
   sidebarHeight: number = 0;
   printView: boolean = false;
   // reportAssessmentsSub: Subscription;
@@ -65,35 +65,12 @@ export class ReportRollupComponent implements OnInit {
   selectedCalcsSub: Subscription;
   ssmtAssessmentsSub: Subscription;
   treasureHuntAssesmentsSub: Subscription;
-
-  showPrint: boolean = false;
-  showPrintMenu: boolean = false;
-
-  showPsatReportOptions: boolean = false;
-  showFsatReportOptions: boolean = false;
-  showPhastReportOptions: boolean = false;
-  showSsmtReportOptions: boolean = false;
-  showTreasureHuntReportOptions: boolean = false;
-  showRollupReportOptions: boolean;
-  selectAll: boolean = false;
-  printReportGraphs: boolean = false;
-  printReportSankey: boolean = false;
-  printResults: boolean = false;
-  printInputData: boolean = false;
-  printPsatRollup: boolean = false;
-  printPhastRollup: boolean = false;
-  printFsatRollup: boolean = false;
-  printTreasureHuntRollup: boolean = false;
-  printEnergyUsed: boolean = false;
-  printExecutiveSummary: boolean = false;
-  printEnergySummary: boolean = false;
-  printLossesSummary: boolean = false;
-  printReportOpportunityPayback: boolean = false;
-  printReportOpportunitySummary: boolean = false;
+  showPrintSub: Subscription;
 
   gatheringAssessments: boolean = true;
-  sidebarCollapsed: boolean = false;
-  constructor(private viewportScroller: ViewportScroller, private reportRollupService: ReportRollupService, private windowRefService: WindowRefService, private settingsDbService: SettingsDbService, private cd: ChangeDetectorRef) { }
+  constructor(private viewportScroller: ViewportScroller, private reportRollupService: ReportRollupService, private windowRefService: WindowRefService,
+    private settingsDbService: SettingsDbService, private cd: ChangeDetectorRef, private directoryDashboardService: DirectoryDashboardService,
+    private rollupPrintService: RollupPrintService) { }
 
   ngOnInit() {
     this._phastAssessments = new Array<ReportItem>();
@@ -105,34 +82,27 @@ export class ReportRollupComponent implements OnInit {
     this.selectedPhastCalcs = new Array<Calculator>();
     this.selectedPsatCalcs = new Array<Calculator>();
     this.selectedFsatCalcs = new Array<Calculator>();
-    this.directoryIds = new Array<number>();
 
+    this.getSettings();
     setTimeout(() => {
       this.gatheringAssessments = false;
+      this.cd.detectChanges();
     }, 1000)
-
     setTimeout(() => {
       this.assessmentsGathered = true;
       this.cd.detectChanges();
     }, 1500);
     setTimeout(() => {
       this.setSidebarHeight();
-      this.initPrintLogic();
       this.cd.detectChanges();
     }, 1600);
 
-    this.settings = this.settingsDbService.globalSettings;
-    this.checkSettings();
-
     this.createdDate = new Date();
-    // this.reportAssessmentsSub = this.reportRollupService.reportAssessments.subscribe(items => {
-    //   if (items) {
-    //     // if (items.length !== 0) {
-    //     this._reportAssessments = items;
-    //     // this.focusedAssessment = this._reportAssessments[this._reportAssessments.length - 1].assessment;
-    //     // }
-    //   }
-    // });
+
+    this.showPrintSub = this.rollupPrintService.showPrintView.subscribe(val => {
+      this.printView = val;
+    });
+
     this.allPhastSub = this.reportRollupService.allPhastResults.subscribe(val => {
       if (val.length !== 0) {
         this.reportRollupService.initPhastCompare(val);
@@ -145,64 +115,49 @@ export class ReportRollupComponent implements OnInit {
     });
     this.psatAssessmentSub = this.reportRollupService.psatAssessments.subscribe(items => {
       if (items) {
-        // if (items.length !== 0) {
         this._psatAssessments = items;
-        this.numPsats = this._psatAssessments.length;
-        // if (!this.focusedAssessment) {
-        //   this.focusedAssessment = this._psatAssessments[0].assessment;
-        // }
-        // }
+        this.reportRollupService.numPsats = this._psatAssessments.length;
+      } else {
+        this.reportRollupService.numPsats = 0;
       }
     });
     this.phastAssessmentsSub = this.reportRollupService.phastAssessments.subscribe(items => {
       if (items) {
-        // if (items.length !== 0) {
         this.reportRollupService.initPhastResultsArr(items);
         this._phastAssessments = items;
-        this.numPhasts = this._phastAssessments.length;
-        // if (!this.focusedAssessment) {
-        //   this.focusedAssessment = this._phastAssessments[0].assessment;
-        // }
-        // }
+        this.reportRollupService.numPhasts = this._phastAssessments.length;
+      } else {
+        this.reportRollupService.numPhasts = 0;
       }
     });
 
     this.fsatAssessmentsSub = this.reportRollupService.fsatAssessments.subscribe(items => {
       if (items) {
-        // if (items.length !== 0) {
         this._fsatAssessments = items;
-        this.numFsats = this._fsatAssessments.length;
+        this.reportRollupService.numFsats = this._fsatAssessments.length;
         this.reportRollupService.initFsatResultsArr(items);
-        // if (!this.focusedAssessment) {
-        //   this.focusedAssessment = this._fsatAssessments[0].assessment;
-        // }
-        // }
+      } else {
+        this.reportRollupService.numFsats = 0;
       }
     });
 
     this.ssmtAssessmentsSub = this.reportRollupService.ssmtAssessments.subscribe(items => {
       if (items) {
-        // if (items.length !== 0) {
         this._ssmtAssessments = items;
-        this.numSsmt = this._ssmtAssessments.length;
+        this.reportRollupService.numSsmt = this._ssmtAssessments.length;
         this.reportRollupService.initSsmtResultsArr(items);
-        // if (!this.focusedAssessment) {
-        //   this.focusedAssessment = this._ssmtAssessments[0].assessment;
-        // }
-        // }
+      } else {
+        this.reportRollupService.numSsmt = 0;
       }
     });
 
     this.treasureHuntAssesmentsSub = this.reportRollupService.treasureHuntAssessments.subscribe(items => {
       if (items) {
-        // if (items.length !== 0) {
         this._treasureHuntAssessments = items;
-        this.numTreasureHunt = this._treasureHuntAssessments.length;
+        this.reportRollupService.numTreasureHunt = this._treasureHuntAssessments.length;
         this.reportRollupService.initTreasureHuntResultsArray(this._treasureHuntAssessments);
-        // if (!this.focusedAssessment) {
-        //   this.focusedAssessment = this._treasureHuntAssessments[0].assessment;
-        // }
-        // }
+      } else {
+        this.reportRollupService.numTreasureHunt = 0;
       }
     });
 
@@ -222,17 +177,14 @@ export class ReportRollupComponent implements OnInit {
         }
       }
     });
+
   }
 
-  ngAfterViewInit() {
-    // setTimeout(() => {
-    //   this.setSidebarHeight();
-    // }, 500)
-  }
 
   ngOnDestroy() {
     this.reportRollupService.initSummary();
     // if (this.reportAssessmentsSub) this.reportAssessmentsSub.unsubscribe();
+    if (this.showPrintSub) this.showPrintSub.unsubscribe();
     if (this.phastAssessmentsSub) this.phastAssessmentsSub.unsubscribe();
     if (this.allPhastSub) this.allPhastSub.unsubscribe();
     if (this.selectedPhastSub) this.selectedPhastSub.unsubscribe();
@@ -241,6 +193,12 @@ export class ReportRollupComponent implements OnInit {
     if (this.fsatAssessmentsSub) this.fsatAssessmentsSub.unsubscribe();
     if (this.ssmtAssessmentsSub) this.ssmtAssessmentsSub.unsubscribe();
     if (this.treasureHuntAssesmentsSub) this.treasureHuntAssesmentsSub.unsubscribe();
+  }
+
+  getSettings() {
+    let directoryId: number = this.directoryDashboardService.selectedDirectoryId.getValue();
+    this.settings = this.settingsDbService.getByDirectoryId(directoryId);
+    this.checkSettings();
   }
 
   checkSettings() {
@@ -278,187 +236,8 @@ export class ReportRollupComponent implements OnInit {
     // this.jsonToCsvService.downloadData(tmpDataArr, 'psatRollup');
   }
 
-  initPrintLogic() {
-    this.showRollupReportOptions = true;
-    // this.showPsatReportOptions = false;
-    // this.showFsatReportOptions = false;
-    // this.showPhastReportOptions = false;
-    if (this.numPsats > 0) {
-      this.showPsatReportOptions = true;
-    }
-    else {
-      this.showPsatReportOptions = false;
-    }
-    if (this.numFsats > 0) {
-      this.showFsatReportOptions = true;
-    }
-    else {
-      this.showFsatReportOptions = false;
-    }
-    if (this.numPhasts > 0) {
-      this.showPhastReportOptions = true;
-    }
-    if (this.numSsmt > 0) {
-      this.showSsmtReportOptions = true;
-    }
-    else {
-      this.showPhastReportOptions = false;
-    }
-    this.selectAll = false;
-    this.printPsatRollup = false;
-    this.printFsatRollup = false;
-    this.printPhastRollup = false;
-    // this.printTreasureHuntRollup = false;
-    // this.printSsmtRollup = false;
-    this.printReportGraphs = false;
-    this.printReportSankey = false;
-    this.printResults = false;
-    this.printInputData = false;
-    this.printEnergyUsed = false;
-    this.printExecutiveSummary = false;
-    this.printEnergySummary = false;
-    this.printLossesSummary = false;
-    this.printReportOpportunityPayback = false;
-    this.printReportOpportunitySummary = false;
-  }
-
-  togglePrint(section: string): void {
-    switch (section) {
-      case "selectAll": {
-        this.selectAll = !this.selectAll;
-        if (this.selectAll) {
-          this.printPsatRollup = true;
-          this.printPhastRollup = true;
-          this.printFsatRollup = true;
-          // this.printTreasureHuntRollup = true;
-          // this.printSsmtRollup = true;
-          this.printReportGraphs = true;
-          this.printReportSankey = true;
-          this.printResults = true;
-          this.printInputData = true;
-          this.printExecutiveSummary = true;
-          this.printEnergyUsed = true;
-          this.printEnergySummary = true;
-          this.printLossesSummary = true;
-          this.printReportOpportunityPayback = true;
-          this.printReportOpportunitySummary = true;
-        }
-        else {
-          this.printPsatRollup = false;
-          this.printPhastRollup = false;
-          this.printFsatRollup = false;
-          // this.printTreasureHuntRollup = false;
-          // this.printSsmtRollup = false;
-          this.printResults = false;
-          this.printReportGraphs = false;
-          this.printReportSankey = false;
-          this.printInputData = false;
-          this.printExecutiveSummary = false;
-          this.printEnergyUsed = false;
-          this.printEnergySummary = false;
-          this.printLossesSummary = false;
-          this.printReportOpportunityPayback = false;
-          this.printReportOpportunitySummary = false;
-        }
-        break;
-      }
-      case "psatRollup": {
-        this.printPsatRollup = !this.printPsatRollup;
-        break;
-      }
-      case "phastRollup": {
-        this.printPhastRollup = !this.printPhastRollup;
-        break;
-      }
-      case "fsatRollup": {
-        this.printFsatRollup = !this.printFsatRollup;
-        break;
-      }
-      // case "treasureHuntRollup": {
-      //   this.printTreasureHuntRollup = !this.printTreasureHuntRollup;
-      //   break;
-      // }
-      // case "ssmtRollup": {
-      //   this.printSsmtRollup = !this.printSsmtRollup;
-      //   break;
-      // }
-      case "reportGraphs": {
-        this.printReportGraphs = !this.printReportGraphs;
-        break;
-      }
-      case "reportSankey": {
-        this.printReportSankey = !this.printReportSankey;
-        break;
-      }
-      case "results": {
-        this.printResults = !this.printResults;
-        break;
-      }
-      case "inputData": {
-        this.printInputData = !this.printInputData;
-        break;
-      }
-      case "energyUsed": {
-        this.printEnergyUsed = !this.printEnergyUsed;
-        break;
-      }
-      case "executiveSummary": {
-        this.printExecutiveSummary = !this.printExecutiveSummary;
-        break;
-      }
-      case "energySummary": {
-        this.printEnergySummary = !this.printEnergySummary;
-        break;
-      }
-      case "lossesSummary": {
-        this.printLossesSummary = !this.printLossesSummary;
-        break;
-      }
-      case "opportunityPayback": {
-        this.printReportOpportunityPayback = !this.printReportOpportunityPayback;
-      }
-      case "opportunitySummary": {
-        this.printReportOpportunitySummary = !this.printReportOpportunitySummary;
-      }
-      default: {
-        break;
-      }
-    }
-  }
-
-  setPrintViewThenPrint() {
-
-    this.printView = true;
-    let tmpPrintBuildTime = 100;
-    if (this._ssmtAssessments.length > 0) {
-      tmpPrintBuildTime += (500 * this._ssmtAssessments.length);
-    }
-    setTimeout(() => {
-      this.print();
-    }, tmpPrintBuildTime);
-  }
-
-  print() {
-    this.closePrintMenu(false);
-    // let win = this.windowRefService.nativeWindow;
-    // let doc = this.windowRefService.getDoc();
-    // win.print();
-    //this.printView = true;
-    // this.phastReportService.showPrint.next(true);
 
 
-    //eventually add logic for modal or something to say "building print view"
-
-    //set timeout for delay to print call. May want to do this differently later but for now should work
-    //10000000 is excessive, put it at whatever you want
-    setTimeout(() => {
-      let win = this.windowRefService.nativeWindow;
-      win.print();
-      //after printing hide content again
-      // this.phastReportService.showPrint.next(false);
-      this.printView = false;
-    }, 5000);
-  }
 
   closeReport() {
     this.emitCloseReport.emit(true);
@@ -476,7 +255,7 @@ export class ReportRollupComponent implements OnInit {
     this.viewportScroller.setOffset([0, this.bannerHeight + 15]);
   }
 
- 
+
 
   showPhastModal() {
     this.phastRollupModal.show();
@@ -518,14 +297,14 @@ export class ReportRollupComponent implements OnInit {
     this.ssmtRollupModal.hide();
   }
 
-  showPrintModal(): void {
-    this.showPrintMenu = true;
-  }
+  // showPrintModal(): void {
+  //   this.showPrintMenu = true;
+  // }
 
-  closePrintMenu(reset: boolean): void {
-    if (reset) {
-      this.initPrintLogic();
-    }
-    this.showPrintMenu = false;
-  }
+  // closePrintMenu(reset: boolean): void {
+  //   if (reset) {
+  //     this.initPrintLogic();
+  //   }
+  //   this.showPrintMenu = false;
+  // }
 }

--- a/src/app/report-rollup/report-rollup.component.ts
+++ b/src/app/report-rollup/report-rollup.component.ts
@@ -38,7 +38,6 @@ export class ReportRollupComponent implements OnInit {
   allPhastSub: Subscription;
   selectedPhastSub: Subscription;
   psatAssessmentSub: Subscription;
-  selectedCalcsSub: Subscription;
   ssmtAssessmentsSub: Subscription;
   treasureHuntAssesmentsSub: Subscription;
   showPrintSub: Subscription;

--- a/src/app/report-rollup/report-rollup.component.ts
+++ b/src/app/report-rollup/report-rollup.component.ts
@@ -17,10 +17,7 @@ import { ViewportScroller } from '@angular/common';
 })
 export class ReportRollupComponent implements OnInit {
 
-  @HostListener("window:scroll", [])
-  onWindowScroll() {
-    this.checkActiveAssessment();
-  }
+
 
   @Output('emitCloseReport')
   emitCloseReport = new EventEmitter<boolean>();
@@ -31,7 +28,7 @@ export class ReportRollupComponent implements OnInit {
   _fsatAssessments: Array<ReportItem>;
   _ssmtAssessments: Array<ReportItem>;
   _treasureHuntAssessments: Array<ReportItem>;
-  focusedAssessment: Assessment;
+  // focusedAssessment: Assessment;
   //debug
   selectedPhastCalcs: Array<Calculator>;
   selectedPsatCalcs: Array<Calculator>;
@@ -59,7 +56,7 @@ export class ReportRollupComponent implements OnInit {
   numTreasureHunt: number = 0;
   sidebarHeight: number = 0;
   printView: boolean = false;
-  reportAssessmentsSub: Subscription;
+  // reportAssessmentsSub: Subscription;
   phastAssessmentsSub: Subscription;
   fsatAssessmentsSub: Subscription;
   allPhastSub: Subscription;
@@ -128,14 +125,14 @@ export class ReportRollupComponent implements OnInit {
     this.checkSettings();
 
     this.createdDate = new Date();
-    this.reportAssessmentsSub = this.reportRollupService.reportAssessments.subscribe(items => {
-      if (items) {
-        // if (items.length !== 0) {
-        this._reportAssessments = items;
-        // this.focusedAssessment = this._reportAssessments[this._reportAssessments.length - 1].assessment;
-        // }
-      }
-    });
+    // this.reportAssessmentsSub = this.reportRollupService.reportAssessments.subscribe(items => {
+    //   if (items) {
+    //     // if (items.length !== 0) {
+    //     this._reportAssessments = items;
+    //     // this.focusedAssessment = this._reportAssessments[this._reportAssessments.length - 1].assessment;
+    //     // }
+    //   }
+    // });
     this.allPhastSub = this.reportRollupService.allPhastResults.subscribe(val => {
       if (val.length !== 0) {
         this.reportRollupService.initPhastCompare(val);
@@ -235,7 +232,7 @@ export class ReportRollupComponent implements OnInit {
 
   ngOnDestroy() {
     this.reportRollupService.initSummary();
-    if (this.reportAssessmentsSub) this.reportAssessmentsSub.unsubscribe();
+    // if (this.reportAssessmentsSub) this.reportAssessmentsSub.unsubscribe();
     if (this.phastAssessmentsSub) this.phastAssessmentsSub.unsubscribe();
     if (this.allPhastSub) this.allPhastSub.unsubscribe();
     if (this.selectedPhastSub) this.selectedPhastSub.unsubscribe();
@@ -479,19 +476,7 @@ export class ReportRollupComponent implements OnInit {
     this.viewportScroller.setOffset([0, this.bannerHeight + 15]);
   }
 
-  checkActiveAssessment() {
-    let scrollAmount = this.windowRefService.nativeWindow.pageYOffset;
-    if (this.reportHeader && scrollAmount) {
-      this._reportAssessments.forEach(item => {
-        let doc = this.windowRefService.getDoc();
-        let element = doc.getElementById('assessment_' + item.assessment.id);
-        let diff = Math.abs(Math.abs(this.bannerHeight - element.offsetTop) - scrollAmount);
-        if (diff > 0 && diff < 50) {
-          this.focusedAssessment = item.assessment;
-        }
-      });
-    }
-  }
+ 
 
   showPhastModal() {
     this.phastRollupModal.show();
@@ -543,8 +528,4 @@ export class ReportRollupComponent implements OnInit {
     }
     this.showPrintMenu = false;
   }
-
-  // collapseSidebar() {
-  //   this.sidebarCollapsed = !this.sidebarCollapsed;
-  // }
 }

--- a/src/app/report-rollup/report-rollup.component.ts
+++ b/src/app/report-rollup/report-rollup.component.ts
@@ -8,6 +8,7 @@ import { Calculator } from '../shared/models/calculators';
 import { Subscription } from 'rxjs';
 import { SettingsDbService } from '../indexedDb/settings-db.service';
 import { ReportItem } from './report-rollup-models';
+import { ViewportScroller } from '@angular/common';
 
 @Component({
   selector: 'app-report-rollup',
@@ -25,7 +26,7 @@ export class ReportRollupComponent implements OnInit {
   _fsatAssessments: Array<ReportItem>;
   _ssmtAssessments: Array<ReportItem>;
   _treasureHuntAssessments: Array<ReportItem>;
-  focusedAssessment: Assessment;
+  // focusedAssessment: Assessment;
   //debug
   selectedPhastCalcs: Array<Calculator>;
   selectedPsatCalcs: Array<Calculator>;
@@ -89,7 +90,7 @@ export class ReportRollupComponent implements OnInit {
 
   gatheringAssessments: boolean = true;
   sidebarCollapsed: boolean = false;
-  constructor(private reportRollupService: ReportRollupService, private windowRefService: WindowRefService, private settingsDbService: SettingsDbService, private cd: ChangeDetectorRef) { }
+  constructor(private viewportScroller: ViewportScroller, private reportRollupService: ReportRollupService, private windowRefService: WindowRefService, private settingsDbService: SettingsDbService, private cd: ChangeDetectorRef) { }
 
   ngOnInit() {
     this._phastAssessments = new Array<ReportItem>();
@@ -123,10 +124,10 @@ export class ReportRollupComponent implements OnInit {
     this.createdDate = new Date();
     this.reportAssessmentsSub = this.reportRollupService.reportAssessments.subscribe(items => {
       if (items) {
-        if (items.length !== 0) {
-          this._reportAssessments = items;
-          // this.focusedAssessment = this._reportAssessments[this._reportAssessments.length - 1].assessment;
-        }
+        // if (items.length !== 0) {
+        this._reportAssessments = items;
+        // this.focusedAssessment = this._reportAssessments[this._reportAssessments.length - 1].assessment;
+        // }
       }
     });
     this.allPhastSub = this.reportRollupService.allPhastResults.subscribe(val => {
@@ -141,64 +142,64 @@ export class ReportRollupComponent implements OnInit {
     });
     this.psatAssessmentSub = this.reportRollupService.psatAssessments.subscribe(items => {
       if (items) {
-        if (items.length !== 0) {
-          this._psatAssessments = items;
-          this.numPsats = this._psatAssessments.length;
-          if (!this.focusedAssessment) {
-            this.focusedAssessment = this._psatAssessments[0].assessment;
-          }
-        }
+        // if (items.length !== 0) {
+        this._psatAssessments = items;
+        this.numPsats = this._psatAssessments.length;
+        // if (!this.focusedAssessment) {
+        //   this.focusedAssessment = this._psatAssessments[0].assessment;
+        // }
+        // }
       }
     });
     this.phastAssessmentsSub = this.reportRollupService.phastAssessments.subscribe(items => {
       if (items) {
-        if (items.length !== 0) {
-          this.reportRollupService.initPhastResultsArr(items);
-          this._phastAssessments = items;
-          this.numPhasts = this._phastAssessments.length;
-          if (!this.focusedAssessment) {
-            this.focusedAssessment = this._phastAssessments[0].assessment;
-          }
-        }
+        // if (items.length !== 0) {
+        this.reportRollupService.initPhastResultsArr(items);
+        this._phastAssessments = items;
+        this.numPhasts = this._phastAssessments.length;
+        // if (!this.focusedAssessment) {
+        //   this.focusedAssessment = this._phastAssessments[0].assessment;
+        // }
+        // }
       }
     });
 
     this.fsatAssessmentsSub = this.reportRollupService.fsatAssessments.subscribe(items => {
       if (items) {
-        if (items.length !== 0) {
-          this._fsatAssessments = items;
-          this.numFsats = this._fsatAssessments.length;
-          this.reportRollupService.initFsatResultsArr(items);
-          if (!this.focusedAssessment) {
-            this.focusedAssessment = this._fsatAssessments[0].assessment;
-          }
-        }
+        // if (items.length !== 0) {
+        this._fsatAssessments = items;
+        this.numFsats = this._fsatAssessments.length;
+        this.reportRollupService.initFsatResultsArr(items);
+        // if (!this.focusedAssessment) {
+        //   this.focusedAssessment = this._fsatAssessments[0].assessment;
+        // }
+        // }
       }
     });
 
     this.ssmtAssessmentsSub = this.reportRollupService.ssmtAssessments.subscribe(items => {
       if (items) {
-        if (items.length !== 0) {
-          this._ssmtAssessments = items;
-          this.numSsmt = this._ssmtAssessments.length;
-          this.reportRollupService.initSsmtResultsArr(items);
-          if (!this.focusedAssessment) {
-            this.focusedAssessment = this._ssmtAssessments[0].assessment;
-          }
-        }
+        // if (items.length !== 0) {
+        this._ssmtAssessments = items;
+        this.numSsmt = this._ssmtAssessments.length;
+        this.reportRollupService.initSsmtResultsArr(items);
+        // if (!this.focusedAssessment) {
+        //   this.focusedAssessment = this._ssmtAssessments[0].assessment;
+        // }
+        // }
       }
     });
 
     this.treasureHuntAssesmentsSub = this.reportRollupService.treasureHuntAssessments.subscribe(items => {
       if (items) {
-        if (items.length !== 0) {
-          this._treasureHuntAssessments = items;
-          this.numTreasureHunt = this._treasureHuntAssessments.length;
-          this.reportRollupService.initTreasureHuntResultsArray(this._treasureHuntAssessments);
-          if (!this.focusedAssessment) {
-            this.focusedAssessment = this._treasureHuntAssessments[0].assessment;
-          }
-        }
+        // if (items.length !== 0) {
+        this._treasureHuntAssessments = items;
+        this.numTreasureHunt = this._treasureHuntAssessments.length;
+        this.reportRollupService.initTreasureHuntResultsArray(this._treasureHuntAssessments);
+        // if (!this.focusedAssessment) {
+        //   this.focusedAssessment = this._treasureHuntAssessments[0].assessment;
+        // }
+        // }
       }
     });
 
@@ -460,15 +461,17 @@ export class ReportRollupComponent implements OnInit {
     this.emitCloseReport.emit(true);
   }
 
-  setFocused(assessment: Assessment) {
-    this.focusedAssessment = assessment;
-  }
+  // setFocused(assessment: Assessment) {
+  //   this.focusedAssessment = assessment;
+  // }
 
   setSidebarHeight() {
     let window = this.windowRefService.nativeWindow;
     let wndHeight = window.innerHeight;
     this.bannerHeight = this.reportHeader.nativeElement.clientHeight;
     this.sidebarHeight = wndHeight - this.bannerHeight;
+    
+    this.viewportScroller.setOffset([0, this.bannerHeight + 15]);
   }
 
   checkActiveAssessment($event) {
@@ -479,7 +482,7 @@ export class ReportRollupComponent implements OnInit {
         let element = doc.getElementById('assessment_' + item.assessment.id);
         let diff = Math.abs(Math.abs(this.reportHeader.nativeElement.clientHeight - element.offsetTop) - scrollAmount);
         if (diff > 0 && diff < 50) {
-          this.focusedAssessment = item.assessment;
+          // this.focusedAssessment = item.assessment;
         }
       });
     }
@@ -536,7 +539,7 @@ export class ReportRollupComponent implements OnInit {
     this.showPrintMenu = false;
   }
 
-  collapseSidebar() {
-    this.sidebarCollapsed = !this.sidebarCollapsed;
-  }
+  // collapseSidebar() {
+  //   this.sidebarCollapsed = !this.sidebarCollapsed;
+  // }
 }

--- a/src/app/report-rollup/report-rollup.module.ts
+++ b/src/app/report-rollup/report-rollup.module.ts
@@ -54,6 +54,7 @@ import { SidebarComponent } from './sidebar/sidebar.component';
 import { RouterModule } from '@angular/router';
 import { RollupPrintService } from './rollup-print.service';
 import { ReportRollupModalsComponent } from './report-rollup-modals/report-rollup-modals.component';
+import { PreAssessmentPrintComponent } from './pre-assessment-print/pre-assessment-print.component';
 
 @NgModule({
   imports: [
@@ -111,6 +112,7 @@ import { ReportRollupModalsComponent } from './report-rollup-modals/report-rollu
     AssessmentReportsComponent,
     SidebarComponent,
     ReportRollupModalsComponent,
+    PreAssessmentPrintComponent,
 
   ],
   providers: [ReportRollupService, RollupPrintService],

--- a/src/app/report-rollup/report-rollup.module.ts
+++ b/src/app/report-rollup/report-rollup.module.ts
@@ -49,6 +49,9 @@ import { TreasureHuntSummaryComponent } from './report-summary/treasure-hunt-sum
 import { PrintOptionsMenuModule } from '../shared/print-options-menu/print-options-menu.module';
 import { PieChartModule } from '../shared/pie-chart/pie-chart.module';
 import { SharedPipesModule } from '../shared/shared-pipes/shared-pipes.module';
+import { AssessmentReportsComponent } from './assessment-reports/assessment-reports.component';
+import { SidebarComponent } from './sidebar/sidebar.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   imports: [
@@ -63,7 +66,8 @@ import { SharedPipesModule } from '../shared/shared-pipes/shared-pipes.module';
     TreasureHuntReportModule,
     PrintOptionsMenuModule,
     PieChartModule,
-    SharedPipesModule
+    SharedPipesModule,
+    RouterModule
   ],
   declarations: [
     ReportRollupComponent, 
@@ -102,6 +106,8 @@ import { SharedPipesModule } from '../shared/shared-pipes/shared-pipes.module';
     SsmtRollupEnergyTableComponent,
     SsmtRollupSteamSummaryTableComponent,
     TreasureHuntSummaryComponent,
+    AssessmentReportsComponent,
+    SidebarComponent,
 
   ],
   providers: [ReportRollupService],

--- a/src/app/report-rollup/report-rollup.module.ts
+++ b/src/app/report-rollup/report-rollup.module.ts
@@ -52,6 +52,8 @@ import { SharedPipesModule } from '../shared/shared-pipes/shared-pipes.module';
 import { AssessmentReportsComponent } from './assessment-reports/assessment-reports.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { RouterModule } from '@angular/router';
+import { RollupPrintService } from './rollup-print.service';
+import { ReportRollupModalsComponent } from './report-rollup-modals/report-rollup-modals.component';
 
 @NgModule({
   imports: [
@@ -108,9 +110,10 @@ import { RouterModule } from '@angular/router';
     TreasureHuntSummaryComponent,
     AssessmentReportsComponent,
     SidebarComponent,
+    ReportRollupModalsComponent,
 
   ],
-  providers: [ReportRollupService],
+  providers: [ReportRollupService, RollupPrintService],
   exports: [ReportRollupComponent]
 })
 export class ReportRollupModule { }

--- a/src/app/report-rollup/report-rollup.service.ts
+++ b/src/app/report-rollup/report-rollup.service.ts
@@ -67,6 +67,7 @@ export class ReportRollupService {
   numFsats: number = 0;
   numSsmt: number = 0;
   numTreasureHunt: number = 0;
+  showSummaryModal: BehaviorSubject<string>;
   constructor(
     private psatService: PsatService,
     private executiveSummaryService: ExecutiveSummaryService,
@@ -112,6 +113,7 @@ export class ReportRollupService {
     this.selectedCalcs = new BehaviorSubject<Array<Calculator>>(new Array<Calculator>());
 
     this.allTreasureHuntResults = new BehaviorSubject<Array<TreasureHuntResultsData>>(new Array<TreasureHuntResultsData>())
+    this.showSummaryModal = new BehaviorSubject<string>(undefined);
   }
 
 

--- a/src/app/report-rollup/report-rollup.service.ts
+++ b/src/app/report-rollup/report-rollup.service.ts
@@ -149,10 +149,19 @@ export class ReportRollupService {
     this.fsatArray = new Array<ReportItem>();
     this.ssmtArray = new Array<ReportItem>();
     this.treasureHuntArray = new Array<ReportItem>();
+    this.calcsArray = new Array<Calculator>();
     let selected = directory.assessments.filter((val) => { return val.selected; });
     selected.forEach(assessment => {
       this.pushAssessment(assessment);
     });
+    if(directory.calculators){
+      directory.calculators.forEach(calc =>{
+        if(calc.selected == true && calc.preAssessments){
+          this.calcsArray.push(calc);
+        }
+      })
+      this.selectedCalcs.next(this.calcsArray);
+    }
     directory.subDirectory.forEach(subDir => {
       if (subDir.selected) {
         this.getChildDirectoryAssessments(subDir.id);

--- a/src/app/report-rollup/report-rollup.service.ts
+++ b/src/app/report-rollup/report-rollup.service.ts
@@ -62,7 +62,11 @@ export class ReportRollupService {
 
   calcsArray: Array<Calculator>;
   selectedCalcs: BehaviorSubject<Array<Calculator>>;
-
+  numPhasts: number = 0;
+  numPsats: number = 0;
+  numFsats: number = 0;
+  numSsmt: number = 0;
+  numTreasureHunt: number = 0;
   constructor(
     private psatService: PsatService,
     private executiveSummaryService: ExecutiveSummaryService,

--- a/src/app/report-rollup/report-summary/fsat-summary/fsat-summary.component.html
+++ b/src/app/report-rollup/report-summary/fsat-summary/fsat-summary.component.html
@@ -6,7 +6,7 @@
       </span>
   </div>
   <div class="card-body">
-      <div class="row justify-content-center">
+      <div class="row no-gutters justify-content-center">
           <div class="col-lg-6 col-md-8 col-sm-12">
               <dl class="summary-list mx-auto">
                   <dt>Maximum Annual

--- a/src/app/report-rollup/report-summary/fsat-summary/fsat-summary.component.html
+++ b/src/app/report-rollup/report-summary/fsat-summary/fsat-summary.component.html
@@ -2,7 +2,7 @@
   <div class="card-header">
       <h3>Fans</h3>
       <span>
-          <span>{{numFsats}}</span>
+          <span>{{reportRollupService.numFsats}}</span>
       </span>
   </div>
   <div class="card-body">

--- a/src/app/report-rollup/report-summary/fsat-summary/fsat-summary.component.ts
+++ b/src/app/report-rollup/report-summary/fsat-summary/fsat-summary.component.ts
@@ -9,8 +9,6 @@ import { FsatResultsData } from '../../report-rollup-models';
   styleUrls: ['./fsat-summary.component.css', '../report-summary.component.css']
 })
 export class FsatSummaryComponent implements OnInit {
-  @Input()
-  numFsats: number;
 
   fanSavingPotential: number = 0;
   energySavingsPotential: number = 0;
@@ -24,7 +22,6 @@ export class FsatSummaryComponent implements OnInit {
 
   ngOnInit() {
     this.assessmentSub = this.reportRollupService.fsatAssessments.subscribe(val => {
-      this.numFsats = val.length
       if (val.length != 0) {
         this.reportRollupService.initFsatResultsArr(val);
       }

--- a/src/app/report-rollup/report-summary/phast-summary/phast-summary.component.html
+++ b/src/app/report-rollup/report-summary/phast-summary/phast-summary.component.html
@@ -6,7 +6,7 @@
         </span>
     </div>
     <div class="card-body">
-        <div class="row justify-content-center">
+        <div class="row no-gutters justify-content-center">
             <div class="col-lg-6 col-md-8 col-sm-12">
                 <dl class="summary-list mx-auto">
                     <dt>Maximum Annual

--- a/src/app/report-rollup/report-summary/phast-summary/phast-summary.component.html
+++ b/src/app/report-rollup/report-summary/phast-summary/phast-summary.component.html
@@ -2,7 +2,7 @@
     <div class="card-header">
         <h3>Furnaces</h3>
         <span>
-            <span>{{numPhasts}}</span>
+            <span>{{reportRollupService.numPhasts}}</span>
         </span>
     </div>
     <div class="card-body">

--- a/src/app/report-rollup/report-summary/phast-summary/phast-summary.component.ts
+++ b/src/app/report-rollup/report-summary/phast-summary/phast-summary.component.ts
@@ -13,8 +13,6 @@ import { PhastResultsData } from '../../report-rollup-models';
 export class PhastSummaryComponent implements OnInit {
   @Input()
   settings: Settings;
-  @Input()
-  numPhasts: number;
 
   furnaceSavingsPotential: number = 0;
   energySavingsPotential: number = 0;

--- a/src/app/report-rollup/report-summary/psat-summary/psat-summary.component.html
+++ b/src/app/report-rollup/report-summary/psat-summary/psat-summary.component.html
@@ -6,7 +6,7 @@
         </span>
     </div>
     <div class="card-body">
-        <div class="row justify-content-center">
+        <div class="row no-gutters justify-content-center">
             <div class="col-lg-6 col-md-8 col-sm-12">
                 <dl class="summary-list mx-auto">
                     <dt>Maximum Annual

--- a/src/app/report-rollup/report-summary/psat-summary/psat-summary.component.html
+++ b/src/app/report-rollup/report-summary/psat-summary/psat-summary.component.html
@@ -2,7 +2,7 @@
     <div class="card-header">
         <h3>Pumps</h3>
         <span>
-            <span>{{numPsats}}</span>
+            <span>{{reportRollupService.numPsats}}</span>
         </span>
     </div>
     <div class="card-body">

--- a/src/app/report-rollup/report-summary/psat-summary/psat-summary.component.ts
+++ b/src/app/report-rollup/report-summary/psat-summary/psat-summary.component.ts
@@ -10,9 +10,6 @@ import { PsatResultsData } from '../../report-rollup-models';
 })
 export class PsatSummaryComponent implements OnInit {
 
-  @Input()
-  numPsats: number;
-
   pumpSavingsPotential: number = 0;
   energySavingsPotential: number = 0;
   totalCost: number = 0;
@@ -25,7 +22,6 @@ export class PsatSummaryComponent implements OnInit {
 
   ngOnInit() {
     this.assessmentSub = this.reportRollupService.psatAssessments.subscribe(val => {
-      this.numPsats = val.length;
       if (val.length !== 0) {
         this.reportRollupService.initResultsArr(val);
       }

--- a/src/app/report-rollup/report-summary/report-summary.component.html
+++ b/src/app/report-rollup/report-summary/report-summary.component.html
@@ -2,25 +2,25 @@
     <div class="row no-gutters">
         <div class="col-12">
             <ul>
-                <li *ngIf="numPsats != 0" [hidden]="showSummary == 'closed'" class="pump-summary"
-                    (click)="showPumpModal()" [ngClass]="{'disabled': numPsats == 0}">
-                    <app-psat-summary [numPsats]="numPsats"></app-psat-summary>
+                <li *ngIf="reportRollupService.numPsats != 0" [hidden]="showSummary == 'closed'" class="pump-summary"
+                    (click)="showPumpModal()">
+                    <app-psat-summary></app-psat-summary>
                 </li>
-                <li *ngIf="numPhasts != 0" [hidden]="showSummary == 'closed'" class="furnace-summary"
-                    (click)="showFurnaceRollup()">
-                    <app-phast-summary [settings]="settings" [numPhasts]="numPhasts"></app-phast-summary>
+                <li *ngIf="reportRollupService.numPhasts != 0" [hidden]="showSummary == 'closed'"
+                    class="furnace-summary" (click)="showFurnaceRollup()">
+                    <app-phast-summary [settings]="settings"></app-phast-summary>
                 </li>
-                <li *ngIf="numFsats != 0" [hidden]="showSummary == 'closed'" class="fan-summary"
-                    (click)="showFanModal()" [ngClass]="{'disabled': numFsats == 0}">
-                    <app-fsat-summary [numFsats]="numFsats"></app-fsat-summary>
+                <li *ngIf="reportRollupService.numFsats != 0" [hidden]="showSummary == 'closed'" class="fan-summary"
+                    (click)="showFanModal()">
+                    <app-fsat-summary></app-fsat-summary>
                 </li>
-                <li *ngIf="numSsmt != 0" [hidden]="showSummary == 'closed'" class="ssmt-summary"
-                    (click)="showSteamModal()" [ngClass]="{'disabled': numSsmt == 0}">
-                    <app-ssmt-summary [numSsmt]="numSsmt" [settings]="settings"></app-ssmt-summary>
+                <li *ngIf="reportRollupService.numSsmt != 0" [hidden]="showSummary == 'closed'" class="ssmt-summary"
+                    (click)="showSteamModal()">
+                    <app-ssmt-summary [settings]="settings"></app-ssmt-summary>
                 </li>
-                <li *ngIf="numTreasureHunt != 0" [hidden]="showSummary == 'closed'" class="treasure-hunt-summary"
-                    [ngClass]="{'disabled': numTreasureHunt == 0}">
-                    <app-treasure-hunt-summary [numTreasureHunt]="numTreasureHunt"></app-treasure-hunt-summary>
+                <li *ngIf="reportRollupService.numTreasureHunt != 0" [hidden]="showSummary == 'closed'"
+                    class="treasure-hunt-summary">
+                    <app-treasure-hunt-summary></app-treasure-hunt-summary>
                 </li>
             </ul>
         </div>

--- a/src/app/report-rollup/report-summary/report-summary.component.html
+++ b/src/app/report-rollup/report-summary/report-summary.component.html
@@ -1,5 +1,5 @@
 <div class="report-summary">
-    <div class="row">
+    <div class="row no-gutters">
         <div class="col-12">
             <ul>
                 <li *ngIf="numPsats != 0" [hidden]="showSummary == 'closed'" class="pump-summary"
@@ -26,7 +26,7 @@
         </div>
     </div>
 
-    <div class="row">
+    <div class="row no-gutters">
         <div class="col-12">
             <a *ngIf="showSummary == 'open'" class="click-link pull-right" (click)="collapseSummary('closed')">-
                 Collapse Summaries</a>

--- a/src/app/report-rollup/report-summary/report-summary.component.html
+++ b/src/app/report-rollup/report-summary/report-summary.component.html
@@ -3,19 +3,19 @@
         <div class="col-12">
             <ul>
                 <li *ngIf="reportRollupService.numPsats != 0" [hidden]="showSummary == 'closed'" class="pump-summary"
-                    (click)="showPumpModal()">
+                    (click)="showAssessmentModal('psat')">
                     <app-psat-summary></app-psat-summary>
                 </li>
                 <li *ngIf="reportRollupService.numPhasts != 0" [hidden]="showSummary == 'closed'"
-                    class="furnace-summary" (click)="showFurnaceRollup()">
+                    class="furnace-summary" (click)="showAssessmentModal('phast')">
                     <app-phast-summary [settings]="settings"></app-phast-summary>
                 </li>
                 <li *ngIf="reportRollupService.numFsats != 0" [hidden]="showSummary == 'closed'" class="fan-summary"
-                    (click)="showFanModal()">
+                    (click)="showAssessmentModal('fsat')">
                     <app-fsat-summary></app-fsat-summary>
                 </li>
                 <li *ngIf="reportRollupService.numSsmt != 0" [hidden]="showSummary == 'closed'" class="ssmt-summary"
-                    (click)="showSteamModal()">
+                    (click)="showAssessmentModal('ssmt')">
                     <app-ssmt-summary [settings]="settings"></app-ssmt-summary>
                 </li>
                 <li *ngIf="reportRollupService.numTreasureHunt != 0" [hidden]="showSummary == 'closed'"

--- a/src/app/report-rollup/report-summary/report-summary.component.ts
+++ b/src/app/report-rollup/report-summary/report-summary.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Settings } from '../../shared/models/settings';
 import { PhastResultsData } from '../report-rollup-models';
+import { ReportRollupService } from '../report-rollup.service';
 
 @Component({
   selector: 'app-report-summary',
@@ -20,22 +21,22 @@ export class ReportSummaryComponent implements OnInit {
   showSsmtModal = new EventEmitter<boolean>();
   @Input()
   phastResults: Array<PhastResultsData>;
-  @Input()
-  numPhasts: number;
-  @Input()
-  numPsats: number;
-  @Input()
-  numFsats: number;
-  @Input()
-  numSsmt: number;
-  @Input()
-  numTreasureHunt: number;
+  // @Input()
+  // numPhasts: number;
+  // @Input()
+  // numPsats: number;
+  // @Input()
+  // numFsats: number;
+  // @Input()
+  // numSsmt: number;
+  // @Input()
+  // numTreasureHunt: number;
 
   @Output('hideSummary')
   hideSummary = new EventEmitter<boolean>();
   // @ViewChild('rollupModal') public rollupModal: ModalDirective;
   showSummary: string = 'open';
-  constructor() { }
+  constructor(private reportRollupService: ReportRollupService) { }
 
   ngOnInit() {
   }

--- a/src/app/report-rollup/report-summary/report-summary.component.ts
+++ b/src/app/report-rollup/report-summary/report-summary.component.ts
@@ -11,58 +11,16 @@ import { ReportRollupService } from '../report-rollup.service';
 export class ReportSummaryComponent implements OnInit {
   @Input()
   settings: Settings;
-  @Output('showPhastModal')
-  showPhastModal = new EventEmitter<boolean>();
-  @Output('showPsatModal')
-  showPsatModal = new EventEmitter<boolean>();
-  @Output('showFsatModal')
-  showFsatModal = new EventEmitter<boolean>();
-  @Output('showSsmtModal')
-  showSsmtModal = new EventEmitter<boolean>();
-  @Input()
-  phastResults: Array<PhastResultsData>;
-  // @Input()
-  // numPhasts: number;
-  // @Input()
-  // numPsats: number;
-  // @Input()
-  // numFsats: number;
-  // @Input()
-  // numSsmt: number;
-  // @Input()
-  // numTreasureHunt: number;
-
   @Output('hideSummary')
   hideSummary = new EventEmitter<boolean>();
-  // @ViewChild('rollupModal') public rollupModal: ModalDirective;
   showSummary: string = 'open';
   constructor(private reportRollupService: ReportRollupService) { }
 
   ngOnInit() {
   }
 
-
-  showFurnaceRollup() {
-    this.showPhastModal.emit(true);
-  }
-  // showModal() {
-  //     this.rollupModal.show();
-  // }
-
-  // hideModal() {
-  //   this.rollupModal.hide();
-  // }
-
-  showPumpModal() {
-    this.showPsatModal.emit(true);
-  }
-
-  showFanModal() {
-    this.showFsatModal.emit(true);
-  }
-
-  showSteamModal(){
-    this.showSsmtModal.emit(true);
+  showAssessmentModal(assessmentModalType: string){
+    this.reportRollupService.showSummaryModal.next(assessmentModalType);
   }
 
   collapseSummary(str: string) {

--- a/src/app/report-rollup/report-summary/ssmt-summary/ssmt-summary.component.html
+++ b/src/app/report-rollup/report-summary/ssmt-summary/ssmt-summary.component.html
@@ -2,7 +2,7 @@
   <div class="card-header">
     <h3>Steam</h3>
     <span>
-      <span>{{numSsmt}}</span>
+      <span>{{reportRollupService.numSsmt}}</span>
     </span>
   </div>
   <div class="card-body">

--- a/src/app/report-rollup/report-summary/ssmt-summary/ssmt-summary.component.html
+++ b/src/app/report-rollup/report-summary/ssmt-summary/ssmt-summary.component.html
@@ -6,7 +6,7 @@
     </span>
   </div>
   <div class="card-body">
-    <div class="row justify-content-center">
+    <div class="row no-gutters justify-content-center">
       <div class="col-lg-6 col-md-8 col-sm-12">
         <dl class="summary-list mx-auto">
           <dt>Maximum Annual

--- a/src/app/report-rollup/report-summary/ssmt-summary/ssmt-summary.component.ts
+++ b/src/app/report-rollup/report-summary/ssmt-summary/ssmt-summary.component.ts
@@ -11,8 +11,6 @@ import { Settings } from '../../../shared/models/settings';
 })
 export class SsmtSummaryComponent implements OnInit {
   @Input()
-  numSsmt: number;
-  @Input()
   settings: Settings;
 
   ssmtSavingPotential: number = 0;

--- a/src/app/report-rollup/report-summary/treasure-hunt-summary/treasure-hunt-summary.component.html
+++ b/src/app/report-rollup/report-summary/treasure-hunt-summary/treasure-hunt-summary.component.html
@@ -6,7 +6,7 @@
     </span>
   </div>
   <div class="card-body">
-    <div class="row justify-content-center my-auto">
+    <div class="row no-gutters justify-content-center my-auto">
       <div class="col-lg-6 col-md-8 col-sm-12">
         <dl class="summary-list mx-auto">
           <dt>Annual Cost Savings</dt>

--- a/src/app/report-rollup/report-summary/treasure-hunt-summary/treasure-hunt-summary.component.html
+++ b/src/app/report-rollup/report-summary/treasure-hunt-summary/treasure-hunt-summary.component.html
@@ -2,7 +2,7 @@
   <div class="card-header">
     <h3>Treasure Hunt</h3>
     <span>
-      <span>{{numTreasureHunt}}</span>
+      <span>{{reportRollupService.numTreasureHunt}}</span>
     </span>
   </div>
   <div class="card-body">

--- a/src/app/report-rollup/report-summary/treasure-hunt-summary/treasure-hunt-summary.component.ts
+++ b/src/app/report-rollup/report-summary/treasure-hunt-summary/treasure-hunt-summary.component.ts
@@ -11,8 +11,6 @@ import { TreasureHuntResultsData } from '../../report-rollup-models';
 })
 export class TreasureHuntSummaryComponent implements OnInit {
   @Input()
-  numTreasureHunt: number;
-  @Input()
   settings: Settings;
 
   treasureHuntAssessmentsSub: Subscription;

--- a/src/app/report-rollup/rollup-print.service.spec.ts
+++ b/src/app/report-rollup/rollup-print.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RollupPrintService } from './rollup-print.service';
+
+describe('RollupPrintService', () => {
+  let service: RollupPrintService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RollupPrintService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/report-rollup/rollup-print.service.ts
+++ b/src/app/report-rollup/rollup-print.service.ts
@@ -1,0 +1,133 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable()
+export class RollupPrintService {
+
+  rollupPrintOptions: BehaviorSubject<RollupPrintOptions>;
+  showPrintView: BehaviorSubject<boolean>;
+  showPrintOptionsModal: BehaviorSubject<boolean>;
+  constructor() {
+    let initPrintOptions: RollupPrintOptions = this.setAll(true);
+    this.rollupPrintOptions = new BehaviorSubject<RollupPrintOptions>(initPrintOptions);
+    this.showPrintView = new BehaviorSubject<boolean>(false);
+    this.showPrintOptionsModal = new BehaviorSubject<boolean>(false);
+  }
+
+
+  toggleSection(section: string): void {
+    let currentPrintOptions: RollupPrintOptions = this.rollupPrintOptions.getValue();
+    switch (section) {
+      case "selectAll": {
+        currentPrintOptions.selectAll = !currentPrintOptions.selectAll;
+        currentPrintOptions = this.setAll(currentPrintOptions.selectAll);
+        break;
+      }
+      case "psatRollup": {
+        currentPrintOptions.printPsatRollup = !currentPrintOptions.printPsatRollup;
+        break;
+      }
+      case "phastRollup": {
+        currentPrintOptions.printPhastRollup = !currentPrintOptions.printPhastRollup;
+        break;
+      }
+      case "fsatRollup": {
+        currentPrintOptions.printFsatRollup = !currentPrintOptions.printFsatRollup;
+        break;
+      }
+      // case "treasureHuntRollup": {
+      //   this.printTreasureHuntRollup = !this.printTreasureHuntRollup;
+      //   break;
+      // }
+      case "ssmtRollup": {
+        currentPrintOptions.printSsmtRollup = !currentPrintOptions.printSsmtRollup;
+        break;
+      }
+      case "reportGraphs": {
+        currentPrintOptions.printReportGraphs = !currentPrintOptions.printReportGraphs;
+        break;
+      }
+      case "reportSankey": {
+        currentPrintOptions.printReportSankey = !currentPrintOptions.printReportSankey;
+        break;
+      }
+      case "results": {
+        currentPrintOptions.printResults = !currentPrintOptions.printResults;
+        break;
+      }
+      case "inputData": {
+        currentPrintOptions.printInputData = !currentPrintOptions.printInputData;
+        break;
+      }
+      case "energyUsed": {
+        currentPrintOptions.printEnergyUsed = !currentPrintOptions.printEnergyUsed;
+        break;
+      }
+      case "executiveSummary": {
+        currentPrintOptions.printExecutiveSummary = !currentPrintOptions.printExecutiveSummary;
+        break;
+      }
+      case "energySummary": {
+        currentPrintOptions.printEnergySummary = !currentPrintOptions.printEnergySummary;
+        break;
+      }
+      case "lossesSummary": {
+        currentPrintOptions.printLossesSummary = !currentPrintOptions.printLossesSummary;
+        break;
+      }
+      case "opportunityPayback": {
+        currentPrintOptions.printReportOpportunityPayback = !currentPrintOptions.printReportOpportunityPayback;
+      }
+      case "opportunitySummary": {
+        currentPrintOptions.printReportOpportunitySummary = !currentPrintOptions.printReportOpportunitySummary;
+      }
+      default: {
+        break;
+      }
+    }
+    this.rollupPrintOptions.next(currentPrintOptions);
+  }
+
+  setAll(bool: boolean): RollupPrintOptions {
+    return {
+      printPsatRollup: bool,
+      printPhastRollup: bool,
+      printFsatRollup: bool,
+      // this.printTreasureHuntRollup: boolean;
+      // this.printSsmtRollup: boolean;
+      printReportGraphs: bool,
+      printReportSankey: bool,
+      printResults: bool,
+      printInputData: bool,
+      printExecutiveSummary: bool,
+      printEnergyUsed: bool,
+      printEnergySummary: bool,
+      printLossesSummary: bool,
+      printReportOpportunityPayback: bool,
+      printReportOpportunitySummary: bool,
+      printSsmtRollup: bool,
+      selectAll: bool
+    }
+  }
+}
+
+
+export interface RollupPrintOptions {
+  printPsatRollup: boolean;
+  printPhastRollup: boolean;
+  printFsatRollup: boolean;
+  // this.printTreasureHuntRollup: boolean;
+  // this.printSsmtRollup: boolean;
+  printReportGraphs: boolean;
+  printReportSankey: boolean;
+  printResults: boolean;
+  printInputData: boolean;
+  printExecutiveSummary: boolean;
+  printEnergyUsed: boolean;
+  printEnergySummary: boolean;
+  printLossesSummary: boolean;
+  printReportOpportunityPayback: boolean;
+  printReportOpportunitySummary: boolean;
+  printSsmtRollup: boolean;
+  selectAll: boolean;
+}

--- a/src/app/report-rollup/sidebar/sidebar.component.css
+++ b/src/app/report-rollup/sidebar/sidebar.component.css
@@ -1,0 +1,46 @@
+.sidebar {
+    background: #fff;
+    border-right: #d0d0d0 solid 1px;
+    overflow-y: auto;
+    position: sticky;
+}
+    .sidebar ul {
+        margin: 0;
+        padding: 0;
+    }
+    .sidebar ul li {
+            list-style: none;
+            padding: 0;
+        }
+    .sidebar ul li.active {
+            background-color: #f5f5f5;
+        }
+    .sidebar ul li:hover {
+            cursor: pointer;
+            background-color: lightgrey;
+        }
+    .sidebar ul li a {
+                font-size: 15px;
+            }
+    .sidebar ul li.active a {
+                color: #000;
+                font-weight: bold;
+            }
+.sidebar.set-width{
+    width: 220px;
+}
+
+.icon-image{
+    width: 35px;
+  }
+  
+  .icon{
+    width: 100%;
+  }
+
+  .sidebar ul li.collapse-option{
+    background-color: #145A32;
+    color: white;
+    padding-top: 6px;
+    padding-bottom: 6px;
+}

--- a/src/app/report-rollup/sidebar/sidebar.component.html
+++ b/src/app/report-rollup/sidebar/sidebar.component.html
@@ -1,0 +1,76 @@
+<div class="sidebar hide-print scroll-item" id="sidebar" [ngStyle]="{'height.px': sidebarHeight, 'top.px':bannerHeight}"
+    [ngClass]="{'set-width': !sidebarCollapsed}">
+    <ul id="sidebar-list">
+        <li class="collapse-option">
+            <div class="d-flex align-items-center" (click)="collapseSidebar()">
+                <div class="p-1 d-flex text-center">
+                    <span *ngIf="!sidebarCollapsed" class="fa fa-chevron-left"></span>
+                    <span *ngIf="sidebarCollapsed" class="fa fa-chevron-right pr-2 pl-2"></span>
+                </div>
+                <div class="p-0" [ngClass]="{'collapse': sidebarCollapsed}">
+                    Collapse Sidebar
+                </div>
+            </div>
+        </li>
+        <li *ngFor="let item of _psatAssessments"
+            [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
+            <div class="d-flex align-items-center psat">
+                <span class="p-1 d-flex align-items-center justify-content-center icon-image">
+                    <img class="icon" src="assets/images/ico-psat-diagram.png">
+                </span>
+                <span class="p-1">
+                    <a class="click-link" [routerLink]='"."' [fragment]="'assessment_'+item.assessment.id"
+                        (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
+                </span>
+            </div>
+        </li>
+        <li *ngFor="let item of _phastAssessments"
+            [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
+            <div class="d-flex align-items-center phast">
+                <span class="p-1 d-flex align-items-center justify-content-center icon-image">
+                    <img class="icon" src="assets/images/ico-phast-diagram.png">
+                </span>
+                <span class="p-1">
+                    <a class="click-link" [routerLink]='"."' [fragment]="'assessment_'+item.assessment.id"
+                        (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
+                </span>
+            </div>
+        </li>
+        <li *ngFor="let item of _fsatAssessments"
+            [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
+            <div class="d-flex align-items-center fsat">
+                <span class="p-1 d-flex align-items-center justify-content-center icon-image">
+                    <img class="icon" src="assets/images/ico-fsat-diagram.png">
+                </span>
+                <span class="p-1">
+                    <a class="click-link" [routerLink]='"."' [fragment]="'assessment_'+item.assessment.id"
+                        (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
+                </span>
+            </div>
+        </li>
+        <li *ngFor="let item of _ssmtAssessments"
+            [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
+            <div class="d-flex align-items-center ssmt">
+                <span class="p-1 d-flex align-items-center justify-content-center icon-image">
+                    <img class="icon" src="assets/images/ico-ssmt-diagram.png">
+                </span>
+                <span class="p-1">
+                    <a class="click-link" [routerLink]='"."' [fragment]="'assessment_'+item.assessment.id"
+                        (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
+                </span>
+            </div>
+        </li>
+        <li *ngFor="let item of _treasureHuntAssessments"
+            [ngClass]="{'active': focusedAssessment.id == item.assessment.id, 'collapse': sidebarCollapsed}">
+            <div class="d-flex align-items-center ssmt">
+                <span class="p-1 d-flex align-items-center justify-content-center icon-image">
+                    <img class="icon" src="assets/images/treasure-hunt.png">
+                </span>
+                <span class="p-1">
+                    <a class="click-link" [routerLink]='"."' [fragment]="'assessment_'+item.assessment.id"
+                        (click)="setFocused(item.assessment)">{{item.assessment.name}}</a>
+                </span>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/src/app/report-rollup/sidebar/sidebar.component.spec.ts
+++ b/src/app/report-rollup/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SidebarComponent } from './sidebar.component';
+
+describe('SidebarComponent', () => {
+  let component: SidebarComponent;
+  let fixture: ComponentFixture<SidebarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SidebarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SidebarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/report-rollup/sidebar/sidebar.component.ts
+++ b/src/app/report-rollup/sidebar/sidebar.component.ts
@@ -1,0 +1,100 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { ReportItem } from '../report-rollup-models';
+import { Subscription } from 'rxjs';
+import { Assessment } from '../../shared/models/assessment';
+import { ReportRollupService } from '../report-rollup.service';
+
+@Component({
+  selector: 'app-sidebar',
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.css']
+})
+export class SidebarComponent implements OnInit {
+  @Input()
+  sidebarHeight: number;
+  @Input()
+  bannerHeight: number;
+
+  sidebarCollapsed: boolean = false;
+  _phastAssessments: Array<ReportItem>;
+  _psatAssessments: Array<ReportItem>;
+  _fsatAssessments: Array<ReportItem>;
+  _ssmtAssessments: Array<ReportItem>;
+  _treasureHuntAssessments: Array<ReportItem>;
+  phastAssessmentsSub: Subscription;
+  fsatAssessmentsSub: Subscription;
+  psatAssessmentSub: Subscription;
+  ssmtAssessmentsSub: Subscription;
+  treasureHuntAssesmentsSub: Subscription;
+  focusedAssessment: Assessment;
+  constructor(private reportRollupService: ReportRollupService) { }
+
+  ngOnInit(): void {
+    this._phastAssessments = new Array<ReportItem>();
+    this._psatAssessments = new Array<ReportItem>();
+    this._fsatAssessments = new Array<ReportItem>();
+    this._ssmtAssessments = new Array<ReportItem>();
+    this._treasureHuntAssessments = new Array<ReportItem>();
+    this.psatAssessmentSub = this.reportRollupService.psatAssessments.subscribe(items => {
+      if (items) {
+        this._psatAssessments = items;
+      }
+    });
+    this.phastAssessmentsSub = this.reportRollupService.phastAssessments.subscribe(items => {
+      if (items) {
+        this._phastAssessments = items;
+      }
+    });
+
+    this.fsatAssessmentsSub = this.reportRollupService.fsatAssessments.subscribe(items => {
+      if (items) {
+        this._fsatAssessments = items;
+      }
+    });
+
+    this.ssmtAssessmentsSub = this.reportRollupService.ssmtAssessments.subscribe(items => {
+      if (items) {
+        this._ssmtAssessments = items;
+      }
+    });
+
+    this.treasureHuntAssesmentsSub = this.reportRollupService.treasureHuntAssessments.subscribe(items => {
+      if (items) {
+        this._treasureHuntAssessments = items;
+      }
+    });
+    this.initFocusedAssessment();
+  }
+
+  ngOnDestroy() {
+    this.phastAssessmentsSub.unsubscribe();
+    this.fsatAssessmentsSub.unsubscribe();
+    this.psatAssessmentSub.unsubscribe();
+    this.ssmtAssessmentsSub.unsubscribe();
+    this.treasureHuntAssesmentsSub.unsubscribe();
+  }
+
+  collapseSidebar() {
+    this.sidebarCollapsed = !this.sidebarCollapsed;
+  }
+
+  initFocusedAssessment() {
+    if (!this.focusedAssessment) {
+      if (this._psatAssessments.length != 0) {
+        this.focusedAssessment = this._psatAssessments[0].assessment;
+      } else if (this._phastAssessments.length != 0) {
+        this.focusedAssessment = this._phastAssessments[0].assessment;
+      } else if (this._fsatAssessments.length != 0) {
+        this.focusedAssessment = this._fsatAssessments[0].assessment;
+      } else if (this._ssmtAssessments.length != 0) {
+        this.focusedAssessment = this._ssmtAssessments[0].assessment;
+      } else if (this._treasureHuntAssessments.length != 0) {
+        this.focusedAssessment = this._treasureHuntAssessments[0].assessment;
+      }
+    }
+  }
+
+  setFocused(assessment: Assessment) {
+    this.focusedAssessment = assessment;
+  }
+}

--- a/src/app/report-rollup/sidebar/sidebar.component.ts
+++ b/src/app/report-rollup/sidebar/sidebar.component.ts
@@ -14,6 +14,8 @@ export class SidebarComponent implements OnInit {
   sidebarHeight: number;
   @Input()
   bannerHeight: number;
+  @Input()
+  focusedAssessment: Assessment;
 
   sidebarCollapsed: boolean = false;
   _phastAssessments: Array<ReportItem>;
@@ -26,7 +28,6 @@ export class SidebarComponent implements OnInit {
   psatAssessmentSub: Subscription;
   ssmtAssessmentsSub: Subscription;
   treasureHuntAssesmentsSub: Subscription;
-  focusedAssessment: Assessment;
   constructor(private reportRollupService: ReportRollupService) { }
 
   ngOnInit(): void {

--- a/src/app/shared/print-options-menu/print-options-menu.component.html
+++ b/src/app/shared/print-options-menu/print-options-menu.component.html
@@ -51,7 +51,7 @@
                         Fan Assessment Rollup Summary
                     </div>
                 </div>
-                <!-- <div class="row toggle-btn pad-top-10" *ngIf="showSsmtReportOptions && showRollupReportOptions"
+                <div class="row toggle-btn pad-top-10" *ngIf="showSsmtReportOptions && showRollupReportOptions"
                     (click)="togglePrint('ssmtRollup')">
                     <div class="col-2">
                         <app-animated-checkmark [active]="printSsmtRollup"></app-animated-checkmark>
@@ -59,7 +59,7 @@
                     <div class="col-8 bottom-divider">
                         SSMT Rollup Summary
                     </div>
-                </div> -->
+                </div>
 
                 <div *ngIf="!showSsmtReportOptions && !showTHReportOptions" class="row toggle-btn pad-top-10"
                     (click)="togglePrint('results')">


### PR DESCRIPTION
connects #3575 

cleans up organization of report rollup
-moved modals to their own component
-moved sidebar to own component
-moved list of reports to own component out of router so we can use route fragments for jumping to specific report in sidebar
-moved print options logic to own component/service

Fixed many print errors
-Opportunity summary removed rotating table that wasn't working
-Steam pie charts showing up
-Created individual pre assessment print component and added psat, fsat printing (previously just phast) but disabled because it was causing all pie charts to be blank. Creating new issue.

