### PR TITLE
Issue 4138

### DIFF
--- a/src/app/phast/system-basics/system-basics.component.ts
+++ b/src/app/phast/system-basics/system-basics.component.ts
@@ -46,11 +46,15 @@ export class SystemBasicsComponent implements OnInit {
   }
 
   lossExists(phast: PHAST) {
-    if (phast.losses) {
-      return true;
-    } else {
-      return false;
+    let phastLosses: boolean = phast.losses && Object.keys(phast.losses).length !== 0;
+    let lossesExist = false;
+
+    if (phastLosses) {
+      // if a loss is added and removed, phast.losses object still has array
+      lossesExist = Object.values(phast.losses).some((lossArray: []) => lossArray.length > 0);
     }
+
+    return lossesExist;
   }
   //save changes to settings
   saveChanges(bool?: boolean) {


### PR DESCRIPTION
connects #4138 

- Allow user to change energy source when no losses exist

Should we refine how loss arrays are added to the PHAST object? Currently, we set an empty phast.losses object that will exist if you click over to the loss screen. Also if you create a loss and remove it, the loss array is still existing on the object. Seemed a little unexpected.

