### PR TITLE
Issue 4454

### DIFF
--- a/src/app/calculator/compressed-air/air-leak/air-leak.component.ts
+++ b/src/app/calculator/compressed-air/air-leak/air-leak.component.ts
@@ -102,7 +102,7 @@ export class AirLeakComponent implements OnInit, AfterViewInit {
   }
 
   save() {
-    this.emitSave.emit({ airLeakSurveyInput: this.airLeakService.airLeakInput.getValue() });
+    this.emitSave.emit({ airLeakSurveyInput: this.airLeakService.airLeakInput.getValue(), opportunityType: 'air-leak-survey'});
   }
 
   cancel() {

--- a/src/app/shared/models/treasure-hunt.ts
+++ b/src/app/shared/models/treasure-hunt.ts
@@ -90,6 +90,7 @@ export interface OtherCostItem {
     description?: string
 }
 
+
 export interface SteamReductionTreasureHunt {
     baseline: Array<SteamReductionData>;
     modification: Array<SteamReductionData>;
@@ -170,11 +171,25 @@ export interface WastewaterReductionTreasureHunt {
     selected?: boolean;
 }
 
-export interface AirLeakSurveyTreasureHunt {
+export interface AirLeakSurveyTreasureHunt extends TreasureHuntOpportunity {
     airLeakSurveyInput: AirLeakSurveyInput,
-    opportunitySheet?: OpportunitySheet,
-    selected?: boolean
 }
+
+export interface TreasureHuntOpportunity {
+    opportunitySheet?: OpportunitySheet
+    selected?: boolean;
+    // opportunityType == calculator selector/name
+    opportunityType: string;
+}
+
+export interface TreasureHuntOpportunityResults {
+    costSavings: number,
+    energySavings: number,
+    baselineCost: number,
+    modificationCost: number,
+    utilityType: string,
+    opportunityDefaultName?: string
+  }
 
 export interface OpportunitySheetResults {
     electricityResults: OpportunitySheetResult,

--- a/src/app/treasure-hunt/calculators/calculators.component.html
+++ b/src/app/treasure-hunt/calculators/calculators.component.html
@@ -52,8 +52,13 @@
   [operatingHours]="treasureHunt.operatingHours">
 </app-tank-insulation-reduction>
 
-<app-air-leak *ngIf="selectedCalc == 'air-leak-survey'" [inTreasureHunt]="true"
+<!-- <app-air-leak *ngIf="selectedCalc == 'air-leak-survey'" [inTreasureHunt]="true"
   (emitSave)="saveAirLeakSurvey($event)" (emitCancel)="cancelAirLeakSurvey()" [settings]="settings"
+  [operatingHours]="treasureHunt.operatingHours">
+</app-air-leak> -->
+
+<app-air-leak *ngIf="selectedCalc == 'air-leak-survey'" [inTreasureHunt]="true"
+  (emitSave)="saveOpportunity($event)" (emitCancel)="cancelTreasureHuntOpportunity()" [settings]="settings"
   [operatingHours]="treasureHunt.operatingHours">
 </app-air-leak>
 

--- a/src/app/treasure-hunt/calculators/calculators.component.ts
+++ b/src/app/treasure-hunt/calculators/calculators.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit, Input, ViewChild } from '@angular/core';
 import { CalculatorsService } from './calculators.service';
 import { Subscription } from 'rxjs';
-import { TreasureHunt, LightingReplacementTreasureHunt, WaterReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, CompressedAirReductionTreasureHunt, ElectricityReductionTreasureHunt, NaturalGasReductionTreasureHunt, MotorDriveInputsTreasureHunt, ReplaceExistingMotorTreasureHunt, OpportunitySheet, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt } from '../../shared/models/treasure-hunt';
+import { TreasureHunt, LightingReplacementTreasureHunt, WaterReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, CompressedAirReductionTreasureHunt, ElectricityReductionTreasureHunt, NaturalGasReductionTreasureHunt, MotorDriveInputsTreasureHunt, ReplaceExistingMotorTreasureHunt, OpportunitySheet, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, TreasureHuntOpportunity } from '../../shared/models/treasure-hunt';
 import { Settings } from '../../shared/models/settings';
 import { TreasureHuntService } from '../treasure-hunt.service';
 import { ModalDirective } from 'ngx-bootstrap';
+import { AirLeakTreasureHuntService } from '../treasure-hunt-calculator-services/air-leak-treasure-hunt.service';
+import { OpportunityCardData, OpportunityCardsService } from '../treasure-chest/opportunity-cards/opportunity-cards.service';
 
 @Component({
   selector: 'app-calculators',
@@ -15,23 +17,22 @@ export class CalculatorsComponent implements OnInit {
   @Input()
   settings: Settings;
 
-
   @ViewChild('saveCalcModal', { static: false }) public saveCalcModal: ModalDirective;
   @ViewChild('opportunitySheetModal', { static: false }) public opportunitySheetModal: ModalDirective;
 
-  lightingReplacementTreasureHunt: LightingReplacementTreasureHunt;
-  replaceExistingMotorsTreasureHunt: ReplaceExistingMotorTreasureHunt;
-  motorDriveTreasureHunt: MotorDriveInputsTreasureHunt;
-  naturalGasReductionTreasureHunt: NaturalGasReductionTreasureHunt;
-  electricityReduction: ElectricityReductionTreasureHunt;
-  compressedAirReduction: CompressedAirReductionTreasureHunt;
-  compressedAirPressureReduction: CompressedAirPressureReductionTreasureHunt;
-  waterReduction: WaterReductionTreasureHunt;
-  standaloneOpportunitySheet: OpportunitySheet;
-  steamReduction: SteamReductionTreasureHunt;
-  pipeInsulationReduction: PipeInsulationReductionTreasureHunt;
-  tankInsulationReduction: TankInsulationReductionTreasureHunt;
-  airLeakSurveyTreasureHunt: AirLeakSurveyTreasureHunt;
+  // lightingReplacementTreasureHunt: LightingReplacementTreasureHunt;
+  // replaceExistingMotorsTreasureHunt: ReplaceExistingMotorTreasureHunt;
+  // motorDriveTreasureHunt: MotorDriveInputsTreasureHunt;
+  // naturalGasReductionTreasureHunt: NaturalGasReductionTreasureHunt;
+  // electricityReduction: ElectricityReductionTreasureHunt;
+  // compressedAirReduction: CompressedAirReductionTreasureHunt;
+  // compressedAirPressureReduction: CompressedAirPressureReductionTreasureHunt;
+  // waterReduction: WaterReductionTreasureHunt;
+  // standaloneOpportunitySheet: OpportunitySheet;
+  // steamReduction: SteamReductionTreasureHunt;
+  // pipeInsulationReduction: PipeInsulationReductionTreasureHunt;
+  // tankInsulationReduction: TankInsulationReductionTreasureHunt;
+  // airLeakSurveyTreasureHunt: AirLeakSurveyTreasureHunt;
 
   selectedCalc: string;
   selectedCalcSubscription: Subscription;
@@ -41,7 +42,13 @@ export class CalculatorsComponent implements OnInit {
   calculatorOpportunitySheet: OpportunitySheet;
   mainTab: string;
   mainTabSub: Subscription;
-  constructor(private calculatorsService: CalculatorsService, private treasureHuntService: TreasureHuntService) { }
+  currentOpportunity: TreasureHuntOpportunity;
+  standaloneOpportunitySheet: OpportunitySheet;
+
+  constructor(private calculatorsService: CalculatorsService,
+    private opportunityCardsService: OpportunityCardsService,
+    private airLeakTreasureHuntService: AirLeakTreasureHuntService,
+    private treasureHuntService: TreasureHuntService) { }
 
   ngOnInit() {
     this.selectedCalcSubscription = this.calculatorsService.selectedCalc.subscribe(val => {
@@ -84,36 +91,9 @@ export class CalculatorsComponent implements OnInit {
     }
   }
 
-  confirmSaveCalc() {
-    if (this.selectedCalc == 'lighting-replacement') {
-      this.confirmSaveLighting();
-    } else if (this.selectedCalc == 'replace-existing') {
-      this.confirmSaveReplaceExisting();
-    } else if (this.selectedCalc == 'motor-drive') {
-      this.confirmSaveMotorDrive();
-    } else if (this.selectedCalc == 'natural-gas-reduction') {
-      this.confirmSaveNaturalGasReduction();
-    } else if (this.selectedCalc == 'electricity-reduction') {
-      this.confirmSaveElectricityReduction();
-    } else if (this.selectedCalc == 'compressed-air-reduction') {
-      this.confirmCompressedAirReduction();
-    } else if (this.selectedCalc == 'compressed-air-pressure-reduction') {
-      this.confirmCompressedAirPressureReduction();
-    } else if (this.selectedCalc == 'water-reduction') {
-      this.confirmSaveWaterReduction();
-    } else if (this.selectedCalc == 'opportunity-sheet') {
-      this.confirmSaveStandaloneOpportunitySheet();
-    } else if (this.selectedCalc == 'steam-reduction') {
-      this.confirmSaveSteamReduction();
-    } else if (this.selectedCalc == 'pipe-insulation-reduction') {
-      this.confirmPipeInsulationReduction();
-    } else if (this.selectedCalc == 'tank-insulation-reduction'){
-      this.confirmTankInsulationReduction();
-    } else if(this.selectedCalc == 'air-leak-survey'){
-      this.confirmAirLeakSurvey();
-    }
-  }
-  initSaveCalc() {
+
+  saveOpportunity(treasureHuntOpportunity: TreasureHuntOpportunity) {
+    this.currentOpportunity = treasureHuntOpportunity;
     this.calculatorOpportunitySheet = this.calculatorsService.calcOpportunitySheet;
     if (this.mainTab == 'find-treasure' && this.selectedCalc != 'opportunity-sheet') {
       this.showOpportunitySheetModal();
@@ -121,243 +101,66 @@ export class CalculatorsComponent implements OnInit {
       this.showSaveCalcModal();
     }
   }
-  finishSaveCalc() {
-    this.hideSaveCalcModal();
+
+  confirmSaveCalc() {
+    this.currentOpportunity.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+    this.currentOpportunity.selected = true;
+    if (this.calculatorsService.isNewOpportunity == true) {
+      this.saveTreasureHuntOpportunity();
+    } else {
+      this.updateTreasureHuntOpportunity();
+    }
+    this.finishSaveCalc();
+  }
+
+
+  saveTreasureHuntOpportunity() {
+    let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+    if (this.selectedCalc === 'air-leak-survey') {
+      let airLeakSurveyOpportunity = this.currentOpportunity as AirLeakSurveyTreasureHunt;
+      treasureHunt = this.airLeakTreasureHuntService.saveTreasureHuntOpportunity(airLeakSurveyOpportunity, treasureHunt);
+    } else if (this.selectedCalc === '') {
+
+    }
+
+    this.treasureHuntService.treasureHunt.next(treasureHunt);
+  }
+
+  cancelTreasureHuntOpportunity() {
+    this.calculatorsService.calcOpportunitySheet = undefined
+
+    if (this.selectedCalc === 'air-leak-survey') {
+      this.airLeakTreasureHuntService.resetCalculatorInputs();
+    } else if (this.selectedCalc === '') {
+
+    }
+
+    this.calculatorsService.itemIndex = undefined;
     this.calculatorsService.selectedCalc.next('none');
   }
 
-  //lighting
-  cancelEditLighting() {
-    this.calculatorsService.cancelLightingCalc();
-  }
-  saveLighting(lightingReplacementTreasureHunt: LightingReplacementTreasureHunt) {
-    this.lightingReplacementTreasureHunt = lightingReplacementTreasureHunt;
-    this.initSaveCalc();
-  }
-  confirmSaveLighting() {
-    this.lightingReplacementTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
-    this.lightingReplacementTreasureHunt.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewLightingReplacementTreasureHuntItem(this.lightingReplacementTreasureHunt);
-    } else {
-      this.treasureHuntService.editLightingReplacementTreasureHuntItem(this.lightingReplacementTreasureHunt, this.calculatorsService.itemIndex);
+  updateTreasureHuntOpportunity() {
+    let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+    // Sending card updates to OppCard Service to eliminate circular dep in TH calc servies
+    let updatedCard: OpportunityCardData;
+    if (this.selectedCalc === 'air-leak-survey') {
+      let airLeakSurveyOpportunity = this.currentOpportunity as AirLeakSurveyTreasureHunt;
+      // treasureHunt = this.airLeakTreasureHuntService.editAirLeakSurveyItem(airLeakSurveyOpportunity, treasureHunt, this.calculatorsService.itemIndex, this.settings);
+      treasureHunt.airLeakSurveys[this.calculatorsService.itemIndex] = airLeakSurveyOpportunity;
+      updatedCard = this.opportunityCardsService.getAirLeakSurveyCardData(airLeakSurveyOpportunity, this.settings, this.calculatorsService.itemIndex, treasureHunt.currentEnergyUsage);
+    } else if (this.selectedCalc === '') {
+      
     }
-    this.finishSaveCalc();
+    
+    this.opportunityCardsService.updatedOpportunityCard.next(updatedCard);
+    this.treasureHuntService.treasureHunt.next(treasureHunt);
   }
-
-  //replace existing
-  cancelReplaceExisting() {
-    this.calculatorsService.cancelReplaceExistingMotors();
-  }
-  saveReplaceExisting(replaceExistingTreasureHunt: ReplaceExistingMotorTreasureHunt) {
-    this.replaceExistingMotorsTreasureHunt = replaceExistingTreasureHunt;
-    this.initSaveCalc();
-  }
-  confirmSaveReplaceExisting() {
-    this.replaceExistingMotorsTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
-    this.replaceExistingMotorsTreasureHunt.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewReplaceExistingMotorsItem(this.replaceExistingMotorsTreasureHunt);
-    } else {
-      this.treasureHuntService.editReplaceExistingMotorsItem(this.replaceExistingMotorsTreasureHunt, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //motor drive
-  cancelMotorDrive() {
-    this.calculatorsService.cancelMotorDrive();
-  }
-  saveMotorDrive(motorDriveTreasureHunt: MotorDriveInputsTreasureHunt) {
-    this.motorDriveTreasureHunt = motorDriveTreasureHunt;
-    this.initSaveCalc();
-  }
-  confirmSaveMotorDrive() {
-    this.motorDriveTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
-    this.motorDriveTreasureHunt.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewMotorDrivesItem(this.motorDriveTreasureHunt);
-    } else {
-      this.treasureHuntService.editMotorDrivesItem(this.motorDriveTreasureHunt, this.calculatorsService.itemIndex);
-    }
-    this.finishSaveCalc();
-  }
-
-  //natural gas reduction
-  cancelNaturalGasReduction() {
-    this.calculatorsService.cancelNaturalGasReduction();
-  }
-  saveNaturalGasReduction(naturalGasReductionTreasureHunt: NaturalGasReductionTreasureHunt) {
-    this.naturalGasReductionTreasureHunt = naturalGasReductionTreasureHunt;
-    this.initSaveCalc();
-  }
-  confirmSaveNaturalGasReduction() {
-    this.naturalGasReductionTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
-    this.naturalGasReductionTreasureHunt.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewNaturalGasReductionsItem(this.naturalGasReductionTreasureHunt);
-    } else {
-      this.treasureHuntService.editNaturalGasReductionsItem(this.naturalGasReductionTreasureHunt, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //electricity reduction
-  cancelElectricityReduction() {
-    this.calculatorsService.cancelElectricityReduction();
-  }
-  saveElectricityReduction(electricityReduction: ElectricityReductionTreasureHunt) {
-    this.electricityReduction = electricityReduction;
-    this.initSaveCalc();
-  }
-  confirmSaveElectricityReduction() {
-    this.electricityReduction.opportunitySheet = this.calculatorOpportunitySheet;
-    this.electricityReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewElectricityReductionsItem(this.electricityReduction);
-    } else {
-      this.treasureHuntService.editElectricityReductionsItem(this.electricityReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //compressed air reduction
-  cancelCompressedAirReduction() {
-    this.calculatorsService.cancelCompressedAirReduction();
-  }
-  saveCompressedAirReduction(compressedAirReduction: CompressedAirReductionTreasureHunt) {
-    this.compressedAirReduction = compressedAirReduction;
-    this.initSaveCalc();
-  }
-  confirmCompressedAirReduction() {
-    this.compressedAirReduction.opportunitySheet = this.calculatorOpportunitySheet;
-    this.compressedAirReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewCompressedAirReductionsItem(this.compressedAirReduction);
-    } else {
-      this.treasureHuntService.editCompressedAirReductionsItem(this.compressedAirReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //compressed air pressure reduction
-  cancelCompressedAirPressureReduction() {
-    this.calculatorsService.cancelCompressedAirPressureReduction();
-  }
-  saveCompressedAirPressureReduction(compressedAirPressureReduction: CompressedAirPressureReductionTreasureHunt) {
-    this.compressedAirPressureReduction = compressedAirPressureReduction;
-    this.initSaveCalc();
-  }
-  confirmCompressedAirPressureReduction() {
-    this.compressedAirPressureReduction.opportunitySheet = this.calculatorOpportunitySheet;
-    this.compressedAirPressureReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewCompressedAirPressureReductionsItem(this.compressedAirPressureReduction);
-    } else {
-      this.treasureHuntService.editCompressedAirPressureReductionsItem(this.compressedAirPressureReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //water reduction
-  cancelWaterReduction() {
-    this.calculatorsService.cancelWaterReduction();
-  }
-  saveWaterReduction(waterReduction: WaterReductionTreasureHunt) {
-    this.waterReduction = waterReduction;
-    this.initSaveCalc();
-  }
-  confirmSaveWaterReduction() {
-    this.waterReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    this.waterReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewWaterReductionsItem(this.waterReduction);
-    } else {
-      this.treasureHuntService.editWaterReductionsItem(this.waterReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //steam reduction
-  cancelSteamReduction() {
-    this.calculatorsService.cancelSteamReduction();
-  }
-  saveSteamReduction(steamReduction: SteamReductionTreasureHunt) {
-    this.steamReduction = steamReduction;
-    this.initSaveCalc();
-  }
-  confirmSaveSteamReduction() {
-    this.steamReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    this.steamReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewSteamReductionItem(this.steamReduction);
-    } else {
-      this.treasureHuntService.editSteamReductionItem(this.steamReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //pipe insulation reduction
-  cancelPipeInsulationReduction() {
-    this.calculatorsService.cancelPipeInsulationReduction();
-  }
-  savePipeInsulationReduction(pipeInsulationReduction: PipeInsulationReductionTreasureHunt) {
-    this.pipeInsulationReduction = pipeInsulationReduction;
-    this.initSaveCalc();
-  }
-  confirmPipeInsulationReduction() {
-    this.pipeInsulationReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    this.pipeInsulationReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewPipeInsulationReductionItem(this.pipeInsulationReduction);
-    } else {
-      this.treasureHuntService.editPipeInsulationReductionItem(this.pipeInsulationReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //tank insulation reduction
-  cancelTankInsulationReduction() {
-    this.calculatorsService.cancelTankInsulationReduction();
-  }
-  saveTankInsulationReduction(tankInsulationReduction: TankInsulationReductionTreasureHunt) {
-    this.tankInsulationReduction = tankInsulationReduction;
-    this.initSaveCalc();
-  }
-  confirmTankInsulationReduction() {
-    this.tankInsulationReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    this.tankInsulationReduction.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewTankInsulationReductionItem(this.tankInsulationReduction);
-    } else {
-      this.treasureHuntService.editTankInsulationReductionItem(this.tankInsulationReduction, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
-  //air leak survey
-  cancelAirLeakSurvey() {
-    this.calculatorsService.cancelAirLeakSurvey();
-  }
-  saveAirLeakSurvey(airLeakSurvey: AirLeakSurveyTreasureHunt) {
-    this.airLeakSurveyTreasureHunt = airLeakSurvey;
-    this.initSaveCalc();
-  }
-  confirmAirLeakSurvey() {
-    this.airLeakSurveyTreasureHunt.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    this.airLeakSurveyTreasureHunt.selected = true;
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.treasureHuntService.addNewAirLeakSurveyItem(this.airLeakSurveyTreasureHunt);
-    } else {
-      this.treasureHuntService.editAirLeakSurveyItem(this.airLeakSurveyTreasureHunt, this.calculatorsService.itemIndex, this.settings);
-    }
-    this.finishSaveCalc();
-  }
-
 
   //stand alone opportunity sheet
   cancelStandaloneOpportunitySheet() {
-    this.calculatorsService.cancelOpportunitySheet();
+    this.calculatorsService.calcOpportunitySheet = undefined;
+    this.calculatorsService.itemIndex = undefined;
+    this.calculatorsService.selectedCalc.next('none');
   }
   saveStandaloneOpportunitySheet(opportunitySheet: OpportunitySheet) {
     this.standaloneOpportunitySheet = opportunitySheet;
@@ -372,4 +175,278 @@ export class CalculatorsComponent implements OnInit {
     }
     this.finishSaveCalc();
   }
+
+  // confirmSaveCalc() {
+  //   if (this.selectedCalc == 'lighting-replacement') {
+  //     this.confirmSaveLighting();
+  //   } else if (this.selectedCalc == 'replace-existing') {
+  //     this.confirmSaveReplaceExisting();
+  //   } else if (this.selectedCalc == 'motor-drive') {
+  //     this.confirmSaveMotorDrive();
+  //   } else if (this.selectedCalc == 'natural-gas-reduction') {
+  //     this.confirmSaveNaturalGasReduction();
+  //   } else if (this.selectedCalc == 'electricity-reduction') {
+  //     this.confirmSaveElectricityReduction();
+  //   } else if (this.selectedCalc == 'compressed-air-reduction') {
+  //     this.confirmCompressedAirReduction();
+  //   } else if (this.selectedCalc == 'compressed-air-pressure-reduction') {
+  //     this.confirmCompressedAirPressureReduction();
+  //   } else if (this.selectedCalc == 'water-reduction') {
+  //     this.confirmSaveWaterReduction();
+  //   } else if (this.selectedCalc == 'opportunity-sheet') {
+  //     this.confirmSaveStandaloneOpportunitySheet();
+  //   } else if (this.selectedCalc == 'steam-reduction') {
+  //     this.confirmSaveSteamReduction();
+  //   } else if (this.selectedCalc == 'pipe-insulation-reduction') {
+  //     this.confirmPipeInsulationReduction();
+  //   } else if (this.selectedCalc == 'tank-insulation-reduction'){
+  //     this.confirmTankInsulationReduction();
+  //   } else if(this.selectedCalc == 'air-leak-survey'){
+  //     this.confirmAirLeakSurvey();
+  //   }
+  // }
+
+  initSaveCalc() {
+    this.calculatorOpportunitySheet = this.calculatorsService.calcOpportunitySheet;
+    if (this.mainTab == 'find-treasure' && this.selectedCalc != 'opportunity-sheet') {
+      this.showOpportunitySheetModal();
+    } else {
+      this.showSaveCalcModal();
+    }
+  }
+
+  finishSaveCalc() {
+    this.hideSaveCalcModal();
+    this.calculatorsService.selectedCalc.next('none');
+  }
+
+  // //lighting
+  // cancelEditLighting() {
+  //   this.calculatorsService.cancelLightingCalc();
+  // }
+  // saveLighting(lightingReplacementTreasureHunt: LightingReplacementTreasureHunt) {
+  //   this.lightingReplacementTreasureHunt = lightingReplacementTreasureHunt;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveLighting() {
+  //   this.lightingReplacementTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.lightingReplacementTreasureHunt.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewLightingReplacementTreasureHuntItem(this.lightingReplacementTreasureHunt);
+  //   } else {
+  //     this.treasureHuntService.editLightingReplacementTreasureHuntItem(this.lightingReplacementTreasureHunt, this.calculatorsService.itemIndex);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //replace existing
+  // cancelReplaceExisting() {
+  //   this.calculatorsService.cancelReplaceExistingMotors();
+  // }
+  // saveReplaceExisting(replaceExistingTreasureHunt: ReplaceExistingMotorTreasureHunt) {
+  //   this.replaceExistingMotorsTreasureHunt = replaceExistingTreasureHunt;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveReplaceExisting() {
+  //   this.replaceExistingMotorsTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.replaceExistingMotorsTreasureHunt.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewReplaceExistingMotorsItem(this.replaceExistingMotorsTreasureHunt);
+  //   } else {
+  //     this.treasureHuntService.editReplaceExistingMotorsItem(this.replaceExistingMotorsTreasureHunt, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //motor drive
+  // cancelMotorDrive() {
+  //   this.calculatorsService.cancelMotorDrive();
+  // }
+  // saveMotorDrive(motorDriveTreasureHunt: MotorDriveInputsTreasureHunt) {
+  //   this.motorDriveTreasureHunt = motorDriveTreasureHunt;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveMotorDrive() {
+  //   this.motorDriveTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.motorDriveTreasureHunt.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewMotorDrivesItem(this.motorDriveTreasureHunt);
+  //   } else {
+  //     this.treasureHuntService.editMotorDrivesItem(this.motorDriveTreasureHunt, this.calculatorsService.itemIndex);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //natural gas reduction
+  // cancelNaturalGasReduction() {
+  //   this.calculatorsService.cancelNaturalGasReduction();
+  // }
+  // saveNaturalGasReduction(naturalGasReductionTreasureHunt: NaturalGasReductionTreasureHunt) {
+  //   this.naturalGasReductionTreasureHunt = naturalGasReductionTreasureHunt;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveNaturalGasReduction() {
+  //   this.naturalGasReductionTreasureHunt.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.naturalGasReductionTreasureHunt.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewNaturalGasReductionsItem(this.naturalGasReductionTreasureHunt);
+  //   } else {
+  //     this.treasureHuntService.editNaturalGasReductionsItem(this.naturalGasReductionTreasureHunt, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //electricity reduction
+  // cancelElectricityReduction() {
+  //   this.calculatorsService.cancelElectricityReduction();
+  // }
+  // saveElectricityReduction(electricityReduction: ElectricityReductionTreasureHunt) {
+  //   this.electricityReduction = electricityReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveElectricityReduction() {
+  //   this.electricityReduction.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.electricityReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewElectricityReductionsItem(this.electricityReduction);
+  //   } else {
+  //     this.treasureHuntService.editElectricityReductionsItem(this.electricityReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //compressed air reduction
+  // cancelCompressedAirReduction() {
+  //   this.calculatorsService.cancelCompressedAirReduction();
+  // }
+  // saveCompressedAirReduction(compressedAirReduction: CompressedAirReductionTreasureHunt) {
+  //   this.compressedAirReduction = compressedAirReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmCompressedAirReduction() {
+  //   this.compressedAirReduction.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.compressedAirReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewCompressedAirReductionsItem(this.compressedAirReduction);
+  //   } else {
+  //     this.treasureHuntService.editCompressedAirReductionsItem(this.compressedAirReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //compressed air pressure reduction
+  // cancelCompressedAirPressureReduction() {
+  //   this.calculatorsService.cancelCompressedAirPressureReduction();
+  // }
+  // saveCompressedAirPressureReduction(compressedAirPressureReduction: CompressedAirPressureReductionTreasureHunt) {
+  //   this.compressedAirPressureReduction = compressedAirPressureReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmCompressedAirPressureReduction() {
+  //   this.compressedAirPressureReduction.opportunitySheet = this.calculatorOpportunitySheet;
+  //   this.compressedAirPressureReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewCompressedAirPressureReductionsItem(this.compressedAirPressureReduction);
+  //   } else {
+  //     this.treasureHuntService.editCompressedAirPressureReductionsItem(this.compressedAirPressureReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //water reduction
+  // cancelWaterReduction() {
+  //   this.calculatorsService.cancelWaterReduction();
+  // }
+  // saveWaterReduction(waterReduction: WaterReductionTreasureHunt) {
+  //   this.waterReduction = waterReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveWaterReduction() {
+  //   this.waterReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+  //   this.waterReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewWaterReductionsItem(this.waterReduction);
+  //   } else {
+  //     this.treasureHuntService.editWaterReductionsItem(this.waterReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //steam reduction
+  // cancelSteamReduction() {
+  //   this.calculatorsService.cancelSteamReduction();
+  // }
+  // saveSteamReduction(steamReduction: SteamReductionTreasureHunt) {
+  //   this.steamReduction = steamReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmSaveSteamReduction() {
+  //   this.steamReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+  //   this.steamReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewSteamReductionItem(this.steamReduction);
+  //   } else {
+  //     this.treasureHuntService.editSteamReductionItem(this.steamReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //pipe insulation reduction
+  // cancelPipeInsulationReduction() {
+  //   this.calculatorsService.cancelPipeInsulationReduction();
+  // }
+  // savePipeInsulationReduction(pipeInsulationReduction: PipeInsulationReductionTreasureHunt) {
+  //   this.pipeInsulationReduction = pipeInsulationReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmPipeInsulationReduction() {
+  //   this.pipeInsulationReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+  //   this.pipeInsulationReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewPipeInsulationReductionItem(this.pipeInsulationReduction);
+  //   } else {
+  //     this.treasureHuntService.editPipeInsulationReductionItem(this.pipeInsulationReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  // //tank insulation reduction
+  // cancelTankInsulationReduction() {
+  //   this.calculatorsService.cancelTankInsulationReduction();
+  // }
+  // saveTankInsulationReduction(tankInsulationReduction: TankInsulationReductionTreasureHunt) {
+  //   this.tankInsulationReduction = tankInsulationReduction;
+  //   this.initSaveCalc();
+  // }
+  // confirmTankInsulationReduction() {
+  //   this.tankInsulationReduction.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+  //   this.tankInsulationReduction.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewTankInsulationReductionItem(this.tankInsulationReduction);
+  //   } else {
+  //     this.treasureHuntService.editTankInsulationReductionItem(this.tankInsulationReduction, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
+  //air leak survey
+  // cancelAirLeakSurvey() {
+  //   this.calculatorsService.cancelAirLeakSurvey();
+  // }
+  // saveAirLeakSurvey(airLeakSurvey: AirLeakSurveyTreasureHunt) {
+  //   this.airLeakSurveyTreasureHunt = airLeakSurvey;
+  //   this.initSaveCalc();
+  // }
+  // confirmAirLeakSurvey() {
+  //   debugger;
+  //   this.airLeakSurveyTreasureHunt.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+  //   this.airLeakSurveyTreasureHunt.selected = true;
+  //   if (this.calculatorsService.isNewOpportunity == true) {
+  //     this.treasureHuntService.addNewAirLeakSurveyItem(this.airLeakSurveyTreasureHunt);
+  //   } else {
+  //     this.treasureHuntService.editAirLeakSurveyItem(this.airLeakSurveyTreasureHunt, this.calculatorsService.itemIndex, this.settings);
+  //   }
+  //   this.finishSaveCalc();
+  // }
+
 }

--- a/src/app/treasure-hunt/calculators/calculators.service.ts
+++ b/src/app/treasure-hunt/calculators/calculators.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { LightingReplacementService } from '../../calculator/lighting/lighting-replacement/lighting-replacement.service';
-import { LightingReplacementTreasureHunt, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt, CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, OpportunitySheet, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt } from '../../shared/models/treasure-hunt';
+import { LightingReplacementTreasureHunt, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt, CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, OpportunitySheet, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, TreasureHuntOpportunity, TreasureHunt } from '../../shared/models/treasure-hunt';
 import { ReplaceExistingService } from '../../calculator/motors/replace-existing/replace-existing.service';
 import { MotorDriveService } from '../../calculator/motors/motor-drive/motor-drive.service';
 import { NaturalGasReductionService } from '../../calculator/utilities/natural-gas-reduction/natural-gas-reduction.service';
@@ -14,6 +14,9 @@ import { CompressedAirPressureReductionService } from '../../calculator/compress
 import { SteamReductionService } from '../../calculator/steam/steam-reduction/steam-reduction.service';
 import { TankInsulationReductionService } from '../../calculator/steam/tank-insulation-reduction/tank-insulation-reduction.service';
 import { AirLeakService } from '../../calculator/compressed-air/air-leak/air-leak.service';
+import { AirLeakTreasureHuntService } from '../treasure-hunt-calculator-services/air-leak-treasure-hunt.service';
+import { OpportunityCardData, OpportunityCardsService } from '../treasure-chest/opportunity-cards/opportunity-cards.service';
+import { Settings } from '../../shared/models/settings';
 
 @Injectable()
 export class CalculatorsService {
@@ -22,298 +25,367 @@ export class CalculatorsService {
   itemIndex: number;
   isNewOpportunity: boolean;
   calcOpportunitySheet: OpportunitySheet;
-  constructor(private lightingReplacementService: LightingReplacementService, private replaceExistingService: ReplaceExistingService,
+  constructor(
+    private opportunityCardsService: OpportunityCardsService,
+    private lightingReplacementService: LightingReplacementService, private replaceExistingService: ReplaceExistingService,
     private motorDriveService: MotorDriveService, private naturalGasReductionService: NaturalGasReductionService, private electricityReductionService: ElectricityReductionService,
     private compressedAirReductionService: CompressedAirReductionService, private compressedAirPressureReductionService: CompressedAirPressureReductionService,
     private waterReductionService: WaterReductionService, private opportunitySheetService: OpportunitySheetService, private steamReductionService: SteamReductionService,
-    private pipeInsulationReductionService: PipeInsulationReductionService, private tankInsulationReductionService: TankInsulationReductionService, private airLeakService: AirLeakService) {
+    private pipeInsulationReductionService: PipeInsulationReductionService, private tankInsulationReductionService: TankInsulationReductionService, private airLeakTreasureHuntService: AirLeakTreasureHuntService,
+    private airLeakService: AirLeakService
+    ) {
     this.selectedCalc = new BehaviorSubject<string>('none');
   }
-  cancelCalc() {
-    this.itemIndex = undefined;
-    this.selectedCalc.next('none');
+  // cancelCalc() {
+  //   this.itemIndex = undefined;
+  //   this.selectedCalc.next('none');
+  // }
+
+  // //lighting replacement
+  // addNewLighting() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.lightingReplacementService.baselineData = undefined;
+  //   this.lightingReplacementService.modificationData = undefined;
+  //   this.lightingReplacementService.baselineElectricityCost = undefined;
+  //   this.lightingReplacementService.modificationElectricityCost = undefined;
+  //   this.selectedCalc.next('lighting-replacement');
+  // }
+  // editLightingReplacementItem(lightingReplacementTreasureHunt: LightingReplacementTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = lightingReplacementTreasureHunt.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.lightingReplacementService.baselineData = lightingReplacementTreasureHunt.baseline;
+  //   this.lightingReplacementService.modificationData = lightingReplacementTreasureHunt.modifications;
+  //   this.lightingReplacementService.baselineElectricityCost = lightingReplacementTreasureHunt.baselineElectricityCost;
+  //   this.lightingReplacementService.modificationElectricityCost = lightingReplacementTreasureHunt.modificationElectricityCost;
+  //   this.itemIndex = index;
+  //   this.selectedCalc.next('lighting-replacement');
+  // }
+  // cancelLightingCalc() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.lightingReplacementService.baselineData = undefined;
+  //   this.lightingReplacementService.modificationData = undefined;
+  //   this.lightingReplacementService.baselineElectricityCost = undefined;
+  //   this.lightingReplacementService.modificationElectricityCost = undefined;
+  //   this.cancelCalc();
+  // }
+  // //opportunitySheet
+  // addNewOpportunitySheet() {
+  //   this.isNewOpportunity = true;
+  //   this.opportunitySheetService.opportunitySheet = undefined;
+  //   this.selectedCalc.next('opportunity-sheet');
+  // }
+  // editOpportunitySheetItem(opportunitySheet: OpportunitySheet, index: number) {
+  //   this.isNewOpportunity = false;
+  //   this.opportunitySheetService.opportunitySheet = opportunitySheet;
+  //   this.itemIndex = index;
+  //   this.selectedCalc.next('opportunity-sheet');
+  // }
+  // cancelOpportunitySheet() {
+  //   this.opportunitySheetService.opportunitySheet = undefined;
+  //   this.cancelCalc();
+  // }
+
+  // //replace existing
+  // addNewReplaceExistingMotor() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.replaceExistingService.replaceExistingData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('replace-existing');
+  // }
+  // editReplaceExistingMotorsItem(replaceExistingMotorsTreasureHunt: ReplaceExistingMotorTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = replaceExistingMotorsTreasureHunt.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.replaceExistingService.replaceExistingData = replaceExistingMotorsTreasureHunt.replaceExistingData;
+  //   this.itemIndex = index;
+  //   this.selectedCalc.next('replace-existing');
+  // }
+  // cancelReplaceExistingMotors() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.replaceExistingService.replaceExistingData = undefined;
+  //   this.cancelCalc();
+  // }
+  // //motor drive
+  // addNewMotorDrive() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.motorDriveService.motorDriveData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('motor-drive');
+  // }
+  // editMotorDrivesItem(motorDriveTreasureHunt: MotorDriveInputsTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = motorDriveTreasureHunt.opportunitySheet;
+  //   this.itemIndex = index;
+  //   this.isNewOpportunity = false;
+  //   this.motorDriveService.motorDriveData = motorDriveTreasureHunt.motorDriveInputs;
+  //   this.selectedCalc.next('motor-drive');
+  // }
+  // cancelMotorDrive() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.motorDriveService.motorDriveData = undefined;
+  //   this.cancelCalc();
+  // }
+  // //natural gas reduction
+  // addNewNaturalGasReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.naturalGasReductionService.baselineData = undefined;
+  //   this.naturalGasReductionService.modificationData = undefined;
+  //   this.selectedCalc.next('natural-gas-reduction');
+  // }
+  // editNaturalGasReductionsItem(naturalGasReductionTreasureHunt: NaturalGasReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = naturalGasReductionTreasureHunt.opportunitySheet;
+  //   this.itemIndex = index;
+  //   this.isNewOpportunity = false;
+  //   this.naturalGasReductionService.baselineData = naturalGasReductionTreasureHunt.baseline;
+  //   this.naturalGasReductionService.modificationData = naturalGasReductionTreasureHunt.modification;
+  //   this.selectedCalc.next('natural-gas-reduction');
+  // }
+  // cancelNaturalGasReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.naturalGasReductionService.baselineData = undefined;
+  //   this.naturalGasReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+  // //edit electricity
+  // addNewElectricityReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.electricityReductionService.baselineData = undefined;
+  //   this.electricityReductionService.modificationData = undefined;
+  //   this.selectedCalc.next('electricity-reduction');
+  // }
+  // editElectricityReductionsItem(electricityReduction: ElectricityReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = electricityReduction.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.electricityReductionService.baselineData = electricityReduction.baseline;
+  //   this.electricityReductionService.modificationData = electricityReduction.modification;
+  //   this.itemIndex = index;
+  //   this.selectedCalc.next('electricity-reduction');
+  // }
+  // cancelElectricityReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.electricityReductionService.baselineData = undefined;
+  //   this.electricityReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+  // //compressed air reduction
+  // addNewCompressedAirReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.compressedAirReductionService.baselineData = undefined;
+  //   this.compressedAirReductionService.modificationData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('compressed-air-reduction');
+  // }
+  // editCompressedAirReductionsItem(compressedAirReduction: CompressedAirReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = compressedAirReduction.opportunitySheet;
+  //   this.compressedAirReductionService.baselineData = compressedAirReduction.baseline;
+  //   this.compressedAirReductionService.modificationData = compressedAirReduction.modification;
+  //   this.itemIndex = index;
+  //   this.isNewOpportunity = false;
+  //   this.selectedCalc.next('compressed-air-reduction');
+  // }
+  // cancelCompressedAirReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.compressedAirReductionService.baselineData = undefined;
+  //   this.compressedAirReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+  // //compressed air pressure
+  // addNewCompressedAirPressureReductions() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.compressedAirPressureReductionService.baselineData = undefined;
+  //   this.compressedAirPressureReductionService.modificationData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('compressed-air-pressure-reduction');
+  // }
+  // editCompressedAirPressureReductionsItem(compressedAirPressureReduction: CompressedAirPressureReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = compressedAirPressureReduction.opportunitySheet;
+  //   this.compressedAirPressureReductionService.baselineData = compressedAirPressureReduction.baseline;
+  //   this.compressedAirPressureReductionService.modificationData = compressedAirPressureReduction.modification;
+  //   this.itemIndex = index;
+  //   this.isNewOpportunity = false;
+  //   this.selectedCalc.next('compressed-air-pressure-reduction');
+  // }
+  // cancelCompressedAirPressureReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.compressedAirPressureReductionService.baselineData = undefined;
+  //   this.compressedAirPressureReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+  // //water reductions
+  // addNewWaterReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.waterReductionService.baselineData = undefined;
+  //   this.waterReductionService.modificationData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('water-reduction');
+  // }
+  // editWaterReductionsItem(waterReduction: WaterReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = waterReduction.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.itemIndex = index;
+  //   this.waterReductionService.baselineData = waterReduction.baseline;
+  //   this.waterReductionService.modificationData = waterReduction.modification;
+  //   this.selectedCalc.next('water-reduction');
+  // }
+  // cancelWaterReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.waterReductionService.baselineData = undefined;
+  //   this.waterReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+
+  // //steam reductions
+  // addNewSteamReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.steamReductionService.baselineData = undefined;
+  //   this.steamReductionService.modificationData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('steam-reduction');
+  // }
+  // editSteamReductionsItem(steamReduction: SteamReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = steamReduction.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.itemIndex = index;
+  //   this.steamReductionService.baselineData = steamReduction.baseline;
+  //   this.steamReductionService.modificationData = steamReduction.modification;
+  //   this.selectedCalc.next('steam-reduction');
+  // }
+  // cancelSteamReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.steamReductionService.baselineData = undefined;
+  //   this.steamReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+
+  // //pipe insulation reduction
+  // addNewPipeInsulationReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.pipeInsulationReductionService.baselineData = undefined;
+  //   this.pipeInsulationReductionService.modificationData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('pipe-insulation-reduction');
+  // }
+  // editPipeInsulationReductionsItem(pipeInsulationReduction: PipeInsulationReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = pipeInsulationReduction.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.itemIndex = index;
+  //   this.pipeInsulationReductionService.baselineData = pipeInsulationReduction.baseline;
+  //   this.pipeInsulationReductionService.modificationData = pipeInsulationReduction.modification;
+  //   this.selectedCalc.next('pipe-insulation-reduction');
+  // }
+  // cancelPipeInsulationReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.pipeInsulationReductionService.baselineData = undefined;
+  //   this.pipeInsulationReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+
+  // //tank insulation reduction
+  // addNewTankInsulationReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.tankInsulationReductionService.baselineData = undefined;
+  //   this.tankInsulationReductionService.modificationData = undefined;
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('tank-insulation-reduction');
+  // }
+  // editTankInsulationReductionsItem(tankInsulationReduction: TankInsulationReductionTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = tankInsulationReduction.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.itemIndex = index;
+  //   this.tankInsulationReductionService.baselineData = tankInsulationReduction.baseline;
+  //   this.tankInsulationReductionService.modificationData = tankInsulationReduction.modification;
+  //   this.selectedCalc.next('tank-insulation-reduction');
+  // }
+  // cancelTankInsulationReduction() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.tankInsulationReductionService.baselineData = undefined;
+  //   this.tankInsulationReductionService.modificationData = undefined;
+  //   this.cancelCalc();
+  // }
+
+  // //air leak survey
+  // addNewAirLeakSurvey() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.airLeakService.airLeakInput.next(undefined);
+  //   this.isNewOpportunity = true;
+  //   this.selectedCalc.next('air-leak-survey');
+  // }
+
+  // editAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt, index: number) {
+  //   this.calcOpportunitySheet = airLeakSurvey.opportunitySheet;
+  //   this.isNewOpportunity = false;
+  //   this.itemIndex = index;
+  //   this.airLeakService.airLeakInput.next(airLeakSurvey.airLeakSurveyInput);
+  //   this.selectedCalc.next('air-leak-survey');
+  // }
+
+  // cancelAirLeakSurvey() {
+  //   this.calcOpportunitySheet = undefined;
+  //   this.airLeakService.airLeakInput.next(undefined);
+  //   this.cancelCalc();
+  // }
+
+
+  //================
+
+  displaySelectedCalculator(calculatorType: string) {
+    this.calcOpportunitySheet = undefined;
+    this.isNewOpportunity = true;
+
+    if (calculatorType === 'air-leak-survey') {
+      this.airLeakTreasureHuntService.initNewAirLeakCalculator();
+    } else if (calculatorType === '') {
+
+    }
+    this.selectedCalc.next(calculatorType);
   }
 
-  //lighting replacement
-  addNewLighting() {
-    this.calcOpportunitySheet = undefined;
-    this.isNewOpportunity = true;
-    this.lightingReplacementService.baselineData = undefined;
-    this.lightingReplacementService.modificationData = undefined;
-    this.lightingReplacementService.baselineElectricityCost = undefined;
-    this.lightingReplacementService.modificationElectricityCost = undefined;
-    this.selectedCalc.next('lighting-replacement');
-  }
-  editLightingReplacementItem(lightingReplacementTreasureHunt: LightingReplacementTreasureHunt, index: number) {
-    this.calcOpportunitySheet = lightingReplacementTreasureHunt.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.lightingReplacementService.baselineData = lightingReplacementTreasureHunt.baseline;
-    this.lightingReplacementService.modificationData = lightingReplacementTreasureHunt.modifications;
-    this.lightingReplacementService.baselineElectricityCost = lightingReplacementTreasureHunt.baselineElectricityCost;
-    this.lightingReplacementService.modificationElectricityCost = lightingReplacementTreasureHunt.modificationElectricityCost;
-    this.itemIndex = index;
-    this.selectedCalc.next('lighting-replacement');
-  }
-  cancelLightingCalc() {
-    this.calcOpportunitySheet = undefined;
-    this.lightingReplacementService.baselineData = undefined;
-    this.lightingReplacementService.modificationData = undefined;
-    this.lightingReplacementService.baselineElectricityCost = undefined;
-    this.lightingReplacementService.modificationElectricityCost = undefined;
-    this.cancelCalc();
-  }
-  //opportunitySheet
-  addNewOpportunitySheet() {
-    this.isNewOpportunity = true;
-    this.opportunitySheetService.opportunitySheet = undefined;
-    this.selectedCalc.next('opportunity-sheet');
-  }
-  editOpportunitySheetItem(opportunitySheet: OpportunitySheet, index: number) {
-    this.isNewOpportunity = false;
-    this.opportunitySheetService.opportunitySheet = opportunitySheet;
-    this.itemIndex = index;
-    this.selectedCalc.next('opportunity-sheet');
-  }
-  cancelOpportunitySheet() {
-    this.opportunitySheetService.opportunitySheet = undefined;
-    this.cancelCalc();
+  copyOpportunity(opportunityCardData: OpportunityCardData,treasureHunt: TreasureHunt, settings: Settings): OpportunityCardData {
+    if (opportunityCardData.opportunityType === 'air-leak-survey') {
+      opportunityCardData.airLeakSurvey.opportunitySheet = this.updateCopyName(opportunityCardData.airLeakSurvey.opportunitySheet);
+      this.airLeakTreasureHuntService.saveTreasureHuntOpportunity(opportunityCardData.airLeakSurvey, treasureHunt);
+      opportunityCardData = this.opportunityCardsService.getAirLeakSurveyCardData(opportunityCardData.airLeakSurvey, settings, treasureHunt.airLeakSurveys.length - 1, treasureHunt.currentEnergyUsage);
+    } else if (opportunityCardData.opportunityType == '') {
+
+    }
+
+    return opportunityCardData;
   }
 
-  //replace existing
-  addNewReplaceExistingMotor() {
-    this.calcOpportunitySheet = undefined;
-    this.replaceExistingService.replaceExistingData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('replace-existing');
-  }
-  editReplaceExistingMotorsItem(replaceExistingMotorsTreasureHunt: ReplaceExistingMotorTreasureHunt, index: number) {
-    this.calcOpportunitySheet = replaceExistingMotorsTreasureHunt.opportunitySheet;
+  editOpportunity(opportunityCardData: OpportunityCardData) {
+    // oppcarddata.oppsheet appears to be the same as opportunutiyCardData.airLeakSurvey.oppsheet
+    console.log(opportunityCardData.opportunitySheet);
+    console.log(opportunityCardData.airLeakSurvey.opportunitySheet);
+    this.calcOpportunitySheet = opportunityCardData.opportunitySheet;
     this.isNewOpportunity = false;
-    this.replaceExistingService.replaceExistingData = replaceExistingMotorsTreasureHunt.replaceExistingData;
-    this.itemIndex = index;
-    this.selectedCalc.next('replace-existing');
-  }
-  cancelReplaceExistingMotors() {
-    this.calcOpportunitySheet = undefined;
-    this.replaceExistingService.replaceExistingData = undefined;
-    this.cancelCalc();
-  }
-  //motor drive
-  addNewMotorDrive() {
-    this.calcOpportunitySheet = undefined;
-    this.motorDriveService.motorDriveData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('motor-drive');
-  }
-  editMotorDrivesItem(motorDriveTreasureHunt: MotorDriveInputsTreasureHunt, index: number) {
-    this.calcOpportunitySheet = motorDriveTreasureHunt.opportunitySheet;
-    this.itemIndex = index;
-    this.isNewOpportunity = false;
-    this.motorDriveService.motorDriveData = motorDriveTreasureHunt.motorDriveInputs;
-    this.selectedCalc.next('motor-drive');
-  }
-  cancelMotorDrive() {
-    this.calcOpportunitySheet = undefined;
-    this.motorDriveService.motorDriveData = undefined;
-    this.cancelCalc();
-  }
-  //natural gas reduction
-  addNewNaturalGasReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.isNewOpportunity = true;
-    this.naturalGasReductionService.baselineData = undefined;
-    this.naturalGasReductionService.modificationData = undefined;
-    this.selectedCalc.next('natural-gas-reduction');
-  }
-  editNaturalGasReductionsItem(naturalGasReductionTreasureHunt: NaturalGasReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = naturalGasReductionTreasureHunt.opportunitySheet;
-    this.itemIndex = index;
-    this.isNewOpportunity = false;
-    this.naturalGasReductionService.baselineData = naturalGasReductionTreasureHunt.baseline;
-    this.naturalGasReductionService.modificationData = naturalGasReductionTreasureHunt.modification;
-    this.selectedCalc.next('natural-gas-reduction');
-  }
-  cancelNaturalGasReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.naturalGasReductionService.baselineData = undefined;
-    this.naturalGasReductionService.modificationData = undefined;
-    this.cancelCalc();
-  }
-  //edit electricity
-  addNewElectricityReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.isNewOpportunity = true;
-    this.electricityReductionService.baselineData = undefined;
-    this.electricityReductionService.modificationData = undefined;
-    this.selectedCalc.next('electricity-reduction');
-  }
-  editElectricityReductionsItem(electricityReduction: ElectricityReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = electricityReduction.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.electricityReductionService.baselineData = electricityReduction.baseline;
-    this.electricityReductionService.modificationData = electricityReduction.modification;
-    this.itemIndex = index;
-    this.selectedCalc.next('electricity-reduction');
-  }
-  cancelElectricityReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.electricityReductionService.baselineData = undefined;
-    this.electricityReductionService.modificationData = undefined;
-    this.cancelCalc();
-  }
-  //compressed air reduction
-  addNewCompressedAirReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.compressedAirReductionService.baselineData = undefined;
-    this.compressedAirReductionService.modificationData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('compressed-air-reduction');
-  }
-  editCompressedAirReductionsItem(compressedAirReduction: CompressedAirReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = compressedAirReduction.opportunitySheet;
-    this.compressedAirReductionService.baselineData = compressedAirReduction.baseline;
-    this.compressedAirReductionService.modificationData = compressedAirReduction.modification;
-    this.itemIndex = index;
-    this.isNewOpportunity = false;
-    this.selectedCalc.next('compressed-air-reduction');
-  }
-  cancelCompressedAirReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.compressedAirReductionService.baselineData = undefined;
-    this.compressedAirReductionService.modificationData = undefined;
-    this.cancelCalc();
-  }
-  //compressed air pressure
-  addNewCompressedAirPressureReductions() {
-    this.calcOpportunitySheet = undefined;
-    this.compressedAirPressureReductionService.baselineData = undefined;
-    this.compressedAirPressureReductionService.modificationData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('compressed-air-pressure-reduction');
-  }
-  editCompressedAirPressureReductionsItem(compressedAirPressureReduction: CompressedAirPressureReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = compressedAirPressureReduction.opportunitySheet;
-    this.compressedAirPressureReductionService.baselineData = compressedAirPressureReduction.baseline;
-    this.compressedAirPressureReductionService.modificationData = compressedAirPressureReduction.modification;
-    this.itemIndex = index;
-    this.isNewOpportunity = false;
-    this.selectedCalc.next('compressed-air-pressure-reduction');
-  }
-  cancelCompressedAirPressureReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.compressedAirPressureReductionService.baselineData = undefined;
-    this.compressedAirPressureReductionService.modificationData = undefined;
-    this.cancelCalc();
-  }
-  //water reductions
-  addNewWaterReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.waterReductionService.baselineData = undefined;
-    this.waterReductionService.modificationData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('water-reduction');
-  }
-  editWaterReductionsItem(waterReduction: WaterReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = waterReduction.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.itemIndex = index;
-    this.waterReductionService.baselineData = waterReduction.baseline;
-    this.waterReductionService.modificationData = waterReduction.modification;
-    this.selectedCalc.next('water-reduction');
-  }
-  cancelWaterReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.waterReductionService.baselineData = undefined;
-    this.waterReductionService.modificationData = undefined;
-    this.cancelCalc();
+    this.itemIndex = opportunityCardData.opportunityIndex;
+
+    if (opportunityCardData.opportunityType === 'air-leak-survey') {
+      this.airLeakTreasureHuntService.setCalculatorInputFromOpportunity(opportunityCardData.airLeakSurvey);
+    } else if (opportunityCardData.opportunityType === '') {
+
+    }
+
+    this.selectedCalc.next(opportunityCardData.opportunityType);
   }
 
-  //steam reductions
-  addNewSteamReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.steamReductionService.baselineData = undefined;
-    this.steamReductionService.modificationData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('steam-reduction');
-  }
-  editSteamReductionsItem(steamReduction: SteamReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = steamReduction.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.itemIndex = index;
-    this.steamReductionService.baselineData = steamReduction.baseline;
-    this.steamReductionService.modificationData = steamReduction.modification;
-    this.selectedCalc.next('steam-reduction');
-  }
-  cancelSteamReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.steamReductionService.baselineData = undefined;
-    this.steamReductionService.modificationData = undefined;
-    this.cancelCalc();
+  deleteOpportunity(deleteOpportunity: OpportunityCardData, treasureHunt: TreasureHunt): TreasureHunt {
+    if (deleteOpportunity.opportunityType === 'air-leak-survey') {
+      treasureHunt = this.airLeakTreasureHuntService.deleteOpportunity(deleteOpportunity.opportunityIndex, treasureHunt);
+    } else if (deleteOpportunity.opportunityType === '') {
+
+    }
+
+    return treasureHunt;
   }
 
-  //pipe insulation reduction
-  addNewPipeInsulationReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.pipeInsulationReductionService.baselineData = undefined;
-    this.pipeInsulationReductionService.modificationData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('pipe-insulation-reduction');
-  }
-  editPipeInsulationReductionsItem(pipeInsulationReduction: PipeInsulationReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = pipeInsulationReduction.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.itemIndex = index;
-    this.pipeInsulationReductionService.baselineData = pipeInsulationReduction.baseline;
-    this.pipeInsulationReductionService.modificationData = pipeInsulationReduction.modification;
-    this.selectedCalc.next('pipe-insulation-reduction');
-  }
-  cancelPipeInsulationReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.pipeInsulationReductionService.baselineData = undefined;
-    this.pipeInsulationReductionService.modificationData = undefined;
-    this.cancelCalc();
+  updateCopyName(oppSheet: OpportunitySheet): OpportunitySheet {
+    if (oppSheet) {
+      oppSheet.name = oppSheet.name + ' (copy)';
+      return oppSheet;
+    } else { return }
   }
 
-  //tank insulation reduction
-  addNewTankInsulationReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.tankInsulationReductionService.baselineData = undefined;
-    this.tankInsulationReductionService.modificationData = undefined;
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('tank-insulation-reduction');
-  }
-  editTankInsulationReductionsItem(tankInsulationReduction: TankInsulationReductionTreasureHunt, index: number) {
-    this.calcOpportunitySheet = tankInsulationReduction.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.itemIndex = index;
-    this.tankInsulationReductionService.baselineData = tankInsulationReduction.baseline;
-    this.tankInsulationReductionService.modificationData = tankInsulationReduction.modification;
-    this.selectedCalc.next('tank-insulation-reduction');
-  }
-  cancelTankInsulationReduction() {
-    this.calcOpportunitySheet = undefined;
-    this.tankInsulationReductionService.baselineData = undefined;
-    this.tankInsulationReductionService.modificationData = undefined;
-    this.cancelCalc();
-  }
 
-  //tank insulation reduction
-  addNewAirLeakSurvey() {
-    this.calcOpportunitySheet = undefined;
-    this.airLeakService.airLeakInput.next(undefined);
-    this.isNewOpportunity = true;
-    this.selectedCalc.next('air-leak-survey');
-  }
-  editAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt, index: number) {
-    this.calcOpportunitySheet = airLeakSurvey.opportunitySheet;
-    this.isNewOpportunity = false;
-    this.itemIndex = index;
-    this.airLeakService.airLeakInput.next(airLeakSurvey.airLeakSurveyInput);
-    this.selectedCalc.next('air-leak-survey');
-  }
-  cancelAirLeakSurvey() {
-    this.calcOpportunitySheet = undefined;
-    this.airLeakService.airLeakInput.next(undefined);
-    this.cancelCalc();
-  }
 }

--- a/src/app/treasure-hunt/find-treasure/find-treasure.component.html
+++ b/src/app/treasure-hunt/find-treasure/find-treasure.component.html
@@ -208,7 +208,7 @@
     <!--compressed air reduction-->
     <div
       *ngIf="(displayCalculatorType == 'All' || displayCalculatorType == 'Electricity' || displayCalculatorType == 'Compressed Air') && (treasureHunt.currentEnergyUsage.electricityUsed == true || treasureHunt.currentEnergyUsage.compressedAirUsed == true)"
-      class="card calc-card-item m-2" (click)="selectAirLeakSurvey()">
+      class="card calc-card-item m-2" (click)="openCalculator('air-leak-survey')">
       <div class="card-body d-flex flex-column p-2 align-items-center">
         <div class="calc-icon d-flex justify-content-center align-items-center">
           <img src="assets/images/calculator-icons/compressed-air-icons/air-leak-icon.png" class="calc-img">

--- a/src/app/treasure-hunt/find-treasure/find-treasure.component.ts
+++ b/src/app/treasure-hunt/find-treasure/find-treasure.component.ts
@@ -37,55 +37,8 @@ export class FindTreasureComponent implements OnInit {
     this.treasureHuntSub.unsubscribe();
   }
 
-  selectLightingCalc() {
-    this.calculatorsService.addNewLighting();
+  openCalculator(calculatorType: string) {
+    this.calculatorsService.displaySelectedCalculator(calculatorType);
   }
 
-  selectReplaceExisting(){
-    this.calculatorsService.addNewReplaceExistingMotor();
-  }
-
-  selectMotorDrive(){
-    this.calculatorsService.addNewMotorDrive();
-  }
-
-  selectNaturalGas(){
-    this.calculatorsService.addNewNaturalGasReduction();
-  }  
-
-  selectElectricityReduction(){
-    this.calculatorsService.addNewElectricityReduction();
-  }
-
-  selectCompressedAirReduction(){
-    this.calculatorsService.addNewCompressedAirReduction();
-  }
-
-  selectCompressedAirPressureReduction(){
-    this.calculatorsService.addNewCompressedAirPressureReductions();
-  }
-
-  selectWaterReduction(){
-    this.calculatorsService.addNewWaterReduction();
-  }
-
-  selectOpportunitySheet(){
-    this.calculatorsService.addNewOpportunitySheet();
-  }
-
-  selectSteamReduction(){
-    this.calculatorsService.addNewSteamReduction();
-  }
-
-  selectPipeInsulationReduction(){
-    this.calculatorsService.addNewPipeInsulationReduction();
-  }
-
-  selectTankInsulationReduction(){
-    this.calculatorsService.addNewTankInsulationReduction();
-  }
-
-  selectAirLeakSurvey(){
-    this.calculatorsService.addNewAirLeakSurvey()
-  }
 }

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
@@ -83,35 +83,40 @@ export class OpportunityCardsComponent implements OnInit {
     this.opportunityCardsService.opportunityCards.next(this.opportunityCardsData);
   }
 
+  // editOpportunity(opportunityCard: OpportunityCardData) {
+  //   this.modifyDataIndex = opportunityCard.index;
+  //   if (opportunityCard.opportunityType == 'lighting-replacement') {
+  //     this.calculatorsService.editLightingReplacementItem(opportunityCard.lightingReplacement, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'opportunity-sheet') {
+  //     this.calculatorsService.editOpportunitySheetItem(opportunityCard.opportunitySheet, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'replace-existing') {
+  //     this.calculatorsService.editReplaceExistingMotorsItem(opportunityCard.replaceExistingMotor, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'motor-drive') {
+  //     this.calculatorsService.editMotorDrivesItem(opportunityCard.motorDrive, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'natural-gas-reduction') {
+  //     this.calculatorsService.editNaturalGasReductionsItem(opportunityCard.naturalGasReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'electricity-reduction') {
+  //     this.calculatorsService.editElectricityReductionsItem(opportunityCard.electricityReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'compressed-air-reduction') {
+  //     this.calculatorsService.editCompressedAirReductionsItem(opportunityCard.compressedAirReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'compressed-air-pressure-reduction') {
+  //     this.calculatorsService.editCompressedAirPressureReductionsItem(opportunityCard.compressedAirPressureReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'water-reduction') {
+  //     this.calculatorsService.editWaterReductionsItem(opportunityCard.waterReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'steam-reduction') {
+  //     this.calculatorsService.editSteamReductionsItem(opportunityCard.steamReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'pipe-insulation-reduction') {
+  //     this.calculatorsService.editPipeInsulationReductionsItem(opportunityCard.pipeInsulationReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'tank-insulation-reduction') {
+  //     this.calculatorsService.editTankInsulationReductionsItem(opportunityCard.tankInsulationReduction, opportunityCard.opportunityIndex);
+  //   } else if (opportunityCard.opportunityType == 'air-leak-survey') {
+  //     this.calculatorsService.editAirLeakSurveyItem(opportunityCard.airLeakSurvey, opportunityCard.opportunityIndex);
+  //   }
+  // }
+
   editOpportunity(opportunityCard: OpportunityCardData) {
     this.modifyDataIndex = opportunityCard.index;
-    if (opportunityCard.opportunityType == 'lighting-replacement') {
-      this.calculatorsService.editLightingReplacementItem(opportunityCard.lightingReplacement, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'opportunity-sheet') {
-      this.calculatorsService.editOpportunitySheetItem(opportunityCard.opportunitySheet, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'replace-existing') {
-      this.calculatorsService.editReplaceExistingMotorsItem(opportunityCard.replaceExistingMotor, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'motor-drive') {
-      this.calculatorsService.editMotorDrivesItem(opportunityCard.motorDrive, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'natural-gas-reduction') {
-      this.calculatorsService.editNaturalGasReductionsItem(opportunityCard.naturalGasReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'electricity-reduction') {
-      this.calculatorsService.editElectricityReductionsItem(opportunityCard.electricityReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'compressed-air-reduction') {
-      this.calculatorsService.editCompressedAirReductionsItem(opportunityCard.compressedAirReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'compressed-air-pressure-reduction') {
-      this.calculatorsService.editCompressedAirPressureReductionsItem(opportunityCard.compressedAirPressureReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'water-reduction') {
-      this.calculatorsService.editWaterReductionsItem(opportunityCard.waterReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'steam-reduction') {
-      this.calculatorsService.editSteamReductionsItem(opportunityCard.steamReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'pipe-insulation-reduction') {
-      this.calculatorsService.editPipeInsulationReductionsItem(opportunityCard.pipeInsulationReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'tank-insulation-reduction') {
-      this.calculatorsService.editTankInsulationReductionsItem(opportunityCard.tankInsulationReduction, opportunityCard.opportunityIndex);
-    } else if (opportunityCard.opportunityType == 'air-leak-survey') {
-      this.calculatorsService.editAirLeakSurveyItem(opportunityCard.airLeakSurvey, opportunityCard.opportunityIndex);
-    }
+    this.calculatorsService.editOpportunity(opportunityCard);
   }
 
   //delete
@@ -127,36 +132,48 @@ export class OpportunityCardsComponent implements OnInit {
     this.deleteOpportunity = undefined;
     this.deletedItemModal.hide();
   }
+
+  // deleteItem() {
+  //   this.opportunityCardsData.splice(this.modifyDataIndex, 1);
+  //   this.updateOpportunityIndexesAfterDelete();
+  //   if (this.deleteOpportunity.opportunityType == 'lighting-replacement') {
+  //     this.treasureHuntService.deleteLightingReplacementTreasureHuntItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'opportunity-sheet') {
+  //     this.treasureHuntService.deleteOpportunitySheetItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'replace-existing') {
+  //     this.treasureHuntService.deleteReplaceExistingMotorsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'motor-drive') {
+  //     this.treasureHuntService.deleteMotorDrivesItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'natural-gas-reduction') {
+  //     this.treasureHuntService.deleteNaturalGasReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'electricity-reduction') {
+  //     this.treasureHuntService.deleteElectricityReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'compressed-air-reduction') {
+  //     this.treasureHuntService.deleteCompressedAirReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'compressed-air-pressure-reduction') {
+  //     this.treasureHuntService.deleteCompressedAirPressureReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'water-reduction') {
+  //     this.treasureHuntService.deleteWaterReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'steam-reduction') {
+  //     this.treasureHuntService.deleteSteamReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'pipe-insulation-reduction') {
+  //     this.treasureHuntService.deletePipeInsulationReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'tank-insulation-reduction') {
+  //     this.treasureHuntService.deleteTankInsulationReductionsItem(this.deleteOpportunity.opportunityIndex);
+  //   } else if (this.deleteOpportunity.opportunityType == 'air-leak-survey') {
+  //     this.treasureHuntService.deleteAirLeakSurveyItem(this.deleteOpportunity.opportunityIndex);
+  //   }
+  //   this.hideDeleteItemModal();
+  //   this.updateOpportunityCardsData();
+  // }
+
   deleteItem() {
     this.opportunityCardsData.splice(this.modifyDataIndex, 1);
     this.updateOpportunityIndexesAfterDelete();
-    if (this.deleteOpportunity.opportunityType == 'lighting-replacement') {
-      this.treasureHuntService.deleteLightingReplacementTreasureHuntItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'opportunity-sheet') {
-      this.treasureHuntService.deleteOpportunitySheetItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'replace-existing') {
-      this.treasureHuntService.deleteReplaceExistingMotorsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'motor-drive') {
-      this.treasureHuntService.deleteMotorDrivesItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'natural-gas-reduction') {
-      this.treasureHuntService.deleteNaturalGasReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'electricity-reduction') {
-      this.treasureHuntService.deleteElectricityReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'compressed-air-reduction') {
-      this.treasureHuntService.deleteCompressedAirReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'compressed-air-pressure-reduction') {
-      this.treasureHuntService.deleteCompressedAirPressureReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'water-reduction') {
-      this.treasureHuntService.deleteWaterReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'steam-reduction') {
-      this.treasureHuntService.deleteSteamReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'pipe-insulation-reduction') {
-      this.treasureHuntService.deletePipeInsulationReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'tank-insulation-reduction') {
-      this.treasureHuntService.deleteTankInsulationReductionsItem(this.deleteOpportunity.opportunityIndex);
-    } else if (this.deleteOpportunity.opportunityType == 'air-leak-survey') {
-      this.treasureHuntService.deleteAirLeakSurveyItem(this.deleteOpportunity.opportunityIndex);
-    }
+    let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+    treasureHunt = this.calculatorsService.deleteOpportunity(this.deleteOpportunity, treasureHunt);
+
+    this.treasureHuntService.treasureHunt.next(treasureHunt);
     this.hideDeleteItemModal();
     this.updateOpportunityCardsData();
   }
@@ -193,46 +210,53 @@ export class OpportunityCardsComponent implements OnInit {
     this.editOpportunitySheetCardData = undefined;
   }
 
+  // saveItemOpportunitySheet(updatedOpportunitySheet: OpportunitySheet) {
+  //   this.editOpportunitySheetCardData.opportunitySheet = updatedOpportunitySheet;
+  //   this.opportunityCardsData[this.modifyDataIndex] = this.editOpportunitySheetCardData;
+  //   if (this.editOpportunitySheetCardData.opportunityType == 'lighting-replacement') {
+  //     this.editOpportunitySheetCardData.lightingReplacement.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editLightingReplacementTreasureHuntItem(this.editOpportunitySheetCardData.lightingReplacement, this.editOpportunitySheetCardData.opportunityIndex);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'replace-existing') {
+  //     this.editOpportunitySheetCardData.replaceExistingMotor.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editReplaceExistingMotorsItem(this.editOpportunitySheetCardData.replaceExistingMotor, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'motor-drive') {
+  //     this.editOpportunitySheetCardData.motorDrive.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editMotorDrivesItem(this.editOpportunitySheetCardData.motorDrive, this.editOpportunitySheetCardData.opportunityIndex);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'natural-gas-reduction') {
+  //     this.editOpportunitySheetCardData.naturalGasReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editNaturalGasReductionsItem(this.editOpportunitySheetCardData.naturalGasReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'electricity-reduction') {
+  //     this.editOpportunitySheetCardData.electricityReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editElectricityReductionsItem(this.editOpportunitySheetCardData.electricityReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'compressed-air-reduction') {
+  //     this.editOpportunitySheetCardData.compressedAirReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editCompressedAirReductionsItem(this.editOpportunitySheetCardData.compressedAirReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'compressed-air-pressure-reduction') {
+  //     this.editOpportunitySheetCardData.compressedAirPressureReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editCompressedAirPressureReductionsItem(this.editOpportunitySheetCardData.compressedAirPressureReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'water-reduction') {
+  //     this.editOpportunitySheetCardData.waterReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editWaterReductionsItem(this.editOpportunitySheetCardData.waterReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'steam-reduction') {
+  //     this.editOpportunitySheetCardData.steamReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editSteamReductionItem(this.editOpportunitySheetCardData.steamReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'pipe-insulation-reduction') {
+  //     this.editOpportunitySheetCardData.pipeInsulationReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editPipeInsulationReductionItem(this.editOpportunitySheetCardData.pipeInsulationReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'tank-insulation-reduction') {
+  //     this.editOpportunitySheetCardData.tankInsulationReduction.opportunitySheet = updatedOpportunitySheet;
+  //     this.treasureHuntService.editTankInsulationReductionItem(this.editOpportunitySheetCardData.tankInsulationReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   } else if (this.editOpportunitySheetCardData.opportunityType == 'air-leak-survey') {
+  //     this.editOpportunitySheetCardData.airLeakSurvey.opportunitySheet = updatedOpportunitySheet;
+  //     // this.treasureHuntService.editAirLeakSurveyItem(this.editOpportunitySheetCardData.airLeakSurvey, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
+  //   }
+  //   this.hideOpportunitySheetModal();
+  // }
+
   saveItemOpportunitySheet(updatedOpportunitySheet: OpportunitySheet) {
     this.editOpportunitySheetCardData.opportunitySheet = updatedOpportunitySheet;
     this.opportunityCardsData[this.modifyDataIndex] = this.editOpportunitySheetCardData;
-    if (this.editOpportunitySheetCardData.opportunityType == 'lighting-replacement') {
-      this.editOpportunitySheetCardData.lightingReplacement.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editLightingReplacementTreasureHuntItem(this.editOpportunitySheetCardData.lightingReplacement, this.editOpportunitySheetCardData.opportunityIndex);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'replace-existing') {
-      this.editOpportunitySheetCardData.replaceExistingMotor.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editReplaceExistingMotorsItem(this.editOpportunitySheetCardData.replaceExistingMotor, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'motor-drive') {
-      this.editOpportunitySheetCardData.motorDrive.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editMotorDrivesItem(this.editOpportunitySheetCardData.motorDrive, this.editOpportunitySheetCardData.opportunityIndex);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'natural-gas-reduction') {
-      this.editOpportunitySheetCardData.naturalGasReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editNaturalGasReductionsItem(this.editOpportunitySheetCardData.naturalGasReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'electricity-reduction') {
-      this.editOpportunitySheetCardData.electricityReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editElectricityReductionsItem(this.editOpportunitySheetCardData.electricityReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'compressed-air-reduction') {
-      this.editOpportunitySheetCardData.compressedAirReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editCompressedAirReductionsItem(this.editOpportunitySheetCardData.compressedAirReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'compressed-air-pressure-reduction') {
-      this.editOpportunitySheetCardData.compressedAirPressureReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editCompressedAirPressureReductionsItem(this.editOpportunitySheetCardData.compressedAirPressureReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'water-reduction') {
-      this.editOpportunitySheetCardData.waterReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editWaterReductionsItem(this.editOpportunitySheetCardData.waterReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'steam-reduction') {
-      this.editOpportunitySheetCardData.steamReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editSteamReductionItem(this.editOpportunitySheetCardData.steamReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'pipe-insulation-reduction') {
-      this.editOpportunitySheetCardData.pipeInsulationReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editPipeInsulationReductionItem(this.editOpportunitySheetCardData.pipeInsulationReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'tank-insulation-reduction') {
-      this.editOpportunitySheetCardData.tankInsulationReduction.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editTankInsulationReductionItem(this.editOpportunitySheetCardData.tankInsulationReduction, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    } else if (this.editOpportunitySheetCardData.opportunityType == 'air-leak-survey') {
-      this.editOpportunitySheetCardData.airLeakSurvey.opportunitySheet = updatedOpportunitySheet;
-      this.treasureHuntService.editAirLeakSurveyItem(this.editOpportunitySheetCardData.airLeakSurvey, this.editOpportunitySheetCardData.opportunityIndex, this.settings);
-    }
+    this.editOpportunity(this.editOpportunitySheetCardData);
     this.hideOpportunitySheetModal();
   }
 
@@ -276,7 +300,7 @@ export class OpportunityCardsComponent implements OnInit {
       this.treasureHuntService.editTankInsulationReductionItem(cardData.tankInsulationReduction, cardData.opportunityIndex, this.settings);
     } else if (cardData.opportunityType == 'air-leak-survey') {
       cardData.airLeakSurvey.selected = cardData.selected;
-      this.treasureHuntService.editAirLeakSurveyItem(cardData.airLeakSurvey, cardData.opportunityIndex, this.settings);
+      // this.treasureHuntService.editAirLeakSurveyItem(cardData.airLeakSurvey, cardData.opportunityIndex, this.settings);
     }
   }
 
@@ -297,75 +321,85 @@ export class OpportunityCardsComponent implements OnInit {
       }
     });
   }
+
+  // createCopy(cardData: OpportunityCardData) {
+  //   let newOpportunityCard: OpportunityCardData = JSON.parse(JSON.stringify(cardData));
+  //   if (newOpportunityCard.opportunityType == 'lighting-replacement') {
+  //     newOpportunityCard.lightingReplacement.opportunitySheet = this.updateCopyName(newOpportunityCard.lightingReplacement.opportunitySheet);
+  //     this.treasureHuntService.addNewLightingReplacementTreasureHuntItem(newOpportunityCard.lightingReplacement);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getLightingReplacementCardData(newOpportunityCard.lightingReplacement, treasureHunt.lightingReplacements.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'replace-existing') {
+  //     newOpportunityCard.replaceExistingMotor.opportunitySheet = this.updateCopyName(newOpportunityCard.replaceExistingMotor.opportunitySheet);
+  //     this.treasureHuntService.addNewReplaceExistingMotorsItem(newOpportunityCard.replaceExistingMotor);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getReplaceExistingCardData(newOpportunityCard.replaceExistingMotor, treasureHunt.replaceExistingMotors.length - 1, treasureHunt.currentEnergyUsage, this.settings);
+  //   } else if (newOpportunityCard.opportunityType == 'motor-drive') {
+  //     newOpportunityCard.motorDrive.opportunitySheet = this.updateCopyName(newOpportunityCard.motorDrive.opportunitySheet);
+  //     this.treasureHuntService.addNewMotorDrivesItem(newOpportunityCard.motorDrive);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getMotorDriveCard(newOpportunityCard.motorDrive, treasureHunt.motorDrives.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'natural-gas-reduction') {
+  //     newOpportunityCard.naturalGasReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.naturalGasReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewNaturalGasReductionsItem(newOpportunityCard.naturalGasReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getNaturalGasReductionCard(newOpportunityCard.naturalGasReduction, this.settings, treasureHunt.naturalGasReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'electricity-reduction') {
+  //     newOpportunityCard.electricityReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.electricityReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewElectricityReductionsItem(newOpportunityCard.electricityReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getElectricityReductionCard(newOpportunityCard.electricityReduction, this.settings, treasureHunt.electricityReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'compressed-air-reduction') {
+  //     newOpportunityCard.compressedAirReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.compressedAirReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewCompressedAirReductionsItem(newOpportunityCard.compressedAirReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getCompressedAirReductionCardData(newOpportunityCard.compressedAirReduction, this.settings, treasureHunt.currentEnergyUsage, treasureHunt.compressedAirReductions.length - 1);
+  //   } else if (newOpportunityCard.opportunityType == 'compressed-air-pressure-reduction') {
+  //     newOpportunityCard.compressedAirPressureReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.compressedAirPressureReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewCompressedAirPressureReductionsItem(newOpportunityCard.compressedAirPressureReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getCompressedAirPressureReductionCardData(newOpportunityCard.compressedAirPressureReduction, this.settings, treasureHunt.compressedAirPressureReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'water-reduction') {
+  //     newOpportunityCard.waterReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.waterReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewWaterReductionsItem(newOpportunityCard.waterReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getWaterReductionCardData(newOpportunityCard.waterReduction, this.settings, treasureHunt.waterReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (cardData.opportunityType == 'opportunity-sheet') {
+  //     newOpportunityCard.opportunitySheet = this.updateCopyName(newOpportunityCard.opportunitySheet);
+  //     this.treasureHuntService.addNewOpportunitySheetsItem(newOpportunityCard.opportunitySheet);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getOpportunitySheetCardData(newOpportunityCard.opportunitySheet, treasureHunt.currentEnergyUsage, treasureHunt.waterReductions.length - 1, this.settings);
+  //   } else if (newOpportunityCard.opportunityType == 'steam-reduction') {
+  //     newOpportunityCard.steamReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.steamReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewSteamReductionItem(newOpportunityCard.steamReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getSteamReductionCardData(newOpportunityCard.steamReduction, this.settings, treasureHunt.steamReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'pipe-insulation-reduction') {
+  //     newOpportunityCard.pipeInsulationReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.pipeInsulationReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewPipeInsulationReductionItem(newOpportunityCard.pipeInsulationReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getPipeInsulationReductionCardData(newOpportunityCard.pipeInsulationReduction, this.settings, treasureHunt.pipeInsulationReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'tank-insulation-reduction') {
+  //     newOpportunityCard.tankInsulationReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.tankInsulationReduction.opportunitySheet);
+  //     this.treasureHuntService.addNewTankInsulationReductionItem(newOpportunityCard.tankInsulationReduction);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getTankInsulationReductionCardData(newOpportunityCard.tankInsulationReduction, this.settings, treasureHunt.tankInsulationReductions.length - 1, treasureHunt.currentEnergyUsage);
+  //   } else if (newOpportunityCard.opportunityType == 'air-leak-survey') {
+  //     newOpportunityCard.airLeakSurvey.opportunitySheet = this.updateCopyName(newOpportunityCard.airLeakSurvey.opportunitySheet);
+  //     // this.treasureHuntService.addNewAirLeakSurveyItem(newOpportunityCard.airLeakSurvey);
+  //     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+  //     newOpportunityCard = this.opportunityCardsService.getAirLeakSurveyCardData(newOpportunityCard.airLeakSurvey, this.settings, treasureHunt.airLeakSurveys.length - 1, treasureHunt.currentEnergyUsage);
+  //   }
+
+  //   this.opportunityCardsData.push(newOpportunityCard);
+  //   this.updateAllIndexes();
+  //   this.updateOpportunityCardsData();
+  // }
+
   createCopy(cardData: OpportunityCardData) {
     let newOpportunityCard: OpportunityCardData = JSON.parse(JSON.stringify(cardData));
-    if (newOpportunityCard.opportunityType == 'lighting-replacement') {
-      newOpportunityCard.lightingReplacement.opportunitySheet = this.updateCopyName(newOpportunityCard.lightingReplacement.opportunitySheet);
-      this.treasureHuntService.addNewLightingReplacementTreasureHuntItem(newOpportunityCard.lightingReplacement);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getLightingReplacementCardData(newOpportunityCard.lightingReplacement, treasureHunt.lightingReplacements.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'replace-existing') {
-      newOpportunityCard.replaceExistingMotor.opportunitySheet = this.updateCopyName(newOpportunityCard.replaceExistingMotor.opportunitySheet);
-      this.treasureHuntService.addNewReplaceExistingMotorsItem(newOpportunityCard.replaceExistingMotor);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getReplaceExistingCardData(newOpportunityCard.replaceExistingMotor, treasureHunt.replaceExistingMotors.length - 1, treasureHunt.currentEnergyUsage, this.settings);
-    } else if (newOpportunityCard.opportunityType == 'motor-drive') {
-      newOpportunityCard.motorDrive.opportunitySheet = this.updateCopyName(newOpportunityCard.motorDrive.opportunitySheet);
-      this.treasureHuntService.addNewMotorDrivesItem(newOpportunityCard.motorDrive);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getMotorDriveCard(newOpportunityCard.motorDrive, treasureHunt.motorDrives.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'natural-gas-reduction') {
-      newOpportunityCard.naturalGasReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.naturalGasReduction.opportunitySheet);
-      this.treasureHuntService.addNewNaturalGasReductionsItem(newOpportunityCard.naturalGasReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getNaturalGasReductionCard(newOpportunityCard.naturalGasReduction, this.settings, treasureHunt.naturalGasReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'electricity-reduction') {
-      newOpportunityCard.electricityReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.electricityReduction.opportunitySheet);
-      this.treasureHuntService.addNewElectricityReductionsItem(newOpportunityCard.electricityReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getElectricityReductionCard(newOpportunityCard.electricityReduction, this.settings, treasureHunt.electricityReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'compressed-air-reduction') {
-      newOpportunityCard.compressedAirReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.compressedAirReduction.opportunitySheet);
-      this.treasureHuntService.addNewCompressedAirReductionsItem(newOpportunityCard.compressedAirReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getCompressedAirReductionCardData(newOpportunityCard.compressedAirReduction, this.settings, treasureHunt.currentEnergyUsage, treasureHunt.compressedAirReductions.length - 1);
-    } else if (newOpportunityCard.opportunityType == 'compressed-air-pressure-reduction') {
-      newOpportunityCard.compressedAirPressureReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.compressedAirPressureReduction.opportunitySheet);
-      this.treasureHuntService.addNewCompressedAirPressureReductionsItem(newOpportunityCard.compressedAirPressureReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getCompressedAirPressureReductionCardData(newOpportunityCard.compressedAirPressureReduction, this.settings, treasureHunt.compressedAirPressureReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'water-reduction') {
-      newOpportunityCard.waterReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.waterReduction.opportunitySheet);
-      this.treasureHuntService.addNewWaterReductionsItem(newOpportunityCard.waterReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getWaterReductionCardData(newOpportunityCard.waterReduction, this.settings, treasureHunt.waterReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (cardData.opportunityType == 'opportunity-sheet') {
-      newOpportunityCard.opportunitySheet = this.updateCopyName(newOpportunityCard.opportunitySheet);
-      this.treasureHuntService.addNewOpportunitySheetsItem(newOpportunityCard.opportunitySheet);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getOpportunitySheetCardData(newOpportunityCard.opportunitySheet, treasureHunt.currentEnergyUsage, treasureHunt.waterReductions.length - 1, this.settings);
-    } else if (newOpportunityCard.opportunityType == 'steam-reduction') {
-      newOpportunityCard.steamReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.steamReduction.opportunitySheet);
-      this.treasureHuntService.addNewSteamReductionItem(newOpportunityCard.steamReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getSteamReductionCardData(newOpportunityCard.steamReduction, this.settings, treasureHunt.steamReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'pipe-insulation-reduction') {
-      newOpportunityCard.pipeInsulationReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.pipeInsulationReduction.opportunitySheet);
-      this.treasureHuntService.addNewPipeInsulationReductionItem(newOpportunityCard.pipeInsulationReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getPipeInsulationReductionCardData(newOpportunityCard.pipeInsulationReduction, this.settings, treasureHunt.pipeInsulationReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'tank-insulation-reduction') {
-      newOpportunityCard.tankInsulationReduction.opportunitySheet = this.updateCopyName(newOpportunityCard.tankInsulationReduction.opportunitySheet);
-      this.treasureHuntService.addNewTankInsulationReductionItem(newOpportunityCard.tankInsulationReduction);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getTankInsulationReductionCardData(newOpportunityCard.tankInsulationReduction, this.settings, treasureHunt.tankInsulationReductions.length - 1, treasureHunt.currentEnergyUsage);
-    } else if (newOpportunityCard.opportunityType == 'air-leak-survey') {
-      newOpportunityCard.airLeakSurvey.opportunitySheet = this.updateCopyName(newOpportunityCard.airLeakSurvey.opportunitySheet);
-      this.treasureHuntService.addNewAirLeakSurveyItem(newOpportunityCard.airLeakSurvey);
-      let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
-      newOpportunityCard = this.opportunityCardsService.getAirLeakSurveyCardData(newOpportunityCard.airLeakSurvey, this.settings, treasureHunt.airLeakSurveys.length - 1, treasureHunt.currentEnergyUsage);
-    }
-
+    let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+    newOpportunityCard = this.calculatorsService.copyOpportunity(newOpportunityCard, treasureHunt, this.settings);
     this.opportunityCardsData.push(newOpportunityCard);
     this.updateAllIndexes();
     this.updateOpportunityCardsData();

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.service.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.service.ts
@@ -12,7 +12,9 @@ export class OpportunityCardsService {
   updatedOpportunityCard: BehaviorSubject<OpportunityCardData>;
   opportunityCards: BehaviorSubject<Array<OpportunityCardData>>;
   updateOpportunityCards: BehaviorSubject<boolean>;
-  constructor(private opportunitySheetService: OpportunitySheetService, private opportunitySummaryService: OpportunitySummaryService) {
+  constructor(private opportunitySheetService: OpportunitySheetService, 
+    private opportunitySummaryService: OpportunitySummaryService
+    ) {
     this.updatedOpportunityCard = new BehaviorSubject<OpportunityCardData>(undefined);
     this.opportunityCards = new BehaviorSubject(new Array());
     this.updateOpportunityCards = new BehaviorSubject<boolean>(true);
@@ -809,7 +811,7 @@ export class OpportunityCardsService {
     return opportunityCardsData;
   }
   getAirLeakSurveyCardData(airLeakSurvey: AirLeakSurveyTreasureHunt, settings: Settings, index: number, currentEnergyUsage: EnergyUsage): OpportunityCardData {
-    let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getAirLeakSurveySummary(airLeakSurvey, index, settings);
+    let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getIndividualOpportunitySummary(airLeakSurvey, index, settings);
     let unitStr: string;
     let currentCosts: number;
     //utilityType: 0 = Compressed Air, 1 = Electricity
@@ -865,8 +867,6 @@ export class OpportunityCardsService {
     }
   }
 }
-
-
 
 
 export interface OpportunityCardData {

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/air-leak-treasure-hunt.service.spec.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/air-leak-treasure-hunt.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AirLeakTreasureHuntService } from './air-leak-treasure-hunt.service';
+
+describe('AirLeakTreasureHuntService', () => {
+  let service: AirLeakTreasureHuntService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AirLeakTreasureHuntService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/air-leak-treasure-hunt.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/air-leak-treasure-hunt.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { AirLeakService } from '../../calculator/compressed-air/air-leak/air-leak.service';
+import { Settings } from '../../shared/models/settings';
+import { AirLeakSurveyOutput } from '../../shared/models/standalone';
+import { AirLeakSurveyTreasureHunt, TreasureHunt, TreasureHuntOpportunityResults } from '../../shared/models/treasure-hunt';
+
+@Injectable()
+export class AirLeakTreasureHuntService {
+
+  constructor(
+    // private opportunityCardsService: OpportunityCardsService,
+    private airLeakService: AirLeakService) { }
+
+
+  initNewAirLeakCalculator() {
+    this.airLeakService.airLeakInput.next(undefined);
+  }
+
+  setCalculatorInputFromOpportunity(airLeakSurvey: AirLeakSurveyTreasureHunt) {
+    this.airLeakService.airLeakInput.next(airLeakSurvey.airLeakSurveyInput);
+  }
+
+  deleteOpportunity(index: number, treasureHunt: TreasureHunt): TreasureHunt {
+    treasureHunt.airLeakSurveys.splice(index, 1);
+    return treasureHunt;
+  }
+
+  // saveTreasureHuntOpportunity<T>(T extends TreasureHuntOpportunity)
+  saveTreasureHuntOpportunity(airLeakSurvey: AirLeakSurveyTreasureHunt, treasureHunt: TreasureHunt): TreasureHunt {
+    if (!treasureHunt.airLeakSurveys) {
+      treasureHunt.airLeakSurveys = new Array();
+    }
+    treasureHunt.airLeakSurveys.push(airLeakSurvey);
+    return treasureHunt;
+  }
+
+  resetCalculatorInputs() {
+    this.airLeakService.airLeakInput.next(undefined);
+  }
+
+  // editAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt, treasureHunt: TreasureHunt, index: number, settings: Settings) {
+  //   treasureHunt.airLeakSurveys[index] = airLeakSurvey;
+  //   // this.treasureHuntCalculatorService.getUpdatedCard(airLeakSurvey, settings, index, treasureHunt);
+  //   // let updatedCard: OpportunityCardData = this.opportunityCardsService.getAirLeakSurveyCardData(airLeakSurvey, settings, index, treasureHunt.currentEnergyUsage);
+  //   // this.opportunityCardsService.updatedOpportunityCard.next(updatedCard);
+  //   return treasureHunt;
+  // }
+
+
+  getTreasureHuntOpportunityResults(airLeakSurveyTreasureHunt: AirLeakSurveyTreasureHunt, index, settings: Settings): TreasureHuntOpportunityResults {
+    let results: AirLeakSurveyOutput = this.airLeakService.getResults(settings, airLeakSurveyTreasureHunt.airLeakSurveyInput);
+    let treasureHuntOpportunityResults: TreasureHuntOpportunityResults = {
+      costSavings: results.savingsData.annualTotalElectricityCost,
+      energySavings: 0,
+      baselineCost: results.baselineData.annualTotalElectricityCost,
+      modificationCost: results.modificationData.annualTotalElectricityCost,
+      utilityType: '',
+      // attach index to oppSheet whenever it's assigned - replace 0 with index
+      opportunityDefaultName: 'Air Leak Survey #' + index
+    }
+
+    // utility type: 0 = compressed air, 1 = electric
+    if (airLeakSurveyTreasureHunt.airLeakSurveyInput.facilityCompressorData.utilityType == 0) {
+      treasureHuntOpportunityResults.energySavings = results.savingsData.annualTotalFlowRate;
+      treasureHuntOpportunityResults.utilityType = 'Compressed Air';
+    } else {
+      treasureHuntOpportunityResults.energySavings = results.savingsData.annualTotalElectricity;
+      treasureHuntOpportunityResults.utilityType = 'Electricity';
+    }
+
+    return treasureHuntOpportunityResults;
+  }
+
+}

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/treasure-hunt-calculator.service.spec.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/treasure-hunt-calculator.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TreasureHuntCalculatorService } from './treasure-hunt-calculator.service';
+
+describe('TreasureHuntCalculatorService', () => {
+  let service: TreasureHuntCalculatorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TreasureHuntCalculatorService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/treasure-hunt-calculator.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/treasure-hunt-calculator.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class TreasureHuntCalculatorService {
+
+  constructor(
+    ) { }
+
+
+}

--- a/src/app/treasure-hunt/treasure-hunt-report/opportunity-summary.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/opportunity-summary.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { OpportunitySheetService } from '../calculators/standalone-opportunity-sheet/opportunity-sheet.service';
-import { OpportunityCost, OpportunitySummary, TreasureHunt, ElectricityReductionTreasureHunt, MotorDriveInputsTreasureHunt, ReplaceExistingMotorTreasureHunt, LightingReplacementTreasureHunt, NaturalGasReductionTreasureHunt, OpportunitySheetResults, OpportunitySheet, CompressedAirReductionTreasureHunt, WaterReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt } from '../../shared/models/treasure-hunt';
+import { OpportunityCost, OpportunitySummary, TreasureHunt, ElectricityReductionTreasureHunt, MotorDriveInputsTreasureHunt, ReplaceExistingMotorTreasureHunt, LightingReplacementTreasureHunt, NaturalGasReductionTreasureHunt, OpportunitySheetResults, OpportunitySheet, CompressedAirReductionTreasureHunt, WaterReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, TreasureHuntOpportunity, TreasureHuntResults, OpportunitySheetResult, TreasureHuntOpportunityResults } from '../../shared/models/treasure-hunt';
 import { Settings } from '../../shared/models/settings';
 import { LightingReplacementService } from '../../calculator/lighting/lighting-replacement/lighting-replacement.service';
 import { LightingReplacementResults } from '../../shared/models/lighting';
@@ -18,6 +18,7 @@ import { SteamReductionService } from '../../calculator/steam/steam-reduction/st
 import { TankInsulationReductionService } from '../../calculator/steam/tank-insulation-reduction/tank-insulation-reduction.service';
 import { AirLeakService } from '../../calculator/compressed-air/air-leak/air-leak.service';
 import { processEquipmentOptions } from '../calculators/opportunity-sheet/general-details-form/processEquipmentOptions';
+import { AirLeakTreasureHuntService } from '../treasure-hunt-calculator-services/air-leak-treasure-hunt.service';
 
 @Injectable()
 export class OpportunitySummaryService {
@@ -27,7 +28,9 @@ export class OpportunitySummaryService {
     private naturalGasReductionService: NaturalGasReductionService, private compressedAirReductionService: CompressedAirReductionService,
     private waterReductionService: WaterReductionService, private compressedAirPressureReductionService: CompressedAirPressureReductionService,
     private steamReductionService: SteamReductionService, private pipeInsulationReductionService: PipeInsulationReductionService,
-    private tankInsulationReductionService: TankInsulationReductionService, private airLeakService: AirLeakService) { }
+    private tankInsulationReductionService: TankInsulationReductionService, 
+    private airLeakService: AirLeakService,
+    private airLeakTreasureHuntService: AirLeakTreasureHuntService) { }
 
   getOpportunitySummaries(treasureHunt: TreasureHunt, settings: Settings): Array<OpportunitySummary> {
     let opportunitySummaries: Array<OpportunitySummary> = new Array<OpportunitySummary>();
@@ -53,14 +56,252 @@ export class OpportunitySummaryService {
     opportunitySummaries = this.getPipeInsulationReductionSummaries(treasureHunt.pipeInsulationReductions, opportunitySummaries, settings);
     //tank insulation reduction
     opportunitySummaries = this.getTankInsulationReductionSummaries(treasureHunt.tankInsulationReductions, opportunitySummaries, settings);
-    //air leak survey
-    opportunitySummaries = this.getAirLeakSurveySummaries(treasureHunt.airLeakSurveys, opportunitySummaries, settings);
+    
+    // Genericish
+    opportunitySummaries = this.getTreasureHuntOpportunitySummaries(treasureHunt.airLeakSurveys, opportunitySummaries, settings);
+    // opportunitySummaries = this.getAirLeakSurveySummaries(treasureHunt.airLeakSurveys, opportunitySummaries, settings);
     //standalone opp sheets
     opportunitySummaries = this.getOpportunitySheetSummaries(treasureHunt.opportunitySheets, opportunitySummaries, settings);
 
 
     return opportunitySummaries;
   }
+
+  getTreasureHuntOpportunitySummaries(opportunities: Array<TreasureHuntOpportunity>, opportunitySummaries: Array<OpportunitySummary>, settings: Settings): Array<OpportunitySummary> {
+    if (opportunities) {
+      let index: number = 1;
+      opportunities.forEach(opportunity => {
+        if (opportunity.selected) {
+          let oppSummary: OpportunitySummary = this.getIndividualOpportunitySummary(opportunity, index, settings);
+          opportunitySummaries.push(oppSummary);
+        }
+        index++;
+      });
+    }
+    return opportunitySummaries;
+  }
+
+    
+  getEquipmentDisplay2(equipment): string {
+    if (equipment) {
+      let findEquipment = processEquipmentOptions.find(option => { return option.value == equipment });
+      if (findEquipment) {
+        return findEquipment.display;
+      }
+    }
+    return
+  }
+
+  getOpportunityMetaData(opportunitySheet: OpportunitySheet, defaultName: string): OpportunityMetaData {
+    let teamData = {
+      name: defaultName,
+      team: undefined,
+      equipment: undefined,
+      owner: undefined,
+      utilityType: undefined,
+      opportunityCost: undefined
+    }
+    if (opportunitySheet) {
+      if (opportunitySheet.name) {
+        teamData.name = opportunitySheet.name;
+      }
+      teamData.opportunityCost = opportunitySheet.opportunityCost;
+      teamData.team = opportunitySheet.owner;
+      teamData.owner = opportunitySheet.businessUnits;
+      teamData.equipment = this.getEquipmentDisplay(opportunitySheet.equipment);
+    }
+    return teamData;
+  }
+
+  getNewOpportunitySummary2(opportunityMetaData: OpportunityMetaData, results: TreasureHuntOpportunityResults, mixedIndividualResults?: Array<OpportunitySummary>): OpportunitySummary {
+    let totalCost: number = this.opportunitySheetService.getOppSheetImplementationCost(opportunityMetaData.opportunityCost)
+    let payback: number = totalCost / results.costSavings;
+    if (opportunityMetaData.opportunityCost && opportunityMetaData.opportunityCost.additionalAnnualSavings) {
+      payback = totalCost / (results.costSavings + opportunityMetaData.opportunityCost.additionalAnnualSavings.cost);
+    }
+    return {
+      opportunityName: opportunityMetaData.name,
+      utilityType: results.utilityType,
+      costSavings: results.costSavings,
+      totalCost: totalCost,
+      payback: payback,
+      opportunityCost: opportunityMetaData.opportunityCost,
+      totalEnergySavings: results.energySavings,
+      mixedIndividualResults: mixedIndividualResults,
+      selected: true,
+      baselineCost: results.baselineCost,
+      modificationCost: results.modificationCost,
+      team: opportunityMetaData.team,
+      equipment: opportunityMetaData.equipment,
+      owner: opportunityMetaData.owner
+    }
+  }
+
+  
+  getIndividualOpportunitySummary(thOpportunity: TreasureHuntOpportunity, index: number, settings: Settings): OpportunitySummary {
+    // pass to another service for narrowing
+    let results: TreasureHuntOpportunityResults = this.getCalculatorTreasureHuntResults(thOpportunity, index, settings);
+    let opportunityMetaData: OpportunityMetaData = this.getOpportunityMetaData(thOpportunity.opportunitySheet, results.opportunityDefaultName);
+    let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, results);
+    return oppSummary;
+  }
+  
+  getCalculatorTreasureHuntResults(treasureHuntOpportunity: TreasureHuntOpportunity, index, settings: Settings): TreasureHuntOpportunityResults {
+    let treasureHuntOpportunityResults: TreasureHuntOpportunityResults; 
+    if (treasureHuntOpportunity.opportunityType === 'air-leak-survey') {
+      let airLeakSurveyOpportunity = treasureHuntOpportunity as AirLeakSurveyTreasureHunt;
+      treasureHuntOpportunityResults = this.airLeakTreasureHuntService.getTreasureHuntOpportunityResults(airLeakSurveyOpportunity, index, settings);
+    } else if (treasureHuntOpportunity.opportunityType === '') {
+
+    }
+
+    return treasureHuntOpportunityResults;
+  }
+
+    //stand alone opp sheets
+    getOpportunitySheetSummaries2(opportunitySheets: Array<OpportunitySheet>, opportunitySummaries: Array<OpportunitySummary>, settings: Settings, getAllResults?: boolean): Array<OpportunitySummary> {
+      if (opportunitySheets) {
+        opportunitySheets.forEach(oppSheet => {
+          if (oppSheet.selected || getAllResults) {
+            let oppSummary: OpportunitySummary = this.getOpportunitySheetSummary(oppSheet, settings);
+            if (oppSummary) {
+              opportunitySummaries.push(oppSummary);
+            }
+          }
+        });
+      }
+      return opportunitySummaries;
+    }
+  
+    getOpportunitySheetSummary2(oppSheet: OpportunitySheet, settings: Settings): OpportunitySummary {
+      let mixedIndividualSummaries: Array<OpportunitySummary> = new Array<OpportunitySummary>();
+      let oppSheetResults: OpportunitySheetResults = this.opportunitySheetService.getResults(oppSheet, settings);
+      let numEnergyTypes: number = 0;
+      let totalEnergySavings: number = 0;
+      let energyTypeLabel: string;
+      let opportunityMetaData: OpportunityMetaData = {
+        name: oppSheet.name,
+        team: oppSheet.owner,
+        equipment: this.getEquipmentDisplay(oppSheet.equipment),
+        owner: oppSheet.businessUnits,
+        opportunityCost: oppSheet.opportunityCost
+      }
+      let treasureHuntOpportunityResults: TreasureHuntOpportunityResults;
+
+      for (let key in oppSheetResults) {
+        if (oppSheetResults[key].baselineItems != 0 || oppSheetResults[key].modificationItems != 0 && oppSheetResults[key].baselineItems != undefined) {
+          numEnergyTypes = numEnergyTypes + 1;
+        }
+      }
+      //electricity
+      if (oppSheetResults.electricityResults.baselineItems != 0 || oppSheetResults.electricityResults.modificationItems != 0) {
+        energyTypeLabel = 'Electricity';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.electricityResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.electricityResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.electricityResults.energyCostSavings, oppSheetResults.electricityResults.energySavings, oppSheet.opportunityCost, oppSheetResults.electricityResults.baselineEnergyCost, oppSheetResults.electricityResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //compressed air
+      if (oppSheetResults.compressedAirResults.baselineItems != 0 || oppSheetResults.compressedAirResults.modificationItems != 0) {
+        energyTypeLabel = 'Compressed Air';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.compressedAirResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.compressedAirResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.compressedAirResults.energyCostSavings, oppSheetResults.compressedAirResults.energySavings, oppSheet.opportunityCost, oppSheetResults.compressedAirResults.baselineEnergyCost, oppSheetResults.compressedAirResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //natural gas
+      if (oppSheetResults.gasResults.baselineItems != 0 || oppSheetResults.gasResults.modificationItems != 0) {
+        energyTypeLabel = 'Natural Gas';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.gasResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.gasResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.gasResults.energyCostSavings, oppSheetResults.gasResults.energySavings, oppSheet.opportunityCost, oppSheetResults.gasResults.baselineEnergyCost, oppSheetResults.gasResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //water
+      if (oppSheetResults.waterResults.baselineItems != 0 || oppSheetResults.waterResults.modificationItems != 0) {
+        energyTypeLabel = 'Water';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.waterResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.waterResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.waterResults.energyCostSavings, oppSheetResults.waterResults.energySavings, oppSheet.opportunityCost, oppSheetResults.waterResults.baselineEnergyCost, oppSheetResults.waterResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //waste water
+      if (oppSheetResults.wasteWaterResults.baselineItems != 0 || oppSheetResults.wasteWaterResults.modificationItems != 0) {
+        energyTypeLabel = 'Waste Water';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.wasteWaterResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.wasteWaterResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.wasteWaterResults.energyCostSavings, oppSheetResults.wasteWaterResults.energySavings, oppSheet.opportunityCost, oppSheetResults.wasteWaterResults.baselineEnergyCost, oppSheetResults.wasteWaterResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //steam
+      if (oppSheetResults.steamResults.baselineItems != 0 || oppSheetResults.steamResults.modificationItems != 0) {
+        energyTypeLabel = 'Steam';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.steamResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.steamResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.steamResults.energyCostSavings, oppSheetResults.steamResults.energySavings, oppSheet.opportunityCost, oppSheetResults.steamResults.baselineEnergyCost, oppSheetResults.steamResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //other fuel
+      if (oppSheetResults.otherFuelResults.baselineItems != 0 || oppSheetResults.otherFuelResults.modificationItems != 0) {
+        energyTypeLabel = 'Other Fuel';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.otherFuelResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.otherFuelResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+        // let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(oppSheet.name, energyTypeLabel, oppSheetResults.otherFuelResults.energyCostSavings, oppSheetResults.otherFuelResults.energySavings, oppSheet.opportunityCost, oppSheetResults.otherFuelResults.baselineEnergyCost, oppSheetResults.otherFuelResults.modificationEnergyCost, team, equipment, owner)
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      let oppSummary: OpportunitySummary;
+      //if only one energy source in opp sheet
+      if (numEnergyTypes == 1) {
+        oppSummary = mixedIndividualSummaries[0];
+      } else if (numEnergyTypes > 1) {
+        treasureHuntOpportunityResults.utilityType = 'Mixed';
+        treasureHuntOpportunityResults.costSavings = oppSheetResults.totalCostSavings;
+        treasureHuntOpportunityResults.energySavings = oppSheetResults.totalEnergySavings;
+        treasureHuntOpportunityResults.baselineCost = 0;
+        treasureHuntOpportunityResults.modificationCost = 0;
+        oppSummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults, mixedIndividualSummaries);
+        // oppSummary = this.getNewOpportunitySummary(oppSheet.name, 'Mixed', oppSheetResults.totalCostSavings, oppSheetResults.totalEnergySavings, oppSheet.opportunityCost, 0, 0, team, equipment, owner, mixedIndividualSummaries);
+      } else {
+        //no energy savings
+        treasureHuntOpportunityResults.utilityType = 'None';
+        treasureHuntOpportunityResults.costSavings = 0;
+        treasureHuntOpportunityResults.energySavings = 0;
+        treasureHuntOpportunityResults.baselineCost = 0;
+        treasureHuntOpportunityResults.modificationCost = 0;
+        opportunityMetaData.opportunityCost = undefined;
+        oppSummary = this.getNewOpportunitySummary2(opportunityMetaData, treasureHuntOpportunityResults);
+      }
+      return oppSummary;
+    }
+
+    setResultsFromOppSheet(sheetResults: OpportunitySheetResult, utilityType: string): TreasureHuntOpportunityResults {
+      let treasureHuntOpportunityResults: TreasureHuntOpportunityResults = {
+        costSavings: 0,
+        energySavings: 0,
+        baselineCost: 0,
+        modificationCost: 0,
+        utilityType: '',
+      }
+
+      treasureHuntOpportunityResults.baselineCost = sheetResults.baselineEnergyCost;
+      treasureHuntOpportunityResults.modificationCost = sheetResults.modificationEnergyCost;
+      treasureHuntOpportunityResults.costSavings = sheetResults.energyCostSavings;
+      treasureHuntOpportunityResults.energySavings = sheetResults.energySavings;
+      treasureHuntOpportunityResults.utilityType = utilityType;
+
+      return treasureHuntOpportunityResults;
+    }
+
+
+//old methods
+  //======================================
 
   getNewOpportunitySummary(opportunityName: string, utilityType: string, costSavings: number, totalEnergySavings: number, opportunityCost: OpportunityCost, baselineCost: number, modificationCost: number, team: string, equipment: string, owner: string, mixedIndividualResults?: Array<OpportunitySummary>): OpportunitySummary {
     let totalCost: number = this.opportunitySheetService.getOppSheetImplementationCost(opportunityCost)
@@ -525,6 +766,7 @@ export class OpportunitySummaryService {
     return opportunitySummaries;
   }
 
+
   getAirLeakSurveySummary(airLeakSurvey: AirLeakSurveyTreasureHunt, index: number, settings: Settings): OpportunitySummary {
     let name: string = 'Air Leak Survey #' + index;
     let results: AirLeakSurveyOutput = this.airLeakService.getResults(settings, airLeakSurvey.airLeakSurveyInput);
@@ -556,7 +798,9 @@ export class OpportunitySummaryService {
   }
 
 
-  //stand alone opp sheets
+
+
+  // //stand alone opp sheets
   getOpportunitySheetSummaries(opportunitySheets: Array<OpportunitySheet>, opportunitySummaries: Array<OpportunitySummary>, settings: Settings, getAllResults?: boolean): Array<OpportunitySummary> {
     if (opportunitySheets) {
       opportunitySheets.forEach(oppSheet => {
@@ -657,4 +901,12 @@ export class OpportunitySummaryService {
     }
     return
   }
+}
+
+export interface OpportunityMetaData {
+    name: string,
+    team: string,
+    equipment: string,
+    owner: string,
+    opportunityCost: OpportunityCost
 }

--- a/src/app/treasure-hunt/treasure-hunt.module.ts
+++ b/src/app/treasure-hunt/treasure-hunt.module.ts
@@ -29,6 +29,8 @@ import { ConvertInputDataService } from './convert-input-data.service';
 import { RouterModule } from '@angular/router';
 import { TreasureChestMenuModule } from './treasure-chest/treasure-chest-menu/treasure-chest-menu.module';
 import { UpdateUnitsModalModule } from '../shared/update-units-modal/update-units-modal.module';
+import { TreasureHuntCalculatorService } from './treasure-hunt-calculator-services/treasure-hunt-calculator.service';
+import { AirLeakTreasureHuntService } from './treasure-hunt-calculator-services/air-leak-treasure-hunt.service';
 
 @NgModule({
   imports: [
@@ -64,7 +66,9 @@ import { UpdateUnitsModalModule } from '../shared/update-units-modal/update-unit
     TreasureHuntReportService,
     OpportunityCardsService, 
     SortCardsService,
-    ConvertInputDataService
+    ConvertInputDataService,
+    TreasureHuntCalculatorService,
+    AirLeakTreasureHuntService
   ]
 })
 export class TreasureHuntModule { }

--- a/src/app/treasure-hunt/treasure-hunt.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { OpportunitySheet, TreasureHunt, LightingReplacementTreasureHunt, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt, CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt } from '../shared/models/treasure-hunt';
+import { OpportunitySheet, TreasureHunt, LightingReplacementTreasureHunt, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt, CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, TreasureHuntOpportunity } from '../shared/models/treasure-hunt';
 import { OpportunityCardsService, OpportunityCardData } from './treasure-chest/opportunity-cards/opportunity-cards.service';
 import { Settings } from '../shared/models/settings';
 
@@ -14,7 +14,9 @@ export class TreasureHuntService {
   getResults: BehaviorSubject<boolean>;
   updateMenuOptions: BehaviorSubject<boolean>;
   modalOpen: BehaviorSubject<boolean>;
-  constructor(private opportunityCardsService: OpportunityCardsService) {
+  constructor(
+    private opportunityCardsService: OpportunityCardsService
+    ) {
     this.mainTab = new BehaviorSubject<string>('system-basics');
     this.subTab = new BehaviorSubject<string>('settings');
     this.getResults = new BehaviorSubject<boolean>(true);
@@ -281,25 +283,29 @@ export class TreasureHuntService {
   }
 
   //air leak survey
-  addNewAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt) {
-    let treasureHunt: TreasureHunt = this.treasureHunt.value;
-    if (!treasureHunt.airLeakSurveys) {
-      treasureHunt.airLeakSurveys = new Array();
-    }
-    treasureHunt.airLeakSurveys.push(airLeakSurvey);
-    this.treasureHunt.next(treasureHunt);
-  }
-  editAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt, index: number, settings: Settings) {
-    let treasureHunt: TreasureHunt = this.treasureHunt.value;
-    treasureHunt.airLeakSurveys[index] = airLeakSurvey;
-    let updatedCard: OpportunityCardData = this.opportunityCardsService.getAirLeakSurveyCardData(airLeakSurvey, settings, index, treasureHunt.currentEnergyUsage);
-    this.opportunityCardsService.updatedOpportunityCard.next(updatedCard);
-    this.treasureHunt.next(treasureHunt);
-  }
-  deleteAirLeakSurveyItem(index: number) {
-    let treasureHunt: TreasureHunt = this.treasureHunt.value;
-    treasureHunt.airLeakSurveys.splice(index, 1);
-    this.treasureHunt.next(treasureHunt);
-  }
+  // addNewAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt) {
+  //   let treasureHunt: TreasureHunt = this.treasureHunt.value;
+  //   if (!treasureHunt.airLeakSurveys) {
+  //     treasureHunt.airLeakSurveys = new Array();
+  //   }
+  //   treasureHunt.airLeakSurveys.push(airLeakSurvey);
+  //   this.treasureHunt.next(treasureHunt);
+  // }
+  
+  // editAirLeakSurveyItem(airLeakSurvey: AirLeakSurveyTreasureHunt, index: number, settings: Settings) {
+  //   let treasureHunt: TreasureHunt = this.treasureHunt.value;
+  //   treasureHunt.airLeakSurveys[index] = airLeakSurvey;
+  //   let updatedCard: OpportunityCardData = this.opportunityCardsService.getAirLeakSurveyCardData(airLeakSurvey, settings, index, treasureHunt.currentEnergyUsage);
+  //   this.opportunityCardsService.updatedOpportunityCard.next(updatedCard);
+  //   this.treasureHunt.next(treasureHunt);
+  // }
+  // deleteAirLeakSurveyItem(index: number) {
+  //   let treasureHunt: TreasureHunt = this.treasureHunt.value;
+  //   treasureHunt.airLeakSurveys.splice(index, 1);
+  //   this.treasureHunt.next(treasureHunt);
+  // }
+
+
 
 }
+


### PR DESCRIPTION
connects #4454 

Still need to rename things, change all the calc references (beside air-leak survey), get interfaces in the right file

- Adding individual TH Calc helper services.
- Removing all methods in Treasure-hunt.service.
- Calculators.component - removing all individual ___TreasureHunt methods and using one method that takes broad interface
- Opp-summary.service - removing all individual methods, passing 2 object args to generic method instead of 11 args
- Moving switching/calcType logic from opp-card.component to calculators service (not much of a win here)
- May be able to consolidate opp-cards.service like opp-summary.service


