### PR TITLE
Cooling tower release fixes

### DIFF
--- a/src/app/calculator/process-cooling/cooling-tower/cooling-tower-form/cooling-tower-form.component.html
+++ b/src/app/calculator/process-cooling/cooling-tower/cooling-tower-form/cooling-tower-form.component.html
@@ -171,6 +171,8 @@
                 <div class="input-group">
                   <input class="form-control" type="number" name="lossCorrectionFactor" id="{{'lossCorrectionFactor_'+idString}}"
                     formControlName="lossCorrectionFactor" (input)="calculate()" (focus)="focusField('lossCorrectionFactor')">
+                  <span class="units input-group-addon">%</span>
+
                 </div>
                 <span class="alert-danger pull-right small"
                   *ngIf="form.controls.lossCorrectionFactor.invalid && !form.controls.lossCorrectionFactor.pristine">
@@ -221,7 +223,7 @@
             </span>
             <span *ngIf="isBaseline && caseResultData">
               <span *ngIf="caseResultData.wcBaseline">
-                {{caseResultData.wcBaseline | number: '1.0-0' }}
+                {{caseResultData.wcBaseline | number: '1.1-1' }}
               </span>
               <span *ngIf="!caseResultData.wcBaseline">
                 <strong>&mdash; &mdash;</strong>
@@ -229,7 +231,7 @@
             </span>
             <span *ngIf="!isBaseline && caseResultData">
               <span *ngIf="caseResultData.wcModification">
-                {{caseResultData.wcModification | number: '1.0-0' }}
+                {{caseResultData.wcModification | number: '1.1-1' }}
               </span>
               <span *ngIf="!caseResultData.wcBaseline">
                 <strong>&mdash; &mdash;</strong>

--- a/src/app/calculator/process-cooling/cooling-tower/cooling-tower-form/cooling-tower-form.component.ts
+++ b/src/app/calculator/process-cooling/cooling-tower/cooling-tower-form/cooling-tower-form.component.ts
@@ -130,7 +130,7 @@ export class CoolingTowerFormComponent implements OnInit {
   }
 
   changeHasDriftEliminator() {
-    if(this.form.controls.hasDriftEliminator.value == true) {
+    if(this.form.controls.hasDriftEliminator.value == 0) {
       this.form.patchValue({driftLossFactor: .2});
     } else {
       this.form.patchValue({driftLossFactor: .01});

--- a/src/app/calculator/process-cooling/cooling-tower/cooling-tower-results/cooling-tower-results.component.html
+++ b/src/app/calculator/process-cooling/cooling-tower/cooling-tower-results/cooling-tower-results.component.html
@@ -7,7 +7,7 @@
       <tr>
         <td class="bold w-50">Baseline Consumption</td>
         <td class="text-center w-50">
-          {{coolingTowerOutput.wcBaseline | number:'1.0-0'}} 
+          {{coolingTowerOutput.wcBaseline | number:'1.1-1'}} 
           <span *ngIf="settings.unitsOfMeasure != 'Metric'">kGal</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'">m<sup>3</sup></span>
         </td>
@@ -15,7 +15,7 @@
       <tr>
         <td class="bold w-50" >Modification Consumption</td>
         <td class="text-center w-50">
-          {{coolingTowerOutput.wcModification | number:'1.0-0'}}
+          {{coolingTowerOutput.wcModification | number:'1.1-1'}}
           <span *ngIf="settings.unitsOfMeasure != 'Metric'">kGal</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'">m<sup>3</sup></span>
         </td>
@@ -23,7 +23,7 @@
       <tr>
         <td class="bold w-50" >Water Savings</td>
         <td class="text-center w-50">
-          {{coolingTowerOutput.waterSavings | number: '1.0-0'}}
+          {{coolingTowerOutput.waterSavings | number: '1.1-1'}}
           <span *ngIf="settings.unitsOfMeasure != 'Metric'">kGal</span>
           <span *ngIf="settings.unitsOfMeasure == 'Metric'">m<sup>3</sup></span>
         </td>


### PR DESCRIPTION
connects #3742 
- Fix drift eliminator onChange, results decimal places

See below:

High priority - finished 4,5

Low priority
Can we limit cooling load's result to just two decimal places? For example 13.00 MMBtu/h
- This was already showing/limiting two places. Couldn't reproduce otherwise.
Can we add one decimal place to the water consumption and water savings results for Baseline, 
- Done