### PR TITLE
Issue 4617

### DIFF
--- a/src/app/compressed-air-assessment/compressed-air-assessment.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-assessment.component.html
@@ -6,7 +6,7 @@
   <!--end header-->
   <div *ngIf="mainTab == 'system-setup'" class="d-flex tab-content">
     <div class="w-50 panel-column modification scroll-item"
-      [ngClass]="{'modal-open': isModalOpen == true || showUpdateUnitsModal, 'w-50': setupTab != 'system-profile', 'w-75': setupTab == 'system-profile'}"
+      [ngClass]="{'modal-open': isModalOpen == true || showUpdateUnitsModal, 'w-50': setupTab != 'system-profile', 'w-100': setupTab == 'system-profile'}"
       [ngStyle]="{'height.px': containerHeight}">
       <app-system-basics *ngIf="setupTab == 'system-basics'" (openUpdateUnitsModal)="initUpdateUnitsModal($event)"
         [assessment]="assessment"></app-system-basics>
@@ -21,7 +21,7 @@
       <app-system-profile-graphs *ngIf="setupTab == 'system-profile' && profileTab == 'graphs'">
       </app-system-profile-graphs>
     </div>
-    <div class="scroll-item" [ngClass]="{'w-50': setupTab != 'system-profile', 'w-25': setupTab == 'system-profile'}"
+    <div *ngIf="setupTab != 'system-profile'" class="scroll-item" [ngClass]="{'w-50': setupTab != 'system-profile'}"
       [ngStyle]="{'height.px': containerHeight}">
       <app-results-panel></app-results-panel>
     </div>

--- a/src/app/compressed-air-assessment/compressed-air-assessment.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-assessment.component.html
@@ -22,11 +22,11 @@
     <div *ngIf="setupTab == 'system-profile'" class="w-100 scroll-item"
       [ngClass]="{'modal-open': isModalOpen == true || showUpdateUnitsModal}"
       [ngStyle]="{'height.px': containerHeight}">
-      <app-system-profile-setup *ngIf="setupTab == 'system-profile' && profileTab == 'setup'">
+      <app-system-profile-setup class="w-100" *ngIf="setupTab == 'system-profile' && profileTab == 'setup'">
       </app-system-profile-setup>
-      <app-system-profile-summary *ngIf="setupTab == 'system-profile' && profileTab == 'summary'">
+      <app-system-profile-summary class="w-100" *ngIf="setupTab == 'system-profile' && profileTab == 'summary'">
       </app-system-profile-summary>
-      <app-system-profile-graphs *ngIf="setupTab == 'system-profile' && profileTab == 'graphs'">
+      <app-system-profile-graphs class="w-100" *ngIf="setupTab == 'system-profile' && profileTab == 'graphs'">
       </app-system-profile-graphs>
     </div>
   </div>

--- a/src/app/compressed-air-assessment/compressed-air-assessment.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-assessment.component.html
@@ -5,8 +5,8 @@
   </div>
   <!--end header-->
   <div *ngIf="mainTab == 'system-setup'" class="d-flex tab-content">
-    <div class="w-50 panel-column modification scroll-item"
-      [ngClass]="{'modal-open': isModalOpen == true || showUpdateUnitsModal, 'w-50': setupTab != 'system-profile', 'w-100': setupTab == 'system-profile'}"
+    <div class="w-50 panel-column modification scroll-item" *ngIf="setupTab !='system-profile'"
+      [ngClass]="{'modal-open': isModalOpen == true || showUpdateUnitsModal}"
       [ngStyle]="{'height.px': containerHeight}">
       <app-system-basics *ngIf="setupTab == 'system-basics'" (openUpdateUnitsModal)="initUpdateUnitsModal($event)"
         [assessment]="assessment"></app-system-basics>
@@ -14,16 +14,20 @@
       <app-day-types *ngIf="setupTab == 'day-types'"></app-day-types>
       <app-end-uses *ngIf="setupTab == 'end-uses'"></app-end-uses>
       <app-inventory *ngIf="setupTab == 'inventory'"></app-inventory>
+    </div>
+    <div *ngIf="setupTab != 'system-profile'" class="scroll-item" [ngClass]="{'w-50': setupTab != 'system-profile'}"
+      [ngStyle]="{'height.px': containerHeight}">
+      <app-results-panel></app-results-panel>
+    </div>
+    <div *ngIf="setupTab == 'system-profile'" class="w-100 scroll-item"
+      [ngClass]="{'modal-open': isModalOpen == true || showUpdateUnitsModal}"
+      [ngStyle]="{'height.px': containerHeight}">
       <app-system-profile-setup *ngIf="setupTab == 'system-profile' && profileTab == 'setup'">
       </app-system-profile-setup>
       <app-system-profile-summary *ngIf="setupTab == 'system-profile' && profileTab == 'summary'">
       </app-system-profile-summary>
       <app-system-profile-graphs *ngIf="setupTab == 'system-profile' && profileTab == 'graphs'">
       </app-system-profile-graphs>
-    </div>
-    <div *ngIf="setupTab != 'system-profile'" class="scroll-item" [ngClass]="{'w-50': setupTab != 'system-profile'}"
-      [ngStyle]="{'height.px': containerHeight}">
-      <app-results-panel></app-results-panel>
     </div>
   </div>
 

--- a/src/app/compressed-air-assessment/compressed-air-banner/setup-tabs/setup-tabs.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-banner/setup-tabs/setup-tabs.component.html
@@ -45,7 +45,7 @@
 
 <ul *ngIf="setupTab == 'system-profile'" class="tabs subtabs progress-tabs compressed-air">
     <li [ngClass]="{'active': profileTab == 'setup'}">
-        <a (click)="changeProfileTab('setup')">System Profile</a>
+        <a (click)="changeProfileTab('setup')">Setup Profile</a>
     </li>
     <li [ngClass]="{'active': profileTab == 'summary'}">
         <a (click)="changeProfileTab('summary')">Profile Summary</a>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.html
@@ -1,12 +1,14 @@
-<div class="p-2">
+<div class="p-3">
     <!--air flow-->
     <div #airflowGraph id="airflowGraph"></div>
 </div>
-<div class="p-2">
+<hr>
+<div class="p-3">
     <!--power-->
     <div #powerGraph id="powerGraph"></div>
 </div>
-<div class="p-2">
+<hr>
+<div class="p-3">
     <!--% capacity-->
     <div #capacityGraph id="capacityGraph"></div>
 </div>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.html
@@ -1,1 +1,12 @@
-<p>system-profile-graphs works!</p>
+<div class="p-2">
+    <!--air flow-->
+    <div #airflowGraph id="airflowGraph"></div>
+</div>
+<div class="p-2">
+    <!--power-->
+    <div #powerGraph id="powerGraph"></div>
+</div>
+<div class="p-2">
+    <!--% capacity-->
+    <div #capacityGraph id="capacityGraph"></div>
+</div>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.ts
@@ -46,15 +46,24 @@ export class SystemProfileGraphsComponent implements OnInit {
     if (this.profileSummary && this.airflowGraph) {
       // let chartData: Array<ProfileChartData> = this.getChartData();
       let traceData = new Array();
+      let rgbaInterval: number =  1 / (this.profileSummary.length + 1);
+      let rgbaOpacity: number = 1;
       this.profileSummary.forEach(compressorProfile => {
         let trace = {
           x: compressorProfile.profileSummaryData.map(data => { return data.timeInterval }),
           y: compressorProfile.profileSummaryData.map(data => { return data.airflow }),
           type: 'bar',
-          name: compressorProfile.compressorName
+          name: compressorProfile.compressorName,
+          marker: {
+            color: 'rgba(112, 48, 160,' + rgbaOpacity + ')',
+            line: {
+              width: 3
+            }
+          },
 
         }
         traceData.push(trace);
+        rgbaOpacity = rgbaOpacity - rgbaInterval;
       })
       var layout = {
         barmode: 'stack',
@@ -66,7 +75,7 @@ export class SystemProfileGraphsComponent implements OnInit {
         },
         xaxis: {
           // ticksuffix: '%',
-          // autotick: false,
+          autotick: false,
           title: {
             text: 'Hour',
             font: {
@@ -110,15 +119,24 @@ export class SystemProfileGraphsComponent implements OnInit {
     if (this.profileSummary && this.powerGraph) {
       // let chartData: Array<ProfileChartData> = this.getChartData();
       let traceData = new Array();
+      let rgbaInterval: number =  1 / (this.profileSummary.length + 1);
+      let rgbaOpacity: number = 1;
+
       this.profileSummary.forEach(compressorProfile => {
         let trace = {
           x: compressorProfile.profileSummaryData.map(data => { return data.timeInterval }),
           y: compressorProfile.profileSummaryData.map(data => { return data.power }),
           type: 'bar',
-          name: compressorProfile.compressorName
-
+          name: compressorProfile.compressorName,
+          marker: {
+            color: 'rgba(112, 48, 160,' + rgbaOpacity + ')',
+            line: {
+              width: 3
+            }
+          }
         }
         traceData.push(trace);
+        rgbaOpacity = rgbaOpacity - rgbaInterval;
       })
       var layout = {
         barmode: 'stack',
@@ -171,15 +189,23 @@ export class SystemProfileGraphsComponent implements OnInit {
     if (this.profileSummary && this.capacityGraph) {
       // let chartData: Array<ProfileChartData> = this.getChartData();
       let traceData = new Array();
+      let rgbaInterval: number =  1 / (this.profileSummary.length + 1);
+      let rgbaOpacity: number = 1;
       this.profileSummary.forEach(compressorProfile => {
         let trace = {
           x: compressorProfile.profileSummaryData.map(data => { return data.timeInterval }),
-          y: compressorProfile.profileSummaryData.map(data => { return data.percentCapacity }),
+          y: compressorProfile.profileSummaryData.map(data => { return data.percentSystemCapacity }),
           type: 'bar',
-          name: compressorProfile.compressorName
-
+          name: compressorProfile.compressorName,
+          marker: {
+            color: 'rgba(112, 48, 160,' + rgbaOpacity + ')',
+            line: {
+              width: 3
+            }
+          }
         }
         traceData.push(trace);
+        rgbaOpacity = rgbaOpacity - rgbaInterval;
       })
       var layout = {
         barmode: 'stack',
@@ -201,7 +227,7 @@ export class SystemProfileGraphsComponent implements OnInit {
           automargin: true
         },
         yaxis: {
-          // range: [0, 105],
+          range: [0, 105],
           ticksuffix: '%',
           title: {
             text: 'Capacity (%)',

--- a/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-graphs/system-profile-graphs.component.ts
@@ -1,5 +1,9 @@
-import { Component, OnInit } from '@angular/core';
-
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ProfileSummary } from '../../../shared/models/compressed-air-assessment';
+import { CompressedAirAssessmentService } from '../../compressed-air-assessment.service';
+import { SystemProfileService } from '../system-profile.service';
+import * as Plotly from 'plotly.js';
 @Component({
   selector: 'app-system-profile-graphs',
   templateUrl: './system-profile-graphs.component.html',
@@ -7,9 +11,221 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SystemProfileGraphsComponent implements OnInit {
 
-  constructor() { }
+  @ViewChild("airflowGraph", { static: false }) airflowGraph: ElementRef;
+  @ViewChild("powerGraph", { static: false }) powerGraph: ElementRef;
+  @ViewChild("capacityGraph", { static: false }) capacityGraph: ElementRef;
+
+  compressedAirAssessmentSub: Subscription;
+  profileSummary: Array<ProfileSummary>;
+  constructor(private systemProfileService: SystemProfileService, private compressedAirAssessmentService: CompressedAirAssessmentService) { }
 
   ngOnInit(): void {
+    this.compressedAirAssessmentSub = this.compressedAirAssessmentService.compressedAirAssessment.subscribe(val => {
+      this.profileSummary = this.systemProfileService.calculateProfileSummary(val);
+      this.drawCharts();
+    });
   }
 
+  ngOnDestroy() {
+    this.compressedAirAssessmentSub.unsubscribe();
+  }
+
+
+  ngAfterViewInit() {
+    this.drawCharts();
+  }
+
+
+  drawCharts() {
+    this.drawAirflowChart();
+    this.drawPowerChart();
+    this.drawCapacityChart();
+  }
+
+  drawAirflowChart() {
+    if (this.profileSummary && this.airflowGraph) {
+      // let chartData: Array<ProfileChartData> = this.getChartData();
+      let traceData = new Array();
+      this.profileSummary.forEach(compressorProfile => {
+        let trace = {
+          x: compressorProfile.profileSummaryData.map(data => { return data.timeInterval }),
+          y: compressorProfile.profileSummaryData.map(data => { return data.airflow }),
+          type: 'bar',
+          name: compressorProfile.compressorName
+
+        }
+        traceData.push(trace);
+      })
+      var layout = {
+        barmode: 'stack',
+        title: {
+          text: 'System Air Flow',
+          font: {
+            size: 18
+          },
+        },
+        xaxis: {
+          // ticksuffix: '%',
+          // autotick: false,
+          title: {
+            text: 'Hour',
+            font: {
+              size: 16
+            },
+          },
+          automargin: true
+        },
+        yaxis: {
+          // range: [0, 105],
+          // ticksuffix: '%',
+          title: {
+            text: 'Airflow (acfm)',
+            font: {
+              size: 16
+            },
+          },
+          hoverformat: ",.2f",
+          // automargin: true
+        },
+        margin: {
+          t: 20,
+          r: 20
+        },
+        legend: {
+          orientation: "h",
+          y: 1.5
+        }
+      };
+      var config = {
+        responsive: true,
+        displaylogo: false
+      };
+      Plotly.newPlot(this.airflowGraph.nativeElement, traceData, layout, config);
+    }
+
+
+  }
+
+  drawPowerChart() {
+    if (this.profileSummary && this.powerGraph) {
+      // let chartData: Array<ProfileChartData> = this.getChartData();
+      let traceData = new Array();
+      this.profileSummary.forEach(compressorProfile => {
+        let trace = {
+          x: compressorProfile.profileSummaryData.map(data => { return data.timeInterval }),
+          y: compressorProfile.profileSummaryData.map(data => { return data.power }),
+          type: 'bar',
+          name: compressorProfile.compressorName
+
+        }
+        traceData.push(trace);
+      })
+      var layout = {
+        barmode: 'stack',
+        title: {
+          text: 'System Power',
+          font: {
+            size: 18
+          },
+        },
+        xaxis: {
+          // ticksuffix: '%',
+          autotick: false,
+          title: {
+            text: 'Hour',
+            font: {
+              size: 16
+            },
+          },
+          automargin: true
+        },
+        yaxis: {
+          // range: [0, 105],
+          // ticksuffix: '%',
+          title: {
+            text: 'Power (kW)',
+            font: {
+              size: 16
+            },
+          },
+          hoverformat: ",.2f",
+          // automargin: true
+        },
+        margin: {
+          t: 20,
+          r: 20
+        },
+        legend: {
+          orientation: "h",
+          y: 1.5
+        }
+      };
+      var config = {
+        responsive: true,
+        displaylogo: false
+      };
+      Plotly.newPlot(this.powerGraph.nativeElement, traceData, layout, config);
+    }
+  }
+  drawCapacityChart() {
+    if (this.profileSummary && this.capacityGraph) {
+      // let chartData: Array<ProfileChartData> = this.getChartData();
+      let traceData = new Array();
+      this.profileSummary.forEach(compressorProfile => {
+        let trace = {
+          x: compressorProfile.profileSummaryData.map(data => { return data.timeInterval }),
+          y: compressorProfile.profileSummaryData.map(data => { return data.percentCapacity }),
+          type: 'bar',
+          name: compressorProfile.compressorName
+
+        }
+        traceData.push(trace);
+      })
+      var layout = {
+        barmode: 'stack',
+        title: {
+          text: 'System Capacity',
+          font: {
+            size: 18
+          },
+        },
+        xaxis: {
+          // ticksuffix: '%',
+          autotick: false,
+          title: {
+            text: 'Hour',
+            font: {
+              size: 16
+            },
+          },
+          automargin: true
+        },
+        yaxis: {
+          // range: [0, 105],
+          ticksuffix: '%',
+          title: {
+            text: 'Capacity (%)',
+            font: {
+              size: 16
+            },
+          },
+          hoverformat: ",.2f",
+          // automargin: true
+        },
+        margin: {
+          t: 20,
+          r: 20
+        },
+        legend: {
+          orientation: "h",
+          y: 1.5
+        }
+      };
+      var config = {
+        responsive: true,
+        displaylogo: false
+      };
+      Plotly.newPlot(this.capacityGraph.nativeElement, traceData, layout, config);
+    }
+  }
 }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/compressor-ordering-table/compressor-ordering-table.component.css
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/compressor-ordering-table/compressor-ordering-table.component.css
@@ -4,6 +4,7 @@ td, th{
     border-right: solid 1px darkgray;
     border-left: solid 1px darkgray;
     padding: 3px;
+    white-space: nowrap;
   }
   
   /* tr > td:first-child {
@@ -15,3 +16,7 @@ td, th{
     box-shadow: 0 4px 8px 0 grey
   }
   
+
+  select.form-control{
+    width: 100%;
+  }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/compressor-ordering-table/compressor-ordering-table.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/compressor-ordering-table/compressor-ordering-table.component.html
@@ -2,7 +2,7 @@
     Compressor Ordering
 </label>
 
-<table class="table table-striped">
+<table class="table table-striped bg-white">
     <thead>
         <tr>
             <th>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/compressor-ordering-table/compressor-ordering-table.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/compressor-ordering-table/compressor-ordering-table.component.html
@@ -5,7 +5,9 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th>Compressor Name</th>
+            <th>
+                <!-- Compressor Name -->
+            </th>
             <th *ngFor="let interval of hourIntervals">
                 {{interval}}
             </th>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.css
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.css
@@ -4,6 +4,7 @@ td, th{
     border-right: solid 1px darkgray;
     border-left: solid 1px darkgray;
     padding: 3px;
+    white-space: nowrap;
   }
   
   /* tr > td:first-child {
@@ -17,5 +18,5 @@ td, th{
   
 
   input.form-control{
-      width: 40px !important;
+      width: 100%;
   }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.css
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.css
@@ -1,0 +1,21 @@
+
+td, th{
+    font-size: small;
+    border-right: solid 1px darkgray;
+    border-left: solid 1px darkgray;
+    padding: 3px;
+  }
+  
+  /* tr > td:first-child {
+    border-right: none;
+  }
+   */
+  
+  table {
+    box-shadow: 0 4px 8px 0 grey
+  }
+  
+
+  input.form-control{
+      width: 40px !important;
+  }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.html
@@ -2,7 +2,7 @@
     Profile Data
 </label>
 
-<table class="table table-striped">
+<table class="table table-striped bg-white">
     <thead>
         <tr>
             <th>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.html
@@ -1,1 +1,43 @@
-<p>operating-profile-table works!</p>
+<label class="group-label">
+    Profile Data
+</label>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>
+                <!-- Compressor Name -->
+
+            </th>
+            <td>
+                
+            </td>
+            <th *ngFor="let interval of hourIntervals">
+                {{interval}}
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let summary of profileSummary; let compressorIndex = index;">
+            <td class="bold">
+                {{summary.compressorName}}
+            </td>
+            <td>
+                <span *ngIf="profileDataType == 'power'">Power</span>
+                <span *ngIf="profileDataType == 'percentCapacity'">% Capacity</span>
+                <span *ngIf="profileDataType == 'airflow'">Airflow</span>
+            </td>
+            <td *ngFor="let summaryData of summary.profileSummaryData; let dataIndex = index;">
+                <input *ngIf="profileDataType == 'power'" type="number" class="form-control"
+                    id="{{'order_'+compressorIndex+dataIndex}}" name="{{'summaryData_'+compressorIndex+dataIndex}}"
+                    [(ngModel)]="profileSummary[compressorIndex].profileSummaryData[dataIndex].power">
+                <input *ngIf="profileDataType == 'airflow'" type="number" class="form-control"
+                    id="{{'order_'+compressorIndex+dataIndex}}" name="{{'summaryData_'+compressorIndex+dataIndex}}"
+                    [(ngModel)]="profileSummary[compressorIndex].profileSummaryData[dataIndex].airflow">
+                <input *ngIf="profileDataType == 'percentCapacity'" type="number" class="form-control"
+                    id="{{'order_'+compressorIndex+dataIndex}}" name="{{'summaryData_'+compressorIndex+dataIndex}}"
+                    [(ngModel)]="profileSummary[compressorIndex].profileSummaryData[dataIndex].percentCapacity">
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { CompressedAirAssessment, CompressorInventoryItem, CompressorOrderItem, ProfileSummary, ProfileSummaryData, SystemProfileSetup } from '../../../../shared/models/compressed-air-assessment';
+import { CompressedAirAssessmentService } from '../../../compressed-air-assessment.service';
+import { SystemProfileService } from '../../system-profile.service';
 
 @Component({
   selector: 'app-operating-profile-table',
@@ -7,9 +11,83 @@ import { Component, OnInit } from '@angular/core';
 })
 export class OperatingProfileTableComponent implements OnInit {
 
-  constructor() { }
+  compressedAirAssessmentSub: Subscription;
+  isFormChange: boolean = false;
+  // orderingOptions: Array<number>;
+  compressorOrdering: Array<CompressorOrderItem>
+  hourIntervals: Array<number>;
+  profileSummary: Array<ProfileSummary>;
+  profileDataType: "power" | "percentCapacity" | "airflow";
+  constructor(private systemProfileService: SystemProfileService, private compressedAirAssessmentService: CompressedAirAssessmentService) { }
 
   ngOnInit(): void {
+    this.compressedAirAssessmentSub = this.compressedAirAssessmentService.compressedAirAssessment.subscribe(val => {
+      if (val && this.isFormChange == false) {
+        this.profileDataType = val.systemProfile.systemProfileSetup.profileDataType;
+        this.profileSummary = val.systemProfile.profileSummary;
+        this.initializeProfileSummary(val.compressorInventoryItems, val.systemProfile.systemProfileSetup);
+      } else {
+        this.isFormChange = false;
+      }
+    });
   }
 
+  ngOnDestroy() {
+    this.compressedAirAssessmentSub.unsubscribe();
+  }
+
+  initializeProfileSummary(compressorInventoryItems: Array<CompressorInventoryItem>, systemProfileSetup: SystemProfileSetup) {
+    if (this.profileSummary.length != compressorInventoryItems.length) {
+      this.profileSummary = new Array();
+      compressorInventoryItems.forEach(item => {
+        this.hourIntervals = new Array();
+        let profileSummaryData: Array<ProfileSummaryData> = new Array();
+        for (let timeInterval = 1; timeInterval <= systemProfileSetup.numberOfHours;) {
+          profileSummaryData.push({
+            power: undefined,
+            airflow: undefined,
+            percentCapacity: Math.floor(Math.random() * 100),
+            timeInterval: timeInterval,
+            percentPower: undefined
+          })
+          this.hourIntervals.push(timeInterval);
+          timeInterval = timeInterval + systemProfileSetup.dataInterval;
+        }
+        this.profileSummary.push({
+          compressorName: item.name,
+          compressorId: item.itemId,
+          profileSummaryData: profileSummaryData
+        })
+      });
+      this.save();
+    } else {
+      this.profileSummary.forEach(summaryItem => {
+        this.hourIntervals = new Array();
+        let profileSummaryData: Array<ProfileSummaryData> = new Array();
+        for (let timeInterval = 1; timeInterval <= systemProfileSetup.numberOfHours;) {
+          profileSummaryData.push({
+            power: undefined,
+            airflow: undefined,
+            percentCapacity: Math.floor(Math.random() * 100),
+            timeInterval: timeInterval,
+            percentPower: undefined
+          })
+          this.hourIntervals.push(timeInterval);
+          timeInterval = timeInterval + systemProfileSetup.dataInterval;
+        }
+        if (summaryItem.profileSummaryData.length != profileSummaryData.length) {
+          summaryItem.profileSummaryData = profileSummaryData;
+        }
+      });
+      this.save();
+    }
+  }
+
+  save() {
+    this.isFormChange = true;
+    // let systemProfileSetup: SystemProfileSetup = this.systemProfileService.getProfileSetupFromForm(this.form);
+    let compressedAirAssessment: CompressedAirAssessment = this.compressedAirAssessmentService.compressedAirAssessment.getValue();
+    compressedAirAssessment.systemProfile.profileSummary = this.profileSummary;
+    this.compressedAirAssessmentService.updateCompressedAir(compressedAirAssessment);
+  }
 }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.ts
@@ -37,7 +37,7 @@ export class OperatingProfileTableComponent implements OnInit {
   }
 
   initializeProfileSummary(compressorInventoryItems: Array<CompressorInventoryItem>, systemProfileSetup: SystemProfileSetup) {
-    if (this.profileSummary.length != compressorInventoryItems.length) {
+    // if (this.profileSummary.length != compressorInventoryItems.length) {
       this.profileSummary = new Array();
       compressorInventoryItems.forEach(item => {
         this.hourIntervals = new Array();
@@ -48,7 +48,8 @@ export class OperatingProfileTableComponent implements OnInit {
             airflow: undefined,
             percentCapacity: Math.floor(Math.random() * 100),
             timeInterval: timeInterval,
-            percentPower: undefined
+            percentPower: undefined,
+            percentSystemCapacity: 0
           })
           this.hourIntervals.push(timeInterval);
           timeInterval = timeInterval + systemProfileSetup.dataInterval;
@@ -60,27 +61,28 @@ export class OperatingProfileTableComponent implements OnInit {
         })
       });
       this.save();
-    } else {
-      this.profileSummary.forEach(summaryItem => {
-        this.hourIntervals = new Array();
-        let profileSummaryData: Array<ProfileSummaryData> = new Array();
-        for (let timeInterval = 1; timeInterval <= systemProfileSetup.numberOfHours;) {
-          profileSummaryData.push({
-            power: undefined,
-            airflow: undefined,
-            percentCapacity: Math.floor(Math.random() * 100),
-            timeInterval: timeInterval,
-            percentPower: undefined
-          })
-          this.hourIntervals.push(timeInterval);
-          timeInterval = timeInterval + systemProfileSetup.dataInterval;
-        }
-        if (summaryItem.profileSummaryData.length != profileSummaryData.length) {
-          summaryItem.profileSummaryData = profileSummaryData;
-        }
-      });
-      this.save();
-    }
+    // } else {
+    //   this.profileSummary.forEach(summaryItem => {
+    //     this.hourIntervals = new Array();
+    //     let profileSummaryData: Array<ProfileSummaryData> = new Array();
+    //     for (let timeInterval = 1; timeInterval <= systemProfileSetup.numberOfHours;) {
+    //       profileSummaryData.push({
+    //         power: undefined,
+    //         airflow: undefined,
+    //         percentCapacity: Math.floor(Math.random() * 100),
+    //         timeInterval: timeInterval,
+    //         percentPower: undefined,
+    //         percentSystemCapacity: 0
+    //       })
+    //       this.hourIntervals.push(timeInterval);
+    //       timeInterval = timeInterval + systemProfileSetup.dataInterval;
+    //     }
+    //     if (summaryItem.profileSummaryData.length != profileSummaryData.length) {
+    //       summaryItem.profileSummaryData = profileSummaryData;
+    //     }
+    //   });
+    //   this.save();
+    // }
   }
 
   save() {

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/profile-setup-form/profile-setup-form.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/profile-setup-form/profile-setup-form.component.html
@@ -35,5 +35,16 @@
                 <label>109 - 120 psig</label>
             </div>
         </div>
+        <div class="col-6">
+            <div class="form-group">
+                <label for="profileDataType">Profile Data Type</label>
+                <select class="form-control" id="profileDataType" formControlName="profileDataType"
+                (focus)="focusField('profileDataType')" (change)="save()">
+                    <option [ngValue]="'percentCapacity'">Airflow, % Capacity</option>
+                    <option [ngValue]="'power'">Calc Power, kW</option>
+                    <option [ngValue]="'airflow'">Calc Airflow, acfm</option>
+                </select>
+            </div>
+        </div>
     </div>
 </form>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/profile-setup-form/profile-setup-form.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/profile-setup-form/profile-setup-form.component.html
@@ -1,5 +1,5 @@
 <form class="p-2" [formGroup]="form">
-    <div class="row m-0">
+    <div class="row m-0 bg-white">
         <div class="col-6">
             <div class="form-group">
                 <label for="dayType">Select Day Type</label>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/system-profile-setup.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/system-profile-setup.component.html
@@ -1,9 +1,13 @@
-<app-profile-setup-form></app-profile-setup-form>
-<hr>
-<div class="p-2">
-    <app-compressor-ordering-table></app-compressor-ordering-table>
-</div>
-<hr>
-<div class="p-2">
-    <app-operating-profile-table></app-operating-profile-table>
+<div class="p-3">
+    <div class="bg-white">
+        <app-profile-setup-form></app-profile-setup-form>
+        <hr>
+        <div class="p-2">
+            <app-compressor-ordering-table></app-compressor-ordering-table>
+        </div>
+        <hr>
+        <div class="p-2 scroll-item">
+            <app-operating-profile-table></app-operating-profile-table>
+        </div>
+    </div>
 </div>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/system-profile-setup.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/system-profile-setup.component.html
@@ -4,4 +4,6 @@
     <app-compressor-ordering-table></app-compressor-ordering-table>
 </div>
 <hr>
-<app-operating-profile-table></app-operating-profile-table>
+<div class="p-2">
+    <app-operating-profile-table></app-operating-profile-table>
+</div>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.css
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.css
@@ -1,0 +1,22 @@
+
+td, th{
+    font-size: small;
+    border-right: solid 1px darkgray;
+    border-left: solid 1px darkgray;
+    padding: 3px;
+    white-space: nowrap;
+  }
+  
+  /* tr > td:first-child {
+    border-right: none;
+  }
+   */
+  
+  table {
+    box-shadow: 0 4px 8px 0 grey
+  }
+  
+
+  .compressor-name-row{
+      background-color: lightgray !important;
+  }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.html
@@ -1,5 +1,5 @@
 <div class="p-2">
-    <table class="table table-hover">
+    <table class="table table-hover bg-white">
         <thead>
             <tr>
                 <th>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.html
@@ -1,4 +1,4 @@
-<div class="p-2">
+<div class="pl-2 pt-3 pr-2">
     <table class="table table-hover bg-white">
         <thead>
             <tr>
@@ -48,7 +48,7 @@
                 </td>
             </tr>
         </tbody>
-        <tfoot>
+        <tbody>
             <tr class="compressor-name-row">
                 <td class="bold" colspan="100">Totals</td>
             </tr>
@@ -84,6 +84,6 @@
                     {{total.percentPower | number:'1.0-2'}}
                 </td>
             </tr>
-        </tfoot>
+        </tbody>
     </table>
 </div>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.html
@@ -1,1 +1,89 @@
-<p>system-profile-summary works!</p>
+<div class="p-2">
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th>
+                    <!-- Compressor Name -->
+
+                </th>
+                <th *ngFor="let summaryData of profileSummary[0].profileSummaryData">
+                    {{summaryData.timeInterval}}
+                </th>
+            </tr>
+        </thead>
+        <tbody *ngFor="let summary of profileSummary; let compressorIndex = index;">
+            <tr class="compressor-name-row">
+                <td colspan="100" class="bold">{{summary.compressorName}}</td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    Calc Power, kW
+                </td>
+                <td *ngFor="let summaryData of summary.profileSummaryData;">
+                    {{summaryData.power | number:'1.0-2'}}
+                </td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    Calc Airflow, acfm
+                </td>
+                <td *ngFor="let summaryData of summary.profileSummaryData;">
+                    {{summaryData.airflow | number:'1.0-2'}}
+                </td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    % Capacity
+                </td>
+                <td *ngFor="let summaryData of summary.profileSummaryData;">
+                    {{summaryData.percentCapacity | number:'1.0-2'}}
+                </td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    % Power
+                </td>
+                <td *ngFor="let summaryData of summary.profileSummaryData;">
+                    {{summaryData.percentPower | number:'1.0-2'}}
+                </td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr class="compressor-name-row">
+                <td class="bold" colspan="100">Totals</td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    Calc Power, kW
+                </td>
+                <td *ngFor="let total of totals;">
+                    {{total.power | number:'1.0-2'}}
+                </td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    Calc Airflow, acfm
+                </td>
+                <td *ngFor="let total of totals;">
+                    {{total.airflow | number:'1.0-2'}}
+                </td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    % Capacity
+                </td>
+                <td *ngFor="let total of totals;">
+                    {{total.percentCapacity | number:'1.0-2'}}
+                </td>
+            </tr>
+            <tr>
+                <td class="pl-2">
+                    % Power
+                </td>
+                <td *ngFor="let total of totals;">
+                    {{total.percentPower | number:'1.0-2'}}
+                </td>
+            </tr>
+        </tfoot>
+    </table>
+</div>

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.ts
@@ -1,4 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { CompressorInventoryItem, ProfileSummary, ProfileSummaryData } from '../../../shared/models/compressed-air-assessment';
+import { CompressedAirAssessmentService } from '../../compressed-air-assessment.service';
+import { CompressedAirCalculationService, CompressorCalcResult } from '../../compressed-air-calculation.service';
+import { SystemProfileService } from '../system-profile.service';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-system-profile-summary',
@@ -7,9 +13,77 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SystemProfileSummaryComponent implements OnInit {
 
-  constructor() { }
+  compressedAirAssessmentSub: Subscription;
+  profileSummary: Array<ProfileSummary>;
+  inventoryItems: Array<CompressorInventoryItem>;
+  profileDataType: "power" | "percentCapacity" | "airflow";
+  totals: Array<{
+    airflow: number;
+    power: number;
+    percentCapacity: number;
+    percentPower: number;
+  }>;
+  constructor(private systemProfileService: SystemProfileService, private compressedAirAssessmentService: CompressedAirAssessmentService,
+    private compressedAirCalculationService: CompressedAirCalculationService) { }
 
   ngOnInit(): void {
+    this.compressedAirAssessmentSub = this.compressedAirAssessmentService.compressedAirAssessment.subscribe(val => {
+      this.inventoryItems = val.compressorInventoryItems;
+      this.profileDataType = val.systemProfile.systemProfileSetup.profileDataType;
+      this.profileSummary = this.calculateProfileSummary(val.systemProfile.profileSummary);
+      this.setTotals();
+    });
   }
 
+  ngOnDestroy() {
+    this.compressedAirAssessmentSub.unsubscribe();
+  }
+
+  calculateProfileSummary(profileSummary: Array<ProfileSummary>): Array<ProfileSummary> {
+    profileSummary.forEach(summary => {
+      let compressor: CompressorInventoryItem = this.inventoryItems.find(item => { return item.itemId == summary.compressorId });
+      summary.profileSummaryData.forEach(summaryData => {
+        let computeFrom: 1 | 2 | 3;
+        let computeFromVal: number;
+        if (this.profileDataType == 'power') {
+          computeFrom = 2;
+          computeFromVal = summaryData.power;
+        } else if (this.profileDataType == 'percentCapacity') {
+          computeFrom = 1;
+          computeFromVal = summaryData.percentCapacity;
+        } else if (this.profileDataType == 'airflow') {
+          computeFrom = 3;
+          computeFromVal = summaryData.airflow;
+        }
+        let calcResult: CompressorCalcResult = this.compressedAirCalculationService.compressorsCalc(compressor, computeFrom, computeFromVal);
+        summaryData.airflow = calcResult.capacityCalculated;
+        summaryData.power = calcResult.powerCalculated;
+        summaryData.percentCapacity = calcResult.percentageCapacity;
+        summaryData.percentPower = calcResult.percentagePower;
+      });
+    });
+    return profileSummary;
+  }
+
+  setTotals() {
+    this.totals = new Array();
+    let intervals: Array<number> = this.profileSummary[0].profileSummaryData.map(data => { return data.timeInterval });
+    let allData: Array<ProfileSummaryData> = _.flatMap(this.profileSummary, (summary) => { return summary.profileSummaryData });
+
+    intervals.forEach(interval => {
+      let filteredData: Array<ProfileSummaryData> = allData.filter(data => { return data.timeInterval == interval });
+      let totalAirFlow: number = _.sumBy(filteredData, 'airflow');
+      let totalPower: number = _.sumBy(filteredData, 'power');
+      let totalPercentCapacity: number = _.sumBy(filteredData, 'percentCapacity');
+      let percentCapacity: number = totalPercentCapacity / filteredData.length;
+      let totalPercentPower: number = _.sumBy(filteredData, 'percentPower');
+      let percentPower: number = totalPercentPower / filteredData.length;
+      this.totals.push({
+        airflow: totalAirFlow,
+        power: totalPower,
+        percentCapacity: percentCapacity,
+        percentPower: percentPower
+      });
+    });
+  }
 }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { CompressorInventoryItem, ProfileSummary, ProfileSummaryData } from '../../../shared/models/compressed-air-assessment';
+import { ProfileSummary } from '../../../shared/models/compressed-air-assessment';
 import { CompressedAirAssessmentService } from '../../compressed-air-assessment.service';
-import { CompressedAirCalculationService, CompressorCalcResult } from '../../compressed-air-calculation.service';
 import { SystemProfileService } from '../system-profile.service';
 import * as _ from 'lodash';
 
@@ -15,75 +14,22 @@ export class SystemProfileSummaryComponent implements OnInit {
 
   compressedAirAssessmentSub: Subscription;
   profileSummary: Array<ProfileSummary>;
-  inventoryItems: Array<CompressorInventoryItem>;
-  profileDataType: "power" | "percentCapacity" | "airflow";
   totals: Array<{
     airflow: number;
     power: number;
     percentCapacity: number;
     percentPower: number;
   }>;
-  constructor(private systemProfileService: SystemProfileService, private compressedAirAssessmentService: CompressedAirAssessmentService,
-    private compressedAirCalculationService: CompressedAirCalculationService) { }
+  constructor(private systemProfileService: SystemProfileService, private compressedAirAssessmentService: CompressedAirAssessmentService) { }
 
   ngOnInit(): void {
     this.compressedAirAssessmentSub = this.compressedAirAssessmentService.compressedAirAssessment.subscribe(val => {
-      this.inventoryItems = val.compressorInventoryItems;
-      this.profileDataType = val.systemProfile.systemProfileSetup.profileDataType;
-      this.profileSummary = this.calculateProfileSummary(val.systemProfile.profileSummary);
-      this.setTotals();
+      this.profileSummary = this.systemProfileService.calculateProfileSummary(val);
+      this.totals = this.systemProfileService.calculateProfileSummaryTotals(this.profileSummary);
     });
   }
 
   ngOnDestroy() {
     this.compressedAirAssessmentSub.unsubscribe();
-  }
-
-  calculateProfileSummary(profileSummary: Array<ProfileSummary>): Array<ProfileSummary> {
-    profileSummary.forEach(summary => {
-      let compressor: CompressorInventoryItem = this.inventoryItems.find(item => { return item.itemId == summary.compressorId });
-      summary.profileSummaryData.forEach(summaryData => {
-        let computeFrom: 1 | 2 | 3;
-        let computeFromVal: number;
-        if (this.profileDataType == 'power') {
-          computeFrom = 2;
-          computeFromVal = summaryData.power;
-        } else if (this.profileDataType == 'percentCapacity') {
-          computeFrom = 1;
-          computeFromVal = summaryData.percentCapacity;
-        } else if (this.profileDataType == 'airflow') {
-          computeFrom = 3;
-          computeFromVal = summaryData.airflow;
-        }
-        let calcResult: CompressorCalcResult = this.compressedAirCalculationService.compressorsCalc(compressor, computeFrom, computeFromVal);
-        summaryData.airflow = calcResult.capacityCalculated;
-        summaryData.power = calcResult.powerCalculated;
-        summaryData.percentCapacity = calcResult.percentageCapacity;
-        summaryData.percentPower = calcResult.percentagePower;
-      });
-    });
-    return profileSummary;
-  }
-
-  setTotals() {
-    this.totals = new Array();
-    let intervals: Array<number> = this.profileSummary[0].profileSummaryData.map(data => { return data.timeInterval });
-    let allData: Array<ProfileSummaryData> = _.flatMap(this.profileSummary, (summary) => { return summary.profileSummaryData });
-
-    intervals.forEach(interval => {
-      let filteredData: Array<ProfileSummaryData> = allData.filter(data => { return data.timeInterval == interval });
-      let totalAirFlow: number = _.sumBy(filteredData, 'airflow');
-      let totalPower: number = _.sumBy(filteredData, 'power');
-      let totalPercentCapacity: number = _.sumBy(filteredData, 'percentCapacity');
-      let percentCapacity: number = totalPercentCapacity / filteredData.length;
-      let totalPercentPower: number = _.sumBy(filteredData, 'percentPower');
-      let percentPower: number = totalPercentPower / filteredData.length;
-      this.totals.push({
-        airflow: totalAirFlow,
-        power: totalPower,
-        percentCapacity: percentCapacity,
-        percentPower: percentPower
-      });
-    });
   }
 }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-summary/system-profile-summary.component.ts
@@ -25,7 +25,7 @@ export class SystemProfileSummaryComponent implements OnInit {
   ngOnInit(): void {
     this.compressedAirAssessmentSub = this.compressedAirAssessmentService.compressedAirAssessment.subscribe(val => {
       this.profileSummary = this.systemProfileService.calculateProfileSummary(val);
-      this.totals = this.systemProfileService.calculateProfileSummaryTotals(this.profileSummary);
+      this.totals = this.systemProfileService.calculateProfileSummaryTotals(val);
     });
   }
 

--- a/src/app/compressed-air-assessment/system-profile/system-profile.service.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile.service.ts
@@ -13,7 +13,8 @@ export class SystemProfileService {
     let form: FormGroup = this.formBuilder.group({
       dayType: [systemProfileSetup.dayType],
       numberOfHours: [systemProfileSetup.numberOfHours, [Validators.required, Validators.min(24)]],
-      dataInterval: [systemProfileSetup.dataInterval, [Validators.required]]
+      dataInterval: [systemProfileSetup.dataInterval, [Validators.required]],
+      profileDataType: [systemProfileSetup.profileDataType]
     })
     return form;
   }
@@ -22,7 +23,8 @@ export class SystemProfileService {
     return {
       dayType: form.controls.dayType.value,
       numberOfHours: form.controls.numberOfHours.value,
-      dataInterval: form.controls.dataInterval.value
+      dataInterval: form.controls.dataInterval.value,
+      profileDataType: form.controls.profileDataType.value
     }
   }
 

--- a/src/app/compressed-air-assessment/system-profile/system-profile.service.ts
+++ b/src/app/compressed-air-assessment/system-profile/system-profile.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { SystemProfileSetup } from '../../shared/models/compressed-air-assessment';
+import { CompressedAirAssessment, CompressorInventoryItem, ProfileSummary, ProfileSummaryData, SystemProfileSetup } from '../../shared/models/compressed-air-assessment';
+import { CompressedAirCalculationService, CompressorCalcResult } from '../compressed-air-calculation.service';
+import * as _ from 'lodash';
 
 @Injectable()
 export class SystemProfileService {
 
 
 
-  constructor(private formBuilder: FormBuilder) { }
+  constructor(private formBuilder: FormBuilder, private compressedAirCalculationService: CompressedAirCalculationService) { }
 
   getProfileSetupFormFromObj(systemProfileSetup: SystemProfileSetup): FormGroup {
     let form: FormGroup = this.formBuilder.group({
@@ -19,7 +21,7 @@ export class SystemProfileService {
     return form;
   }
 
-  getProfileSetupFromForm(form: FormGroup): SystemProfileSetup{
+  getProfileSetupFromForm(form: FormGroup): SystemProfileSetup {
     return {
       dayType: form.controls.dayType.value,
       numberOfHours: form.controls.numberOfHours.value,
@@ -28,4 +30,53 @@ export class SystemProfileService {
     }
   }
 
+
+  calculateProfileSummary(compressedAirAssessment: CompressedAirAssessment): Array<ProfileSummary> {
+    compressedAirAssessment.systemProfile.profileSummary.forEach(summary => {
+      let compressor: CompressorInventoryItem = compressedAirAssessment.compressorInventoryItems.find(item => { return item.itemId == summary.compressorId });
+      summary.profileSummaryData.forEach(summaryData => {
+        let computeFrom: 1 | 2 | 3;
+        let computeFromVal: number;
+        if (compressedAirAssessment.systemProfile.systemProfileSetup.profileDataType == 'power') {
+          computeFrom = 2;
+          computeFromVal = summaryData.power;
+        } else if (compressedAirAssessment.systemProfile.systemProfileSetup.profileDataType == 'percentCapacity') {
+          computeFrom = 1;
+          computeFromVal = summaryData.percentCapacity;
+        } else if (compressedAirAssessment.systemProfile.systemProfileSetup.profileDataType == 'airflow') {
+          computeFrom = 3;
+          computeFromVal = summaryData.airflow;
+        }
+        let calcResult: CompressorCalcResult = this.compressedAirCalculationService.compressorsCalc(compressor, computeFrom, computeFromVal);
+        summaryData.airflow = calcResult.capacityCalculated;
+        summaryData.power = calcResult.powerCalculated;
+        summaryData.percentCapacity = calcResult.percentageCapacity;
+        summaryData.percentPower = calcResult.percentagePower;
+      });
+    });
+    return compressedAirAssessment.systemProfile.profileSummary;
+  }
+
+  calculateProfileSummaryTotals(profileSummary: Array<ProfileSummary>): Array<{ airflow: number, power: number, percentCapacity: number, percentPower: number }> {
+    let totals: Array<{ airflow: number, power: number, percentCapacity: number, percentPower: number }> = new Array();
+    let intervals: Array<number> = profileSummary[0].profileSummaryData.map(data => { return data.timeInterval });
+    let allData: Array<ProfileSummaryData> = _.flatMap(profileSummary, (summary) => { return summary.profileSummaryData });
+
+    intervals.forEach(interval => {
+      let filteredData: Array<ProfileSummaryData> = allData.filter(data => { return data.timeInterval == interval });
+      let totalAirFlow: number = _.sumBy(filteredData, 'airflow');
+      let totalPower: number = _.sumBy(filteredData, 'power');
+      let totalPercentCapacity: number = _.sumBy(filteredData, 'percentCapacity');
+      let percentCapacity: number = totalPercentCapacity / filteredData.length;
+      let totalPercentPower: number = _.sumBy(filteredData, 'percentPower');
+      let percentPower: number = totalPercentPower / filteredData.length;
+      totals.push({
+        airflow: totalAirFlow,
+        power: totalPower,
+        percentCapacity: percentCapacity,
+        percentPower: percentPower
+      });
+    });
+    return totals;
+  }
 }

--- a/src/app/dashboard/assessment.service.ts
+++ b/src/app/dashboard/assessment.service.ts
@@ -361,9 +361,11 @@ export class AssessmentService {
         systemProfileSetup: {
           dayType: undefined,
           numberOfHours: 24,
-          dataInterval: 1
+          dataInterval: 1,
+          profileDataType: "percentCapacity",
         },
-        compressorOrdering: new Array()
+        compressorOrdering: new Array(),
+        profileSummary: new Array()
       }
     }
   }

--- a/src/app/shared/models/compressed-air-assessment.ts
+++ b/src/app/shared/models/compressed-air-assessment.ts
@@ -95,13 +95,15 @@ export interface PerformancePoint {
 export interface SystemProfile {
     systemProfileSetup: SystemProfileSetup,
     compressorOrdering: Array<CompressorOrderItem>;
+    profileSummary: Array<ProfileSummary>
 }
 
 
 export interface SystemProfileSetup {
     dayType: string,
     numberOfHours: number,
-    dataInterval: 2 | 1 | .5 | .25
+    dataInterval: 2 | 1 | .5 | .25,
+    profileDataType: "power" | "percentCapacity" | "airflow"
 }
 
 
@@ -117,4 +119,18 @@ export interface CentrifugalSpecifics {
     maxFullLoadCapacity: number,
     minFullLoadPressure: number
     minFullLoadCapacity: number
+}
+
+export interface ProfileSummary {
+    compressorName: string,
+    compressorId: string,
+    profileSummaryData: Array<ProfileSummaryData>
+}
+
+export interface ProfileSummaryData {
+    power: number,
+    airflow: number,
+    percentCapacity: number,
+    timeInterval: number,
+    percentPower: number
 }

--- a/src/app/shared/models/compressed-air-assessment.ts
+++ b/src/app/shared/models/compressed-air-assessment.ts
@@ -132,5 +132,6 @@ export interface ProfileSummaryData {
     airflow: number,
     percentCapacity: number,
     timeInterval: number,
-    percentPower: number
+    percentPower: number,
+    percentSystemCapacity: number
 }


### PR DESCRIPTION
connects #4617 

Adds logic for system profiling. Currently just setting random numbers for % Capacity and using them for profiling. Numbers always being randomly generated on init, will be fixed when integrating day types.

Ordering not implemented.

Results summary added and working based on dummy numbers.
Results graphs implemented based on dummy numbers.

No help text panel for profiling, need the screen space...