### PR TITLE
Issue 3822 (post-verification)

### DIFF
--- a/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form.service.ts
+++ b/src/app/calculator/furnaces/o2-enrichment/o2-enrichment-form.service.ts
@@ -155,7 +155,18 @@ export class O2EnrichmentFormService {
       },
     ];
 
+    if (settings.unitsOfMeasure == 'Metric') {
+      exampleInputs = this.convertExampleInputs(exampleInputs);
+    }
     return exampleInputs;
+  }
+
+  convertExampleInputs(inputs: Array<EnrichmentInput>): Array<EnrichmentInput> {
+    inputs.map((input: EnrichmentInput)  => {
+      input.inputData.combAirTemp = this.convertUnitsService.roundVal(this.convertUnitsService.value(input.inputData.combAirTemp).from('F').to('C'), 2);
+      input.inputData.name = `T = ${this.convertUnitsService.roundVal(input.inputData.combAirTemp, 0)}C`;
+    });
+    return inputs;
   }
 
   getResetData(): EnrichmentInputData {


### PR DESCRIPTION
Change request commented to issue 3852 "one unit conversion problem. "Combustion Air Preheat Temp" is not converting when "generate example"

connects #3822 

Convert example temp combAirTemp.
