### PR TITLE
fix treasure hunt modification results bug

### DIFF
--- a/src/app/calculator/compressed-air/compressed-air-pressure-reduction/compressed-air-pressure-reduction.service.ts
+++ b/src/app/calculator/compressed-air/compressed-air-pressure-reduction/compressed-air-pressure-reduction.service.ts
@@ -79,20 +79,21 @@ export class CompressedAirPressureReductionService {
   getResults(settings: Settings, baseline: Array<CompressedAirPressureReductionData>, modification?: Array<CompressedAirPressureReductionData>) {
     let baselineInpCpy: Array<CompressedAirPressureReductionData> = JSON.parse(JSON.stringify(baseline));
     let baselineResults: CompressedAirPressureReductionResult = this.calculate(baselineInpCpy, settings);
-    let modificationResults: CompressedAirPressureReductionResult;
-    let annualEnergySavings: number = 0;
-    let annualCostSavings: number = 0;
-
+    let modificationResults: CompressedAirPressureReductionResult = {
+      energyUse: 0,
+      energyCost: 0
+    };
     if (modification) {
       let modificationInpCpy: Array<CompressedAirPressureReductionData> = JSON.parse(JSON.stringify(modification));
       modificationResults = this.calculate(modificationInpCpy, settings);
+    }else{
+      modificationResults = baselineResults;
     }
-
     let compressedAirPressureReductionResults: CompressedAirPressureReductionResults = {
       baselineResults: baselineResults,
       modificationResults: modificationResults,
-      annualEnergySavings: annualEnergySavings,
-      annualCostSavings: annualCostSavings
+      annualEnergySavings: 0,
+      annualCostSavings: 0
     };
 
     if (modificationResults) {

--- a/src/app/calculator/compressed-air/compressed-air-reduction/compressed-air-reduction.service.ts
+++ b/src/app/calculator/compressed-air/compressed-air-reduction/compressed-air-reduction.service.ts
@@ -225,22 +225,26 @@ export class CompressedAirReductionService {
   getResults(settings: Settings, baseline: Array<CompressedAirReductionData>, modification?: Array<CompressedAirReductionData>): CompressedAirReductionResults {
     let baselineInpCpy: Array<CompressedAirReductionData> = JSON.parse(JSON.stringify(baseline));
     let baselineResults: CompressedAirReductionResult = this.calculate(baselineInpCpy, settings);
-    let modificationResults: CompressedAirReductionResult;
-    let annualEnergySavings: number = 0;
-    let annualCostSavings: number = 0;
-    let flowRateReduction: number = 0;
-    let annualConsumptionReduction: number = 0;
+    let modificationResults: CompressedAirReductionResult = {
+      energyUse: 0,
+      energyCost: 0,
+      flowRate: 0,
+      singleNozzeFlowRate: 0,
+      consumption: 0
+    };
     if (modification) {
       let modificationInpCpy: Array<CompressedAirReductionData> = JSON.parse(JSON.stringify(modification));
       modificationResults = this.calculate(modificationInpCpy, settings);
+    } else{
+      modificationResults = baselineResults;
     }
     let compressedAirReductionResults: CompressedAirReductionResults = {
       baselineResults: baselineResults,
       modificationResults: modificationResults,
-      annualCostSavings: annualCostSavings,
-      annualEnergySavings: annualEnergySavings,
-      annualFlowRateReduction: flowRateReduction,
-      annualConsumptionReduction: annualConsumptionReduction
+      annualCostSavings: 0,
+      annualEnergySavings: 0,
+      annualFlowRateReduction: 0,
+      annualConsumptionReduction: 0
     }
     if (modificationResults) {
       if (baselineInpCpy[0].utilityType == 0) {

--- a/src/app/calculator/steam/steam-reduction/steam-reduction.service.ts
+++ b/src/app/calculator/steam/steam-reduction/steam-reduction.service.ts
@@ -237,22 +237,24 @@ export class SteamReductionService {
   getResults(settings: Settings, baseline: Array<SteamReductionData>, modification?: Array<SteamReductionData>): SteamReductionResults {
     let baselineInpCpy: Array<SteamReductionData> = JSON.parse(JSON.stringify(baseline));
     let baselineResults: SteamReductionResult = this.calculate(baselineInpCpy, settings);
-    let modificationResults: SteamReductionResult;
-    let annualEnergySavings: number = 0;
-    let annualCostSavings: number = 0;
-    let annualSteamSavings: number = 0;
+    let modificationResults: SteamReductionResult = {
+      energyCost: 0,
+      energyUse: 0,
+      steamUse: 0
+    };
     if (modification) {
       let modificationInpCpy: Array<SteamReductionData> = JSON.parse(JSON.stringify(modification));
       modificationResults = this.calculate(modificationInpCpy, settings);
+    }else{
+      modificationResults = baselineResults;
     }
     let steamReductionResults: SteamReductionResults = {
       baselineResults: baselineResults,
       modificationResults: modificationResults,
-      annualCostSavings: annualCostSavings,
-      annualEnergySavings: annualEnergySavings,
-      annualSteamSavings: annualSteamSavings
+      annualCostSavings: 0,
+      annualEnergySavings: 0,
+      annualSteamSavings: 0
     };
-    // steamReductionResults = this.convertResults(steamReductionResults, settings);
     if (modificationResults) {
       steamReductionResults.annualEnergySavings = baselineResults.energyUse - modificationResults.energyUse;
       steamReductionResults.annualCostSavings = baselineResults.energyCost - modificationResults.energyCost;

--- a/src/app/calculator/utilities/electricity-reduction/electricity-reduction.service.ts
+++ b/src/app/calculator/utilities/electricity-reduction/electricity-reduction.service.ts
@@ -243,18 +243,22 @@ export class ElectricityReductionService {
   getResults(settings: Settings, baseline: Array<ElectricityReductionData>, modification?: Array<ElectricityReductionData>): ElectricityReductionResults {
     let baselineInpCpy: Array<ElectricityReductionData> = JSON.parse(JSON.stringify(baseline));
     let baselineResults: ElectricityReductionResult = this.calculate(baselineInpCpy, settings);
-    let modificationResults: ElectricityReductionResult;
-    let annualEnergySavings: number = 0;
-    let annualCostSavings: number = 0;
+    let modificationResults: ElectricityReductionResult = {
+      energyUse: 0,
+      energyCost: 0,
+      power: 0
+    };
     if (modification) {
       let modificationInpCpy: Array<ElectricityReductionData> = JSON.parse(JSON.stringify(modification));
       modificationResults = this.calculate(modificationInpCpy, settings);
+    }else{
+      modificationResults = baselineResults;
     }
     let naturalGasReductionResults: ElectricityReductionResults = {
       baselineResults: baselineResults,
       modificationResults: modificationResults,
-      annualCostSavings: annualCostSavings,
-      annualEnergySavings: annualEnergySavings
+      annualCostSavings: 0,
+      annualEnergySavings: 0
     }
     if (modificationResults) {
       naturalGasReductionResults.annualEnergySavings = baselineResults.energyUse - modificationResults.energyUse;

--- a/src/app/calculator/utilities/natural-gas-reduction/natural-gas-reduction.service.ts
+++ b/src/app/calculator/utilities/natural-gas-reduction/natural-gas-reduction.service.ts
@@ -239,18 +239,23 @@ export class NaturalGasReductionService {
   getResults(settings: Settings, baseline: Array<NaturalGasReductionData>, modification?: Array<NaturalGasReductionData>): NaturalGasReductionResults {
     let baselineInpCpy: Array<NaturalGasReductionData> = JSON.parse(JSON.stringify(baseline));
     let baselineResults: NaturalGasReductionResult = this.calculate(baselineInpCpy, settings);
-    let modificationResults: NaturalGasReductionResult;
-    let annualEnergySavings: number = 0;
-    let annualCostSavings: number = 0;
+    let modificationResults: NaturalGasReductionResult = {
+      energyUse: 0,
+      energyCost: 0,
+      heatFlow: 0,
+      totalFlow: 0
+    };
     if (modification) {
       let modificationInpCpy: Array<NaturalGasReductionData> = JSON.parse(JSON.stringify(modification));
       modificationResults = this.calculate(modificationInpCpy, settings);
+    }else{
+      modificationResults = baselineResults;
     }
     let naturalGasReductionResults: NaturalGasReductionResults = {
       baselineResults: baselineResults,
       modificationResults: modificationResults,
-      annualCostSavings: annualCostSavings,
-      annualEnergySavings: annualEnergySavings
+      annualCostSavings: 0,
+      annualEnergySavings: 0
     }
     naturalGasReductionResults = this.convertResults(naturalGasReductionResults, settings);
     if (modificationResults) {

--- a/src/app/calculator/utilities/water-reduction/water-reduction.service.ts
+++ b/src/app/calculator/utilities/water-reduction/water-reduction.service.ts
@@ -161,20 +161,24 @@ export class WaterReductionService {
   getResults(settings: Settings, baseline: Array<WaterReductionData>, modification?: Array<WaterReductionData>) {
     let baselineInpCpy: Array<WaterReductionData> = JSON.parse(JSON.stringify(baseline));
     let baselineResults: WaterReductionResult = this.calculate(baselineInpCpy, settings);
-    let modificationResults: WaterReductionResult;
-    let annualWaterSavings: number = 0;
-    let annualCostSavings: number = 0;
-
+    let modificationResults: WaterReductionResult = {
+      waterUse: 0,
+      waterCost: 0,
+      annualWaterSavings: 0,
+      costSavings: 0
+    };
     if (modification) {
       let modificationInpCpy: Array<WaterReductionData> = JSON.parse(JSON.stringify(modification));
       modificationResults = this.calculate(modificationInpCpy, settings);
+    } else {
+      modificationResults = baselineResults;
     }
 
     let waterReductionResults: WaterReductionResults = {
       baselineResults: baselineResults,
       modificationResults: modificationResults,
-      annualWaterSavings: annualWaterSavings,
-      annualCostSavings: annualCostSavings
+      annualWaterSavings: 0,
+      annualCostSavings: 0
     };
 
     if (modificationResults) {


### PR DESCRIPTION
connects #3964 

fixes bug that causes opportunity calculation errors for opportunities without modifications by setting the modification result to the baseline. (0 savings)