### PR TITLE
Issue-5007: Old Pump Assessment Bugged

### DIFF
--- a/src/app/psat/psat-warning.service.ts
+++ b/src/app/psat/psat-warning.service.ts
@@ -316,7 +316,13 @@ export class PsatWarningService {
   //warnings for pump fluid form
   checkPumpFluidWarnings(psat: PSAT, settings: Settings): PumpFluidWarnings {
     let rpmError: string = this.checkPumpRpm(psat);
-    let temperatureError: string = this.checkTemperatureError(psat, settings);
+    let temperatureError: string;
+    if(psat.inputs.fluidType !== 'Other'){
+      temperatureError = this.checkTemperatureError(psat, settings);
+    } else {
+      temperatureError = null;      
+    }
+    
     return {
       rpmError: rpmError,
       temperatureError: temperatureError

--- a/src/app/psat/pump-fluid/pump-fluid.component.ts
+++ b/src/app/psat/pump-fluid/pump-fluid.component.ts
@@ -152,9 +152,8 @@ export class PumpFluidComponent implements OnInit {
     if (fluidType && t) {
 
       if (fluidType === 'Other') {
-        return;
-      }
-      if (fluidType === 'Water') {
+        this.save();
+      } else if (fluidType === 'Water') {
         let tTemp = (t - 32) * (5.0 / 9) + 273.15;
         let density = 0.14395 / Math.pow(0.0112, (1 + Math.pow(1 - tTemp / 649.727, 0.05107)));
         let kinViscosity = 0.000000003 * Math.pow(t, 4) - 0.000002 * Math.pow(t, 3) + 0.0005 * Math.pow(t, 2) - 0.0554 * t + 3.1271;

--- a/src/app/shared/helper-services/update-data.service.ts
+++ b/src/app/shared/helper-services/update-data.service.ts
@@ -53,9 +53,21 @@ export class UpdateDataService {
         //logic for updating psat data
         assessment.appVersion = packageJson.version;
 
+        if (assessment.psat.inputs.line_frequency === 0){
+            assessment.psat.inputs.line_frequency = 50;
+        }         
+        if (assessment.psat.inputs.line_frequency === 1){
+            assessment.psat.inputs.line_frequency = 60;
+        } 
         if (assessment.psat.modifications) {
             assessment.psat.modifications.forEach(mod => {
                 mod.psat = this.addWhatIfScenarioPsat(mod.psat);
+                if (mod.psat.inputs.line_frequency === 0){
+                    mod.psat.inputs.line_frequency = 50;
+                }         
+                if (mod.psat.inputs.line_frequency === 1){
+                    mod.psat.inputs.line_frequency = 60;
+                } 
             })
         }
 


### PR DESCRIPTION
connects #5007 
The bugs were in Pump Fluid and Motor. The Pump Fluid bug occurred when Fluid Type = "Other", the property Boiling Point could not be calculated, so when Fluid Type = "Other" the form does not check for warnings or validation. 
The Motor bug was cause by older PSAT having the line_frequency property set to 0 or 1, so the fix was to check for those values and set line_frequency = 50 if value was 0 and set it to 60 if value was 1. 