### PR TITLE
Update existing mods co2savings

### DIFF
--- a/src/app/psat/add-modification/add-modification.component.ts
+++ b/src/app/psat/add-modification/add-modification.component.ts
@@ -64,7 +64,6 @@ export class AddModificationComponent implements OnInit {
     tmpModification.exploreOpportunities = (this.currentTab == 'explore-opportunities');
     let baselineResults: PsatOutputs = this.psatService.resultsExisting(this.psat.inputs, this.settings);
     tmpModification.psat.inputs.pump_specified = baselineResults.pump_efficiency;
-    console.log(tmpModification.psat.inputs.pump_specified);
     this.save.emit(tmpModification)
   }
 

--- a/src/app/psat/psat.component.ts
+++ b/src/app/psat/psat.component.ts
@@ -300,8 +300,9 @@ export class PsatComponent implements OnInit {
           mod.psat.inputs.load_estimation_method = this._psat.inputs.load_estimation_method;
           mod.psat.inputs.motor_field_current = this._psat.inputs.motor_field_current;
           mod.psat.inputs.motor_field_power = this._psat.inputs.motor_field_power;
+          mod.psat = this.updateModificationCO2Savings(mod.psat);
         }
-      })
+      });
     } else {
       this.modificationExists = false;
     }
@@ -313,6 +314,21 @@ export class PsatComponent implements OnInit {
       })
     });
     this.cd.detectChanges();
+  }
+
+  updateModificationCO2Savings(modPsat: PSAT) {
+    if (this._psat.inputs.co2SavingsData) {
+      if (!modPsat.inputs.co2SavingsData) {
+        modPsat.inputs.co2SavingsData = this._psat.inputs.co2SavingsData;
+      } else {
+        modPsat.inputs.co2SavingsData.zipcode = this._psat.inputs.co2SavingsData.zipcode;
+        modPsat.inputs.co2SavingsData.eGridSubregion = this._psat.inputs.co2SavingsData.eGridSubregion;
+        if (!modPsat.inputs.co2SavingsData.totalEmissionOutputRate) {
+          modPsat.inputs.co2SavingsData.totalEmissionOutputRate = this._psat.inputs.co2SavingsData.totalEmissionOutputRate;
+        }
+      }
+    }
+    return modPsat;
   }
 
   savePsat(newPSAT: PSAT) {

--- a/src/app/shared/assessment-co2-savings/assessment-co2-savings.component.ts
+++ b/src/app/shared/assessment-co2-savings/assessment-co2-savings.component.ts
@@ -105,7 +105,7 @@ export class AssessmentCo2SavingsComponent implements OnInit {
       this.disableForm()
     };
 
-    this.setSubRegionData();
+    this.setSubRegionData(true);
   }
 
   focusField(str: string) {
@@ -135,7 +135,7 @@ export class AssessmentCo2SavingsComponent implements OnInit {
     }
   }
 
-  setSubRegionData() {
+  setSubRegionData(isFormInit: boolean = false) {
     this.zipCodeSubRegionData = [];
 
     let subRegionData: SubRegionData = _.find(this.egridService.subRegionsByZipcode, (val) => this.form.controls.zipcode.value === val.zip);
@@ -156,7 +156,9 @@ export class AssessmentCo2SavingsComponent implements OnInit {
       this.form.controls.totalEmissionOutputRate.patchValue(null);
       this.form.controls.eGridSubregion.patchValue(null);
     }
-    this.calculate();
+    if (!isFormInit) {
+      this.calculate();
+    }
   }
 
   setBaselineSubregionForm() {


### PR DESCRIPTION
connects #4924 

When user has old assessment with existing mods --> populate co2Data from baseline on unselected mods without user needing to view operations page for each.