### PR TITLE
add peak demand values to results

### DIFF
--- a/src/app/compressed-air-assessment/compressed-air-report/executive-summary/executive-summary.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-report/executive-summary/executive-summary.component.html
@@ -33,12 +33,85 @@
                         </app-percent-graph>
                     </div>
                     <div class="show-print text-center"
-                        *ngIf="result.combinedResults.allSavingsResults.savings.percentSavings">
+                        *ngIf="result.combinedResults.allSavingsResults.adjustedResults.percentSavings">
                         {{result.combinedResults.allSavingsResults.savings.percentSavings | number:'1.0'}} %
                     </div>
                     <div *ngIf="!result.combinedResults.allSavingsResults.savings.percentSavings">
                         &mdash; &mdash;
                     </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Peak Demand
+                    <span> (kW)</span>
+                </td>
+                <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+                    {{baselineResults.total.peakDemand | number:'1.0-2'}}</td>
+                <td *ngFor="let result of combinedDayTypeResults; let index = index;"
+                    [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+                    <span
+                        *ngIf="result.combinedResults.peakDemand">{{result.combinedResults.peakDemand
+                        | number:'1.0-2'}}</span>
+                    <span *ngIf="!result.combinedResults.peakDemand">&mdash;
+                        &mdash;</span>
+                </td>
+            </tr>
+            <tr>
+                <td>Peak Demand Savings
+                    <span> (kW)</span>
+                </td>
+                <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+                    &mdash;</td>
+                <td *ngFor="let result of combinedDayTypeResults; let index = index;"
+                    [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+                    <span *ngIf="result.combinedResults.peakDemand">{{baselineResults.total.peakDemand
+                        - result.combinedResults.peakDemand
+                        | number:'1.0-2'}}</span>
+                    <span *ngIf="!result.combinedResults.peakDemand">&mdash;
+                        &mdash;</span>
+                </td>
+            </tr>
+            <tr>
+                <td>Peak Demand Cost
+                    <span> ($)</span>
+                </td>
+                <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+                    {{baselineResults.demandCost | number:'1.0-2'}}</td>
+                <td *ngFor="let result of combinedDayTypeResults; let index = index;"
+                    [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+                    <span *ngIf="result.combinedResults.peakDemandCost">{{result.combinedResults.peakDemandCost
+                        | number:'1.0-2'}}</span>
+                    <span *ngIf="!result.combinedResults.peakDemandCost">&mdash;
+                        &mdash;</span>
+                </td>
+            </tr>
+            <tr>
+                <td>Peak Demand Cost Savings
+                    <span> ($)</span>
+                </td>
+                <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+                    &mdash;</td>
+                <td *ngFor="let result of combinedDayTypeResults; let index = index;"
+                    [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+                    <span *ngIf="result.combinedResults.peakDemandCost">{{baselineResults.demandCost
+                        - result.combinedResults.peakDemandCost
+                        | number:'1.0-2'}}</span>
+                    <span *ngIf="!result.combinedResults.peakDemandCost">&mdash;
+                        &mdash;</span>
+                </td>
+            </tr>
+            <tr>
+                <td>Flow Reallocation Savings
+                    <span> ($/yr)</span>
+                </td>
+                <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+                    &mdash;</td>
+                <td *ngFor="let result of combinedDayTypeResults; let index = index;"
+                    [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+                    <span
+                        *ngIf="result.combinedResults.flowReallocationSavings.savings.power">{{result.combinedResults.flowReallocationSavings.savings.power
+                        | number:'1.0-0'}}</span>
+                    <span *ngIf="!result.combinedResults.flowReallocationSavings.savings.power">&mdash; &mdash;</span>
                 </td>
             </tr>
             <tr *ngIf="displayAddReceiverVolume">
@@ -51,7 +124,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.addReceiverVolumeSavings.savings.power">{{result.combinedResults.addReceiverVolumeSavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.addReceiverVolumeSavings.savings.power">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -65,7 +138,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.adjustCascadingSetPointsSavings.savings.power">{{result.combinedResults.adjustCascadingSetPointsSavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.adjustCascadingSetPointsSavings.savings.power">&mdash;
                         &mdash;</span>
                 </td>
@@ -80,7 +153,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.improveEndUseEfficiencySavings.savings.power">{{result.combinedResults.improveEndUseEfficiencySavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.improveEndUseEfficiencySavings.savings.power">&mdash;
                         &mdash;</span>
                 </td>
@@ -95,7 +168,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.reduceAirLeaksSavings.savings.power">{{result.combinedResults.reduceAirLeaksSavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.reduceAirLeaksSavings.savings.power">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -109,7 +182,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.reduceRunTimeSavings.savings.power">{{result.combinedResults.reduceRunTimeSavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.reduceRunTimeSavings.savings.power">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -123,7 +196,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.reduceSystemAirPressureSavings.savings.power">{{result.combinedResults.reduceSystemAirPressureSavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.reduceSystemAirPressureSavings.savings.power">&mdash;
                         &mdash;</span>
                 </td>
@@ -138,7 +211,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.useAutomaticSequencerSavings.savings.power">{{result.combinedResults.useAutomaticSequencerSavings.savings.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.useAutomaticSequencerSavings.savings.power">&mdash;
                         &mdash;</span>
                 </td>
@@ -154,7 +227,7 @@
                     <span
                         *ngIf="result.combinedResults.auxiliaryPowerUsage.cost">{{result.combinedResults.auxiliaryPowerUsage.cost
                         * -1
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.auxiliaryPowerUsage.cost">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -177,12 +250,12 @@
                     <span> (kWh/yr)</span>
                 </td>
                 <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-                    {{baselineResults.total.energyUse | sigFigs:'5'}}</td>
+                    {{baselineResults.total.energyUse | number:'1.0-0'}}</td>
                 <td *ngFor="let result of combinedDayTypeResults; let index = index;"
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.allSavingsResults.adjustedResults.power">{{result.combinedResults.allSavingsResults.adjustedResults.power
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.allSavingsResults.adjustedResults.power">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -205,12 +278,12 @@
                     <span> ($/yr)</span>
                 </td>
                 <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-                    {{baselineResults.total.cost | sigFigs:'5'}}</td>
+                    {{baselineResults.total.cost | number:'1.0-0'}}</td>
                 <td *ngFor="let result of combinedDayTypeResults; let index = index;"
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.allSavingsResults.adjustedResults.cost">{{result.combinedResults.allSavingsResults.adjustedResults.cost
-                        | sigFigs:'5'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.allSavingsResults.adjustedResults.cost">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -223,8 +296,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.allSavingsResults.savings.cost">{{result.combinedResults.allSavingsResults.savings.cost
-                        |
-                        sigFigs:'5'}}</span>
+                        |number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.allSavingsResults.savings.cost">&mdash; &mdash;</span>
                 </td>
             </tr>
@@ -238,7 +310,7 @@
                     [ngClass]="{'selected-modification': index == selectedModificationIndex}">
                     <span
                         *ngIf="result.combinedResults.allSavingsResults.implementationCost">{{result.combinedResults.allSavingsResults.implementationCost
-                        | number:'1.0-2'}}</span>
+                        | number:'1.0-0'}}</span>
                     <span *ngIf="!result.combinedResults.allSavingsResults.implementationCost">&mdash; &mdash;</span>
                 </td>
             </tr>

--- a/src/app/compressed-air-assessment/compressed-air-report/executive-summary/executive-summary.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-report/executive-summary/executive-summary.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Modification } from '../../../shared/models/compressed-air-assessment';
-import { BaselineResults, CompressedAirAssessmentResult, DayTypeModificationResult, EemSavingsResults } from '../../compressed-air-assessment-results.service';
+import { BaselineResults, DayTypeModificationResult } from '../../compressed-air-assessment-results.service';
 
 @Component({
   selector: 'app-executive-summary',

--- a/src/app/compressed-air-assessment/explore-opportunities/explore-opportunities-results/explore-opportunities-results.component.html
+++ b/src/app/compressed-air-assessment/explore-opportunities/explore-opportunities-results/explore-opportunities-results.component.html
@@ -23,6 +23,54 @@
         </div>
     </div>
 
+    <div class="d-flex my-table-item stripe"
+        *ngIf="dayTypeModificationResult.flowReallocationSavings.savings.cost != 0">
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text">Peak Demand</span>
+        </div>
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text"> {{baselineResults.total.peakDemand | number:'1.0-2'}} kW</span>
+        </div>
+        <div class="col-4 d-flex align-items-center pl-1 pr-1 table-text">
+            {{dayTypeModificationResult.peakDemand | number:'1.0-2'}} kW
+        </div>
+    </div>
+    <div class="d-flex my-table-item stripe"
+        *ngIf="dayTypeModificationResult.flowReallocationSavings.savings.cost != 0">
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text">Peak Demand Savings</span>
+        </div>
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text">&mdash;</span>
+        </div>
+        <div class="col-4 d-flex align-items-center pl-1 pr-1 table-text">
+            {{baselineResults.total.peakDemand - dayTypeModificationResult.peakDemand | number:'1.0-2'}} kW
+        </div>
+    </div>
+    <div class="d-flex my-table-item stripe"
+        *ngIf="dayTypeModificationResult.flowReallocationSavings.savings.cost != 0">
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text">Peak Demand Cost</span>
+        </div>
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text"> {{baselineResults.demandCost | currency}}</span>
+        </div>
+        <div class="col-4 d-flex align-items-center pl-1 pr-1 table-text">
+            {{dayTypeModificationResult.peakDemandCost | currency}}
+        </div>
+    </div>
+    <div class="d-flex my-table-item stripe"
+        *ngIf="dayTypeModificationResult.flowReallocationSavings.savings.cost != 0">
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text">Peak Demand Cost Savings</span>
+        </div>
+        <div class="d-flex align-items-center pl-1 pr-1 col-4">
+            <span class="table-text">&mdash;</span>
+        </div>
+        <div class="col-4 d-flex align-items-center pl-1 pr-1 table-text">
+            {{baselineResults.demandCost - dayTypeModificationResult.peakDemandCost | currency}}
+        </div>
+    </div>
 
     <div class="d-flex my-table-item stripe"
         *ngIf="dayTypeModificationResult.flowReallocationSavings.savings.cost != 0">
@@ -141,7 +189,7 @@
             <span class="table-text"> &mdash; &mdash;</span>
         </div>
         <div class="col-4 d-flex align-items-center pl-1 pr-1 table-text">
-            {{dayTypeModificationResult.auxiliaryPowerUsage.energyUse |  number:'1.0-0'}}
+            {{dayTypeModificationResult.auxiliaryPowerUsage.energyUse | number:'1.0-0'}}
         </div>
     </div>
 

--- a/src/app/compressed-air-assessment/explore-opportunities/explore-opportunities-results/explore-opportunities-results.component.ts
+++ b/src/app/compressed-air-assessment/explore-opportunities/explore-opportunities-results/explore-opportunities-results.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { CompressedAirAssessment, CompressedAirDayType, Modification, ProfileSummary, ProfileSummaryTotal } from '../../../shared/models/compressed-air-assessment';
-import { CompressedAirAssessmentResult, CompressedAirAssessmentResultsService, DayTypeModificationResult } from '../../compressed-air-assessment-results.service';
+import { BaselineResults, CompressedAirAssessmentResult, CompressedAirAssessmentResultsService, DayTypeModificationResult } from '../../compressed-air-assessment-results.service';
 import { CompressedAirAssessmentService } from '../../compressed-air-assessment.service';
 import { ExploreOpportunitiesService } from '../explore-opportunities.service';
 
@@ -24,12 +24,18 @@ export class ExploreOpportunitiesResultsComponent implements OnInit {
   modificationResults: CompressedAirAssessmentResult;
   modificationResultsSub: Subscription;
   dayTypeModificationResult: DayTypeModificationResult;
+  baselineResults: BaselineResults;
   constructor(private compressedAirAssessmentService: CompressedAirAssessmentService,
     private exploreOpportunitiesService: ExploreOpportunitiesService, private compressedAirAssessmentResultsService: CompressedAirAssessmentResultsService) { }
 
   ngOnInit(): void {
+
     this.compressedAirAssessmentSub = this.compressedAirAssessmentService.compressedAirAssessment.subscribe(val => {
       if (val) {
+        if(!this.baselineResults){
+          this.baselineResults = this.compressedAirAssessmentResultsService.calculateBaselineResults(val);
+        }
+
         this.compressedAirAssessment = val;
         this.dayTypeOptions = this.compressedAirAssessment.compressedAirDayTypes;
         let selectedModificationId: string = this.compressedAirAssessmentService.selectedModificationId.getValue();


### PR DESCRIPTION
connects #4892 

adds peak demand, cost and savings to results

calculates hours per year based on hours on instead of 24 hours by default