### PR TITLE
PH excessAirWarnings undefined

### DIFF
--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-flue-gas-form/explore-flue-gas-form.component.ts
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-flue-gas-form/explore-flue-gas-form.component.ts
@@ -59,6 +59,8 @@ export class ExploreFlueGasFormComponent implements OnInit {
   }
 
   initData() {
+    this.baselineWarnings = {excessAirWarning: null, o2Warning: null};
+    this.modificationWarnings = {excessAirWarning: null, o2Warning: null};
     if (this.phast.losses.flueGasLosses[0].flueGasType === 'By Mass') {
       this.baselineFlueGas = this.phast.losses.flueGasLosses[0].flueGasByMass;
     } else {


### PR DESCRIPTION
Sets warnings null on init to avoid object undefined console errors. 

Both checkWarnings methods return currently, though it seems like the calculate event that's emitted while checking baseline warnings resets the component state before it can set this.modificationWarnings - so is undefined.