### PR TITLE
PH standalones - stop accessing -1 index

### DIFF
--- a/src/app/calculator/furnaces/atmosphere/atmosphere.service.ts
+++ b/src/app/calculator/furnaces/atmosphere/atmosphere.service.ts
@@ -117,7 +117,7 @@ export class AtmosphereService {
   }
 
   initDefaultEmptyInputs() {
-    let emptyBaselineData: AtmosphereLoss = this.initDefaultLoss(0);
+    let emptyBaselineData: AtmosphereLoss = this.initDefaultLoss(0, undefined);
     let baselineData: Array<AtmosphereLoss> = [emptyBaselineData];
     this.baselineData.next(baselineData);
     this.modificationData.next(undefined);
@@ -125,7 +125,22 @@ export class AtmosphereService {
 
   }
 
-  initDefaultLoss(index: number, hoursPerYear: number = 8760) {
+  initDefaultLoss(index: number, treasureHours: number, atmoshpereLoss?: AtmosphereLoss) {
+    let fuelCost: number = 0;
+    let availableHeat: number = 100;
+    let hoursPerYear = 8760;
+
+    if (atmoshpereLoss) {
+      fuelCost = atmoshpereLoss.fuelCost;
+      availableHeat = atmoshpereLoss.availableHeat;
+
+      if (treasureHours) {
+        hoursPerYear = treasureHours;
+      } else {
+        hoursPerYear = atmoshpereLoss.hoursPerYear;
+      }
+    }
+
     let defaultBaselineData: AtmosphereLoss = {
       atmosphereGas: 1,
       specificHeat: 0,
@@ -136,9 +151,9 @@ export class AtmosphereService {
       heatLoss: 0,
       name: 'Loss #' + (index + 1),
       energySourceType: 'Fuel',
-      fuelCost: 0,
+      fuelCost: fuelCost,
       hoursPerYear: hoursPerYear,    
-      availableHeat: 100,  
+      availableHeat: availableHeat,  
     };
 
     return defaultBaselineData;
@@ -206,24 +221,13 @@ export class AtmosphereService {
   addLoss(treasureHours: number, modificationExists: boolean) {
     let currentBaselineData: Array<AtmosphereLoss> = JSON.parse(JSON.stringify(this.baselineData.getValue()));
     let index = currentBaselineData.length;
-    let hoursPerYear = treasureHours? treasureHours : currentBaselineData[index - 1].hoursPerYear;
-    let baselineObj: AtmosphereLoss = this.initDefaultLoss(index, hoursPerYear);
-    if (index > 0) {
-      baselineObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-      baselineObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-    }
+    let baselineObj: AtmosphereLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
     currentBaselineData.push(baselineObj)
     this.baselineData.next(currentBaselineData);
     
     if (modificationExists) {
       let currentModificationData: Array<AtmosphereLoss> = this.modificationData.getValue();
-      let modificationObj: AtmosphereLoss = this.initDefaultLoss(index, hoursPerYear);
-      
-      if (index > 0) {
-        modificationObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-        modificationObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-      }
-
+      let modificationObj: AtmosphereLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
       currentModificationData.push(modificationObj);
       this.modificationData.next(currentModificationData);
     }

--- a/src/app/calculator/furnaces/charge-material/charge-material.service.ts
+++ b/src/app/calculator/furnaces/charge-material/charge-material.service.ts
@@ -148,15 +148,13 @@ export class ChargeMaterialService {
   addLoss(hoursPerYear: number, modificationExists: boolean) {
     let currentBaselineData: Array<ChargeMaterial> = JSON.parse(JSON.stringify(this.baselineData.getValue()));
     let index = currentBaselineData.length;
-    let chargeMaterialType = index == 0? 'Solid' : currentBaselineData[index - 1].chargeMaterialType;
-    let baselineObj: ChargeMaterial = this.initDefaultLoss(index, chargeMaterialType);
+    let baselineObj: ChargeMaterial = this.initDefaultLoss(index, currentBaselineData[0]);
     currentBaselineData.push(baselineObj)
     this.baselineData.next(currentBaselineData);
     
     if (modificationExists) {
       let currentModificationData: Array<ChargeMaterial> = this.modificationData.getValue();
-      let modificationObj: ChargeMaterial = this.initDefaultLoss(index, chargeMaterialType);
-
+      let modificationObj: ChargeMaterial = this.initDefaultLoss(index, currentBaselineData[0]);
       currentModificationData.push(modificationObj);
       this.modificationData.next(currentModificationData);
     }
@@ -230,7 +228,7 @@ export class ChargeMaterialService {
   }
 
   initDefaultEmptyInputs() {
-    let emptyBaselineData = this.initDefaultLoss(0, 'Solid');
+    let emptyBaselineData = this.initDefaultLoss(0, undefined);
 
     let energyData: EnergyData = {
       energySourceType: "Fuel",
@@ -246,7 +244,9 @@ export class ChargeMaterialService {
     this.energySourceType.next('Fuel');
   }
 
-  initDefaultLoss(index: number, materialType: string) {
+  initDefaultLoss(index: number, chargeMaterial?: ChargeMaterial) {
+    let materialType = chargeMaterial? chargeMaterial.chargeMaterialType : 'Solid';
+
     let defaultLoss: ChargeMaterial = {
       chargeMaterialType: materialType,
       liquidChargeMaterial: undefined,

--- a/src/app/calculator/furnaces/fixture/fixture.service.ts
+++ b/src/app/calculator/furnaces/fixture/fixture.service.ts
@@ -119,7 +119,7 @@ export class FixtureService {
   }
 
   initDefaultEmptyInputs() {
-    let emptyBaselineData: FixtureLoss = this.initDefaultLoss(0);
+    let emptyBaselineData: FixtureLoss = this.initDefaultLoss(0, undefined);
     let baselineData: Array<FixtureLoss> = [emptyBaselineData];
     this.baselineData.next(baselineData);
     this.modificationData.next(undefined);
@@ -127,7 +127,22 @@ export class FixtureService {
 
   }
 
-  initDefaultLoss(index: number, hoursPerYear: number = 8760) {
+  initDefaultLoss(index: number, treasureHours: number, fixtureLoss?: FixtureLoss) {
+    let fuelCost: number = 0;
+    let availableHeat: number = 100;
+    let hoursPerYear = 8760;
+
+    if (fixtureLoss) {
+      fuelCost = fixtureLoss.fuelCost;
+      availableHeat = fixtureLoss.availableHeat;
+
+      if (treasureHours) {
+        hoursPerYear = treasureHours;
+      } else {
+        hoursPerYear = fixtureLoss.hoursPerYear;
+      }
+    }
+
     let defaultBaselineData: FixtureLoss = {
       specificHeat: 0,
       feedRate: 0,
@@ -138,9 +153,9 @@ export class FixtureService {
       heatLoss: 0,
       name: 'Loss #' + (index + 1),
       energySourceType: 'Fuel',
-      fuelCost: 0,
+      fuelCost: fuelCost,
       hoursPerYear: hoursPerYear,    
-      availableHeat: 100,  
+      availableHeat: availableHeat,  
     };
 
     return defaultBaselineData;
@@ -197,25 +212,13 @@ export class FixtureService {
   addLoss(treasureHours, modificationExists: boolean) {
     let currentBaselineData: Array<FixtureLoss> = JSON.parse(JSON.stringify(this.baselineData.getValue()));
     let index = currentBaselineData.length;
-    let hoursPerYear = treasureHours? treasureHours : currentBaselineData[index - 1].hoursPerYear;
-    let baselineObj: FixtureLoss = this.initDefaultLoss(index, hoursPerYear);
-    
-    if (index > 0) {
-      baselineObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-      baselineObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-    }
+    let baselineObj: FixtureLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
     currentBaselineData.push(baselineObj)
     this.baselineData.next(currentBaselineData);
     
     if (modificationExists) {
       let currentModificationData: Array<FixtureLoss> = this.modificationData.getValue();
-      let modificationObj: FixtureLoss = this.initDefaultLoss(index, hoursPerYear);
-      
-      if (index > 0) {
-        modificationObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-        modificationObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-      }
-
+      let modificationObj: FixtureLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
       currentModificationData.push(modificationObj);
       this.modificationData.next(currentModificationData);
     }

--- a/src/app/calculator/furnaces/opening/opening.service.ts
+++ b/src/app/calculator/furnaces/opening/opening.service.ts
@@ -106,25 +106,13 @@ export class OpeningService {
   addLoss(treasureHours: number, modificationExists: boolean) {
     let currentBaselineData: Array<OpeningLoss> = JSON.parse(JSON.stringify(this.baselineData.getValue()));
     let index = currentBaselineData.length;
-    
-    let hoursPerYear = treasureHours? treasureHours : currentBaselineData[index - 1].hoursPerYear;
-    let baselineObj: OpeningLoss = this.initDefaultLoss(index, hoursPerYear);
-    if (index > 0) {
-      baselineObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-      baselineObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-    }
+    let baselineObj: OpeningLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
     currentBaselineData.push(baselineObj)
     this.baselineData.next(currentBaselineData);
     
     if (modificationExists) {
       let currentModificationData: Array<OpeningLoss> = this.modificationData.getValue();
-      let modificationObj: OpeningLoss = this.initDefaultLoss(index, hoursPerYear);
-      
-      if (index > 0) {
-        modificationObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-        modificationObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-      }
-
+      let modificationObj: OpeningLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
       currentModificationData.push(modificationObj);
       this.modificationData.next(currentModificationData);
     }
@@ -143,7 +131,7 @@ export class OpeningService {
   }
 
   initDefaultEmptyInputs() {
-    let emptyBaselineData: OpeningLoss = this.initDefaultLoss(0);
+    let emptyBaselineData: OpeningLoss = this.initDefaultLoss(0, undefined);
     this.modificationData.next(undefined);
     this.energySourceType.next('Fuel');
     this.baselineData.next([emptyBaselineData]);
@@ -168,7 +156,22 @@ export class OpeningService {
     }
   }
 
-  initDefaultLoss(index: number, hoursPerYear: number = 8760) {
+  initDefaultLoss(index: number, treasureHours: number, openingLoss?: OpeningLoss) {
+    let fuelCost: number = 0;
+    let availableHeat: number = 100;
+    let hoursPerYear = 8760;
+
+    if (openingLoss) {
+      fuelCost = openingLoss.fuelCost;
+      availableHeat = openingLoss.availableHeat;
+
+      if (treasureHours) {
+        hoursPerYear = treasureHours;
+      } else {
+        hoursPerYear = openingLoss.hoursPerYear;
+      }
+    }
+
     let defaultBaselineLoss: OpeningLoss = {
       numberOfOpenings: 1,
       emissivity: .9,
@@ -182,10 +185,10 @@ export class OpeningService {
       heightOfOpening: 0,
       openingTotalArea: 0,
       heatLoss: 0,
-      fuelCost: 3.99,
+      fuelCost: fuelCost,
       hoursPerYear: hoursPerYear,
       energySourceType: 'Fuel',
-      availableHeat: 100,
+      availableHeat: availableHeat,
       name: 'Loss #' + (index + 1),
       
     };

--- a/src/app/calculator/furnaces/wall/wall.service.ts
+++ b/src/app/calculator/furnaces/wall/wall.service.ts
@@ -114,14 +114,29 @@ export class WallService {
   }
 
   initDefaultEmptyInputs() {
-    let emptyBaselineData: WallLoss = this.initDefaultLoss(0);
+    let emptyBaselineData: WallLoss = this.initDefaultLoss(0, undefined);
     let baselineData: Array<WallLoss> = [emptyBaselineData];
     this.modificationData.next(undefined);
     this.energySourceType.next('Fuel');
     this.baselineData.next(baselineData);
   }
 
-  initDefaultLoss(index: number, hoursPerYear: number = 8760) {
+  initDefaultLoss(index: number, treasureHours: number, wallLoss?: WallLoss) {
+    let fuelCost: number = 0;
+    let availableHeat: number = 100;
+    let hoursPerYear = 8760;
+
+    if (wallLoss) {
+      fuelCost = wallLoss.fuelCost;
+      availableHeat = wallLoss.availableHeat;
+
+      if (treasureHours) {
+        hoursPerYear = treasureHours;
+      } else {
+        hoursPerYear = wallLoss.hoursPerYear;
+      }
+    }
+
     let defaultBaselineLoss: WallLoss = {
       surfaceArea: 0,
       surfaceTemperature: 0,
@@ -131,10 +146,10 @@ export class WallService {
       surfaceShape: 3,
       conditionFactor: 1.394,
       surfaceEmissivity: 0.9,
-      availableHeat: 100,
+      availableHeat: availableHeat,
       name: 'Loss #' + (index + 1),
       hoursPerYear: hoursPerYear,
-      fuelCost: undefined,
+      fuelCost: fuelCost,
       energySourceType: 'Fuel'
     };
 
@@ -205,24 +220,13 @@ export class WallService {
   addLoss(treasureHours: number, modificationExists: boolean) {
     let currentBaselineData: Array<WallLoss> = JSON.parse(JSON.stringify(this.baselineData.getValue()));
     let index = currentBaselineData.length;
-
-    let hoursPerYear = treasureHours? treasureHours : currentBaselineData[index - 1].hoursPerYear;
-    let baselineObj: WallLoss = this.initDefaultLoss(index, hoursPerYear);
-    if (index > 0) {
-      baselineObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-      baselineObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-    }
+    let baselineObj: WallLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
     currentBaselineData.push(baselineObj)
     this.baselineData.next(currentBaselineData);
     
     if (modificationExists) {
       let currentModificationData: Array<WallLoss> = this.modificationData.getValue();
-      let modificationObj: WallLoss = this.initDefaultLoss(index, hoursPerYear);
-      
-      if (index > 0) {
-        modificationObj.fuelCost = currentBaselineData[index - 1].fuelCost;
-        modificationObj.availableHeat = currentBaselineData[index - 1].availableHeat;
-      }
+      let modificationObj: WallLoss = this.initDefaultLoss(index, treasureHours, currentBaselineData[0]);
       currentModificationData.push(modificationObj);
       this.modificationData.next(currentModificationData);
     }


### PR DESCRIPTION
Don't access -1 index on losses array. Pass undefined loss object instead...
 
This follows up a leakage PR review last week. Adding the same change to other PH calcs.

