### PR TITLE
Issue-5102: Old tutorial step bug in PHAST

### DIFF
--- a/src/app/phast/phast.component.ts
+++ b/src/app/phast/phast.component.ts
@@ -127,7 +127,6 @@ export class PhastComponent implements OnInit {
       this.mainTab = val;
       //on tab change get container height
       this.getContainerHeight();
-      this.checkTutorials();
     });
     //subscription for stepTab
     this.stepTabSubscription = this.phastService.stepTab.subscribe(val => {
@@ -177,6 +176,10 @@ export class PhastComponent implements OnInit {
       }
     });
 
+  }
+
+  ngAfterContentInit(){
+    this.checkTutorials();
   }
 
   setExploreOppsDefaults(modification: Modification) {  


### PR DESCRIPTION
connects #5102 
I fixed this bug by added the lifecycle hook ngAfterContentInit() to check for tutorials after all subscriptions have been made 