### PR TITLE
issue-4345

### DIFF
--- a/src/app/calculator/fans/fan-analysis/fan-analysis-form/fan-info-form/fan-info-form.component.html
+++ b/src/app/calculator/fans/fan-analysis/fan-analysis-form/fan-info-form/fan-info-form.component.html
@@ -64,6 +64,8 @@
           {{ratedInfoForm.controls.globalBarometricPressure.errors.min.min}}.</span>
       </span>
     </div>
+
+    <div *ngIf="!inModal">
     <div class="form-group">
       <label for="fanSpeedCorrected">Corrected Fan Speed (N<sub>c</sub>)</label>
       <div class="input-group">
@@ -111,6 +113,8 @@
           {{ratedInfoForm.controls.pressureBarometricCorrected.errors.min.min}}.</span>
       </span>
     </div>
+  </div>
+  
     <div class="form-group">
       <label for="includesEvase">Rated Fan Performance Includes Evase</label>
       <div class="input-group">

--- a/src/app/calculator/fans/fan-analysis/fan-analysis-form/fan-info-form/fan-info-form.component.ts
+++ b/src/app/calculator/fans/fan-analysis/fan-analysis-form/fan-info-form/fan-info-form.component.ts
@@ -14,6 +14,8 @@ import { Subscription } from 'rxjs';
 export class FanInfoFormComponent implements OnInit {
   @Input()
   settings: Settings;
+  @Input()
+  inModal: boolean;
 
   ratedInfoForm: FormGroup;
 

--- a/src/app/fsat/calculate-pressures/calculate-flow-pressure/calculate-flow-pressure.component.html
+++ b/src/app/fsat/calculate-pressures/calculate-flow-pressure/calculate-flow-pressure.component.html
@@ -1,7 +1,7 @@
 <div class="panel-container d-flex w-100">
   <div class="panel-column flow-pressure-form w-50 scroll-item pl-1 pr-1" [ngStyle]="{'height.px': bodyHeight}">
     <app-calculate-flow-pressure-banner [settings]="settings"></app-calculate-flow-pressure-banner>
-    <app-fan-info-form *ngIf="stepTab == 'fan-info'" [settings]="settings"></app-fan-info-form>
+    <app-fan-info-form *ngIf="stepTab == 'fan-info'" [inModal]="true" [settings]="settings"></app-fan-info-form>
     <app-plane-data-form *ngIf="stepTab == 'plane-data'" [settings]="settings"></app-plane-data-form>
   </div>
   <div class="w-50 help-panel scroll-item" [ngStyle]="{'height.px': bodyHeight}">

--- a/src/app/fsat/calculate-pressures/calculate-flow-pressure/calculate-flow-pressure.component.ts
+++ b/src/app/fsat/calculate-pressures/calculate-flow-pressure/calculate-flow-pressure.component.ts
@@ -3,7 +3,7 @@ import { Settings } from '../../../shared/models/settings';
 import { FanAnalysisService } from '../../../calculator/fans/fan-analysis/fan-analysis.service';
 import { ConvertFanAnalysisService } from '../../../calculator/fans/fan-analysis/convert-fan-analysis.service';
 import { Subscription } from 'rxjs';
-import { FSAT, PlaneResults } from '../../../shared/models/fans';
+import { FieldData, FSAT, PlaneResults } from '../../../shared/models/fans';
 import { FanInfoFormService } from '../../../calculator/fans/fan-analysis/fan-analysis-form/fan-info-form/fan-info-form.service';
 import { PlaneDataFormService } from '../../../calculator/fans/fan-analysis/fan-analysis-form/plane-data-form/plane-data-form.service';
 
@@ -19,8 +19,8 @@ export class CalculateFlowPressureComponent implements OnInit {
   bodyHeight: number;
   @Input()
   fsat: FSAT;
-  @Output('updateFsatCopy')
-  updateFsatCopy = new EventEmitter<FSAT>();
+  @Output('updateFieldData')
+  updateFieldData = new EventEmitter<FieldData>();
   @Output('emitInvalid')
   emitInvalid = new EventEmitter<boolean>();
 
@@ -38,8 +38,14 @@ export class CalculateFlowPressureComponent implements OnInit {
     this.fanAnalysisService.inputData = this.fanAnalysisService.getExampleData();
     this.fanAnalysisService.inputData = this.convertFanAnalysisService.convertFan203Inputs(this.fanAnalysisService.inputData, this.settings);
 
+    if (this.fsat.baseGasDensity) {
+      this.fanAnalysisService.inputData.BaseGasDensity = this.fsat.baseGasDensity;
+    }
     if (this.fsat.fieldData.fanRatedInfo) {
       this.fanAnalysisService.inputData.FanRatedInfo = this.fsat.fieldData.fanRatedInfo;
+      this.fanAnalysisService.inputData.FanRatedInfo.fanSpeedCorrected = this.fsat.fieldData.fanRatedInfo.fanSpeed
+      this.fanAnalysisService.inputData.FanRatedInfo.pressureBarometricCorrected = this.fsat.fieldData.fanRatedInfo.globalBarometricPressure;
+      this.fanAnalysisService.inputData.FanRatedInfo.densityCorrected = this.fsat.baseGasDensity.gasDensity;
     }
     if (this.fsat.fieldData.planeData) {
       this.fanAnalysisService.inputData.PlaneData = this.fsat.fieldData.planeData;
@@ -87,6 +93,6 @@ export class CalculateFlowPressureComponent implements OnInit {
     } else {
       this.emitInvalid.emit(true);
     }
-    this.updateFsatCopy.emit(this.fsat);
+    this.updateFieldData.emit(this.fsat.fieldData);
   }
 }

--- a/src/app/fsat/fan-field-data/fan-field-data.component.html
+++ b/src/app/fsat/fan-field-data/fan-field-data.component.html
@@ -233,7 +233,7 @@
           [bodyHeight]="bodyHeight"></app-calculate-outlet-pressure>
         <app-calculate-flow-pressure *ngIf="pressureCalcType == 'flow' && bodyHeight" [settings]="settings"
           [bodyHeight]="bodyHeight" [fsat]="modalFsatCopy" 
-          (emitInvalid)="setCalcInvalid($event)" (updateFsatCopy)="updateTempFsatCopy($event)">
+          (emitInvalid)="setCalcInvalid($event)" (updateFieldData)="updateFsatWithModalData($event)">
         </app-calculate-flow-pressure>
       </div>
       <div class="modal-footer fsat justify-content-between">

--- a/src/app/fsat/fan-field-data/fan-field-data.component.ts
+++ b/src/app/fsat/fan-field-data/fan-field-data.component.ts
@@ -243,10 +243,9 @@ export class FanFieldDataComponent implements OnInit {
   }
 
   showAmcaModal() {
-    if (this.fsat.tempFsatCopy) {
-      this.modalFsatCopy = this.fsat.tempFsatCopy;
-    } else {
-      this.modalFsatCopy = JSON.parse(JSON.stringify(this.fsat));
+    this.modalFsatCopy = JSON.parse(JSON.stringify(this.fsat));
+    if (this.fsat.modalFieldData) {
+      this.modalFsatCopy.fieldData = this.fsat.modalFieldData;
     }
     this.pressureCalcType = 'flow';
     this.fsatService.modalOpen.next(true);
@@ -260,7 +259,7 @@ export class FanFieldDataComponent implements OnInit {
   }
 
   resetModalData() {
-    this.fsat.tempFsatCopy = undefined;
+    this.fsat.modalFieldData = undefined;
     this.disableApplyData = false;
     this.hidePressureModal();
   }
@@ -288,12 +287,12 @@ export class FanFieldDataComponent implements OnInit {
     this.inletPressureCopy = inletPressureData;
   }
 
-  saveFlowAndPressure(fsat: FSAT) {
-    this.fieldData.inletPressure = fsat.fieldData.inletPressure;
-    this.fieldData.outletPressure = fsat.fieldData.outletPressure;
-    this.fieldData.flowRate = fsat.fieldData.flowRate;
-    this.fieldData.fanRatedInfo = fsat.fieldData.fanRatedInfo;
-    this.fieldData.planeData = fsat.fieldData.planeData;
+  saveFlowAndPressure(fieldData: FieldData) {
+    this.fieldData.inletPressure = fieldData.inletPressure;
+    this.fieldData.outletPressure = fieldData.outletPressure;
+    this.fieldData.flowRate = fieldData.flowRate;
+    this.fieldData.fanRatedInfo = fieldData.fanRatedInfo;
+    this.fieldData.planeData = fieldData.planeData;
     this.fieldDataForm.patchValue({
       inletPressure: this.fieldData.inletPressure,
       outletPressure: this.fieldData.outletPressure,
@@ -302,8 +301,8 @@ export class FanFieldDataComponent implements OnInit {
     this.save();
   }
 
-  updateTempFsatCopy(modalFsat: FSAT) {
-    this.fsat.tempFsatCopy = modalFsat;
+  updateFsatWithModalData(modalFieldData: FieldData) {
+    this.fsat.modalFieldData = JSON.parse(JSON.stringify(modalFieldData));
   }
 
   setCalcInvalid(isCalcValid: boolean) {
@@ -312,8 +311,8 @@ export class FanFieldDataComponent implements OnInit {
 
   applyModalData() {
     if (this.pressureCalcType === 'flow') {
-      this.saveFlowAndPressure(this.fsat.tempFsatCopy);
-      this.fsat.tempFsatCopy = undefined;
+      this.saveFlowAndPressure(this.fsat.modalFieldData);
+      this.fsat.modalFieldData = undefined;
     } else if (this.pressureCalcType === 'inlet') {
       this.saveInletPressure(this.inletPressureCopy);
     } else if (this.pressureCalcType === 'outlet') {

--- a/src/app/shared/models/fans.ts
+++ b/src/app/shared/models/fans.ts
@@ -16,7 +16,7 @@ export interface FSAT {
   operatingHours?: OperatingHours;
   outputs?: FsatOutput;
   valid?: FsatValid;
-  tempFsatCopy?: FSAT;
+  modalFieldData?: FieldData;
 }
 
 export interface FsatValid {


### PR DESCRIPTION
connects #4345 #4354 

- Hide corrected fields and use defaults
- Use assessment gas density in modal

Changed tempFsatCopy to modalFieldData - modal only assigning to field data so don't need to save the whole FSAT object