### PR TITLE
Various EAF and Co2 issues in PHAST

### DIFF
--- a/src/app/phast/convert-phast.service.ts
+++ b/src/app/phast/convert-phast.service.ts
@@ -547,13 +547,9 @@ export class ConvertPhastService {
   convertCO2SavingsData(co2SavingsData: PhastCo2SavingsData, oldSettings: Settings, newSettings: Settings): PhastCo2SavingsData {
     let oldFuelUnit: string = 'MMBtu'; 
     let newFuelUnit: string = 'GJ';
-    let oldMassUnit: string = 'lb';
-    let newMassUnit: string = 'kg';
     if (oldSettings.unitsOfMeasure !== 'Imperial') {
       oldFuelUnit = 'GJ';
       newFuelUnit = 'MMBtu';
-      oldMassUnit = 'kg';
-      newMassUnit = 'lb';
     } 
 
     co2SavingsData.totalFuelEmissionOutputRate = this.convertUnitsService.value(co2SavingsData.totalFuelEmissionOutputRate).from(oldFuelUnit).to(newFuelUnit);
@@ -564,7 +560,7 @@ export class ConvertPhastService {
       co2SavingsData.totalEmissionOutputRate = this.roundVal(co2SavingsData.totalEmissionOutputRate, 2);
 
       if (oldSettings.furnaceType === 'Electric Arc Furnace (EAF)') {
-        co2SavingsData.totalCoalEmissionOutputRate = this.convertUnitsService.value(co2SavingsData.totalCoalEmissionOutputRate).from(oldMassUnit).to(newMassUnit);
+        co2SavingsData.totalCoalEmissionOutputRate = this.convertUnitsService.value(co2SavingsData.totalCoalEmissionOutputRate).from(oldFuelUnit).to(newFuelUnit);
         co2SavingsData.totalCoalEmissionOutputRate = this.roundVal(co2SavingsData.totalCoalEmissionOutputRate, 2);
 
         co2SavingsData.totalNaturalGasEmissionOutputRate = this.convertUnitsService.value(co2SavingsData.totalNaturalGasEmissionOutputRate).from(oldFuelUnit).to(newFuelUnit);

--- a/src/app/phast/losses/operations/co2-savings-phast/co2-savings-phast.component.html
+++ b/src/app/phast/losses/operations/co2-savings-phast/co2-savings-phast.component.html
@@ -25,7 +25,7 @@
       
       <div class="form-group">
         <label for="totalFuelEmissionOutputRate">Total Fuel Emission Output Rate
-          <a class="form-text small click-link" (click)="showMixedCO2EmissionsModal()">
+          <a class="form-text small click-link" *ngIf="form.controls.energySource.value == 'Mixed Fuels'" (click)="showMixedCO2EmissionsModal()">
             Calculate Net CO<sub>2</sub> Emissions from Mixed Sources</a>
           </label>
           <div class="input-group">
@@ -71,9 +71,9 @@
           formControlName="totalCoalEmissionOutputRate" type="number"
           (focus)="focusField('totalEmissionOutputRate')" (input)="calculate()">
         <span class="units input-group-addon" *ngIf="settings.unitsOfMeasure == 'Imperial'">kg
-          CO<sub>2</sub>/lb</span>
+          CO<sub>2</sub>/MMBtu</span>
         <span class="units input-group-addon" *ngIf="settings.unitsOfMeasure != 'Imperial'">kg
-          CO<sub>2</sub>/kg</span>
+          CO<sub>2</sub>/GJ</span>
       </div>
     </div>
 

--- a/src/app/phast/losses/operations/co2-savings-phast/co2-savings-phast.service.ts
+++ b/src/app/phast/losses/operations/co2-savings-phast/co2-savings-phast.service.ts
@@ -194,9 +194,9 @@ export class Co2SavingsPhastService {
     };
 
     if (settings.energySourceType == 'Electricity') { 
-      let hourlyElectricityEmissionOutput = phastCopy.co2SavingsData.totalEmissionOutputRate * resultsCopy.electricalHeatDelivered;
-      hourlyElectricityEmissionOutput = this.getCo2EmissionsResult(phastCopy.co2SavingsData, settings);   
-      if (settings.furnaceType == 'Electric Arc Furnace (EAF)') {
+      phastCopy.co2SavingsData.electricityUse = resultsCopy.electricalHeatDelivered;
+      let hourlyElectricityEmissionOutput = this.getCo2EmissionsResult(phastCopy.co2SavingsData, settings);
+      if (settings.furnaceType == 'Electric Arc Furnace (EAF)') { 
         if (settings.unitsOfMeasure == 'Imperial') {
           resultsCopy.hourlyEAFResults.electrodeUsed = this.convertUnitsService.value(resultsCopy.hourlyEAFResults.electrodeUsed).from('lb').to('kg');
         } else {
@@ -219,10 +219,13 @@ export class Co2SavingsPhastService {
         co2EmissionsOutput.totalEmissionOutput = co2EmissionsOutput.electricityEmissionOutput + co2EmissionsOutput.fuelEmissionOutput + co2EmissionsOutput.coalCarbonEmissionsOutput + co2EmissionsOutput.electrodeEmissionsOutput + co2EmissionsOutput.otherFuelEmissionsOutput;
         
       } else {
-        let hourlyFuelEmissionOutput = resultsCopy.energyInputHeatDelivered * phastCopy.co2SavingsData.totalFuelEmissionOutputRate;
+        let fuelHeatInputTotal: number = 0;
+        phastCopy.losses.energyInputExhaustGasLoss.forEach(exGas => {
+          fuelHeatInputTotal += exGas.totalHeatInput;
+        });
+        let hourlyFuelEmissionOutput = fuelHeatInputTotal * phastCopy.co2SavingsData.totalFuelEmissionOutputRate;
         co2EmissionsOutput.hourlyTotalEmissionOutput = hourlyElectricityEmissionOutput + hourlyFuelEmissionOutput;
         
-
         co2EmissionsOutput.fuelEmissionOutput = hourlyFuelEmissionOutput * phastCopy.operatingHours.hoursPerYear;
         co2EmissionsOutput.electricityEmissionOutput = hourlyElectricityEmissionOutput * phastCopy.operatingHours.hoursPerYear;
         co2EmissionsOutput.totalEmissionOutput = co2EmissionsOutput.electricityEmissionOutput + co2EmissionsOutput.fuelEmissionOutput;

--- a/src/app/phast/phast-report/executive-summary.service.ts
+++ b/src/app/phast/phast-report/executive-summary.service.ts
@@ -70,12 +70,15 @@ export class ExecutiveSummaryService {
 
     if (settings.energySourceType === 'Electricity') {
       if (settings.furnaceType === 'Electric Arc Furnace (EAF)') {
-        let naturalGasCost: number = phastResults.annualEAFResults.naturalGasUsed * phast.operatingCosts.fuelCost;
-        resultsSummary.annualCarbonCoalCost = phastResults.annualEAFResults.coalCarbonUsed * this.convertEAFChemicalFuelCosts(phast.operatingCosts.coalCarbonCost);
-        resultsSummary.annualElectrodeCost = phastResults.annualEAFResults.electrodeUsed * this.convertEAFChemicalFuelCosts(phast.operatingCosts.electrodeCost);
+        resultsSummary.annualNaturalGasCost = phastResults.annualEAFResults.naturalGasUsed * phast.operatingCosts.fuelCost;
+        // resultsSummary.annualCarbonCoalCost = phastResults.annualEAFResults.coalCarbonUsed * this.convertEAFChemicalFuelCosts(phast.operatingCosts.coalCarbonCost);
+        // resultsSummary.annualElectrodeCost = phastResults.annualEAFResults.electrodeUsed * this.convertEAFChemicalFuelCosts(phast.operatingCosts.electrodeCost);
+        // No longer need to convert cost
+        resultsSummary.annualCarbonCoalCost = phastResults.annualEAFResults.coalCarbonUsed * phast.operatingCosts.coalCarbonCost;
+        resultsSummary.annualElectrodeCost = phastResults.annualEAFResults.electrodeUsed * phast.operatingCosts.electrodeCost;
         resultsSummary.annualOtherFuelCost = phastResults.annualEAFResults.otherFuelUsed * phast.operatingCosts.otherFuelCost;
         resultsSummary.annualElectricityCost = phastResults.annualEAFResults.electricEnergyUsed * phast.operatingCosts.electricityCost;
-        resultsSummary.annualTotalFuelCost = naturalGasCost + resultsSummary.annualCarbonCoalCost + resultsSummary.annualElectrodeCost + resultsSummary.annualOtherFuelCost;
+        resultsSummary.annualTotalFuelCost = resultsSummary.annualNaturalGasCost + resultsSummary.annualCarbonCoalCost + resultsSummary.annualElectrodeCost + resultsSummary.annualOtherFuelCost;
         resultsSummary.annualCost = resultsSummary.annualTotalFuelCost + resultsSummary.annualElectricityCost;
       } else {
         let totalHeatInput: number = 0; 

--- a/src/app/phast/phast-report/executive-summary.service.ts
+++ b/src/app/phast/phast-report/executive-summary.service.ts
@@ -71,11 +71,8 @@ export class ExecutiveSummaryService {
     if (settings.energySourceType === 'Electricity') {
       if (settings.furnaceType === 'Electric Arc Furnace (EAF)') {
         resultsSummary.annualNaturalGasCost = phastResults.annualEAFResults.naturalGasUsed * phast.operatingCosts.fuelCost;
-        // resultsSummary.annualCarbonCoalCost = phastResults.annualEAFResults.coalCarbonUsed * this.convertEAFChemicalFuelCosts(phast.operatingCosts.coalCarbonCost);
-        // resultsSummary.annualElectrodeCost = phastResults.annualEAFResults.electrodeUsed * this.convertEAFChemicalFuelCosts(phast.operatingCosts.electrodeCost);
-        // No longer need to convert cost
-        resultsSummary.annualCarbonCoalCost = phastResults.annualEAFResults.coalCarbonUsed * phast.operatingCosts.coalCarbonCost;
-        resultsSummary.annualElectrodeCost = phastResults.annualEAFResults.electrodeUsed * phast.operatingCosts.electrodeCost;
+        resultsSummary.annualCarbonCoalCost = phast.losses.energyInputEAF[0].coalCarbonInjection * phast.operatingCosts.coalCarbonCost;
+        resultsSummary.annualElectrodeCost = phast.losses.energyInputEAF[0].electrodeUse * phast.operatingCosts.electrodeCost;
         resultsSummary.annualOtherFuelCost = phastResults.annualEAFResults.otherFuelUsed * phast.operatingCosts.otherFuelCost;
         resultsSummary.annualElectricityCost = phastResults.annualEAFResults.electricEnergyUsed * phast.operatingCosts.electricityCost;
         resultsSummary.annualTotalFuelCost = resultsSummary.annualNaturalGasCost + resultsSummary.annualCarbonCoalCost + resultsSummary.annualElectrodeCost + resultsSummary.annualOtherFuelCost;
@@ -109,12 +106,6 @@ export class ExecutiveSummaryService {
     return resultsSummary;
   }
 
-  convertEAFChemicalFuelCosts(cost: number): number {
-    // convert btu/lb to mmbtu/lb (or kJ/kg to GJ/kg)
-    let converted: number = cost / (1/1000000);
-    return converted;
-  }
-  
 
   initSummary(): ExecutiveSummary {
     let tmpSummary: ExecutiveSummary = {

--- a/src/app/phast/phast-report/phast-input-summary/operation-data/operation-data.component.html
+++ b/src/app/phast/phast-report/phast-input-summary/operation-data/operation-data.component.html
@@ -159,6 +159,7 @@
           </td>
           </tr>
 
+      <ng-container *ngIf="settings.furnaceType !== 'Electric Arc Furnace (EAF)'">
           <tr>
             <td>
               Energy Source
@@ -170,7 +171,7 @@
               {{mod.phast.co2SavingsData.energySource}}
             </td>
           </tr>
-          <tr>
+          <tr *ngIf="phast.co2SavingsData.energySource != 'Mixed Fuels'">
             <td>
               Fuel Type
             </td>
@@ -183,17 +184,140 @@
           </tr>
           <tr>
             <td>
-              Total Emission Output Rate
-              <span>(kg CO<sub>2</sub>/{{settings.energyResultUnit}})</span>
+              Total Fuel Emission Output Rate
+              (<span *ngIf="settings.unitsOfMeasure == 'Imperial'">kg
+                CO<sub>2</sub>/MMBtu</span>
+              <span *ngIf="settings.unitsOfMeasure != 'Imperial'">kg
+                CO<sub>2</sub>/GJ</span>)
             </td>
             <td>
-              {{phast.co2SavingsData.totalEmissionOutputRate}}
+              {{phast.co2SavingsData.totalFuelEmissionOutputRate}}
             </td>
             <td *ngFor="let mod of phast.modifications">
-              {{mod.phast.co2SavingsData.totalEmissionOutputRate}}
+              {{mod.phast.co2SavingsData.totalFuelEmissionOutputRate}}
             </td>
           </tr>
-          </tbody>
+        </ng-container>
+
+
+    <ng-container *ngIf="settings.furnaceType === 'Electric Arc Furnace (EAF)'">
+      <tr>
+        <td>
+          Natural Gas Emission Output Rate
+          <span *ngIf="settings.unitsOfMeasure == 'Imperial'">kg
+            CO<sub>2</sub>/MMBtu</span>
+          <span *ngIf="settings.unitsOfMeasure != 'Imperial'">kg
+            CO<sub>2</sub>/GJ</span>
+        </td>
+        <td>
+          {{phast.co2SavingsData.totalNaturalGasEmissionOutputRate}}
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          {{mod.phast.co2SavingsData.totalNaturalGasEmissionOutputRate}}
+        </td>
+      </tr>
+      <tr>
+        <td>
+         Coal Carbon Fuel Type
+        </td>
+        <td>
+          {{phast.co2SavingsData.coalFuelType}}
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          {{mod.phast.co2SavingsData.coalFuelType}}
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Coal Carbon Emission Output Rate
+          (<span *ngIf="settings.unitsOfMeasure == 'Imperial'">kg
+            CO<sub>2</sub>/MMBtu</span>
+          <span *ngIf="settings.unitsOfMeasure != 'Imperial'">kg
+            CO<sub>2</sub>/GJ</span>)
+        </td>
+        <td>
+          {{phast.co2SavingsData.totalCoalEmissionOutputRate}}
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          {{mod.phast.co2SavingsData.totalCoalEmissionOutputRate}}
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Other Fuel Energy Source
+        </td>
+        <td>
+          {{phast.co2SavingsData.eafOtherFuelSource}}
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          {{mod.phast.co2SavingsData.eafOtherFuelSource}}
+        </td>
+      </tr>
+      <tr>
+        <td>
+         Other Fuel Type
+        </td>
+        <td>
+          <span *ngIf="phast.co2SavingsData.eafOtherFuelSource != 'Mixed Fuels' && phast.co2SavingsData.eafOtherFuelSource != 'None'">
+            {{phast.co2SavingsData.otherFuelType}}
+          </span>
+          <span *ngIf="phast.co2SavingsData.eafOtherFuelSource == 'Mixed Fuels' || phast.co2SavingsData.eafOtherFuelSource == 'None'">
+            &mdash;
+          </span>
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          <span *ngIf="mod && mod.phast.co2SavingsData.eafOtherFuelSource != 'Mixed Fuels' && mod.phast.co2SavingsData.eafOtherFuelSource != 'None'">
+            {{mod.phast.co2SavingsData.otherFuelType}}
+          </span>
+          <span *ngIf="mod && mod.phast.co2SavingsData.eafOtherFuelSource == 'Mixed Fuels' || mod.phast.co2SavingsData.eafOtherFuelSource == 'None'">
+            &mdash;
+          </span>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Other Fuel Emission Output Rate
+          (<span *ngIf="settings.unitsOfMeasure == 'Imperial'">kg
+            CO<sub>2</sub>/MMBtu</span>
+          <span *ngIf="settings.unitsOfMeasure != 'Imperial'">kg
+            CO<sub>2</sub>/GJ</span>)
+        </td>
+        <td>
+          {{phast.co2SavingsData.totalOtherEmissionOutputRate}}
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          {{mod.phast.co2SavingsData.totalOtherEmissionOutputRate}}
+        </td>
+      </tr>
+    </ng-container>
+          
+
+    <ng-container *ngIf="settings.energySourceType == 'Electricity'">
+      <tr>
+        <td class="bold">
+          Carbon Emissions From Electricity
+        </td>
+        <td>
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+        </td>
+        </tr>
+      <tr>
+        <td>
+          Total Emission Output Rate
+          <span>(kg CO<sub>2</sub>/MWh)</span>
+        </td>
+        <td>
+          {{phast.co2SavingsData.totalEmissionOutputRate}}
+        </td>
+        <td *ngFor="let mod of phast.modifications">
+          {{mod.phast.co2SavingsData.totalEmissionOutputRate}}
+        </td>
+      </tr>
+    </ng-container>
+      
+  
+        </tbody>
         </table>
       </div>
     </div>

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -659,9 +659,20 @@
             <span *ngIf="!mod.annualElectricityCost">&mdash; &mdash;</span>
           </td>
         </tr>
-        <tr>
-          <td *ngIf="settings.furnaceType === 'Electric Arc Furnace (EAF)'"> Natural Gas </td>
-          <td *ngIf="settings.furnaceType !== 'Electric Arc Furnace (EAF)'"> Fuel  </td>
+        <tr *ngIf="settings.furnaceType === 'Electric Arc Furnace (EAF)'">
+          <td> Natural Gas </td>
+          <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baselineExecutiveSummary.annualNaturalGasCost | currency:'USD':'symbol':'1.0-0'}}</td>
+          <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
+            [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+            <span *ngIf="mod.annualNaturalGasCost">{{baselineExecutiveSummary.annualNaturalGasCost |
+              currency:'USD':'symbol':'1.0-0'}}</span>
+            <span *ngIf="!mod.annualNaturalGasCost">&mdash; &mdash;</span>
+          </td>
+        </tr>
+
+        <tr *ngIf="settings.furnaceType !== 'Electric Arc Furnace (EAF)'">
+          <td> Fuel </td>
           <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
             {{baselineExecutiveSummary.annualTotalFuelCost | currency:'USD':'symbol':'1.0-0'}}</td>
           <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
@@ -674,9 +685,9 @@
 
         <ng-container *ngIf="settings.furnaceType === 'Electric Arc Furnace (EAF)'">
           <tr>
-            <td> Carbon Coal </td>
+            <td> Coal Carbon </td>
             <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-              {{baselineExecutiveSummary.annualElectricityCost | currency:'USD':'symbol':'1.0-0'}}</td>
+              {{baselineExecutiveSummary.annualCarbonCoalCost | currency:'USD':'symbol':'1.0-0'}}</td>
             <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
               <span *ngIf="mod.annualCarbonCoalCost">{{mod.annualCarbonCoalCost |

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -361,14 +361,14 @@
         <td> CO<sub>2</sub> Emissions (kg CO<sub>2</sub>/hr)</td>
         <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
           <span *ngIf="baseLineResults.co2EmissionsOutput.hourlyTotalEmissionOutput">
-            {{baseLineResults.co2EmissionsOutput.hourlyTotalEmissionOutput | number:'1.0-0'}}
+            {{baseLineResults.co2EmissionsOutput.hourlyTotalEmissionOutput | number:'1.0-3'}}
           </span>
           <span *ngIf="!baseLineResults.co2EmissionsOutput.hourlyTotalEmissionOutput">&mdash; &mdash;</span>
         </td>
         <td *ngFor="let mod of modificationResults; let index = index;"
           [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.co2EmissionsOutput">{{mod.co2EmissionsOutput.hourlyTotalEmissionOutput |
-            number:'1.0-0'}}</span>
+            number:'1.0-3'}}</span>
           <span *ngIf="!mod.co2EmissionsOutput">&mdash; &mdash;</span>
         </td>
       </tr>
@@ -378,7 +378,7 @@
         <td *ngFor="let mod of modificationResults; let index = index;"
           [ngClass]="{'selected-modification': index == selectedModificationIndex}">
           <span *ngIf="mod.co2EmissionsOutput">
-            {{mod.co2EmissionsOutput.emissionsSavings | number:'1.0-0'}}
+            {{mod.co2EmissionsOutput.emissionsSavings | number:'1.0-3'}}
           </span>
           <span *ngIf="!mod.co2EmissionsOutput">&mdash; &mdash;</span>
         </td>
@@ -542,13 +542,13 @@
         <tr>
           <td> Electrical CO<sub>2</sub> Emissions </td>
           <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-            {{baseLineResults.co2EmissionsOutput.electricityEmissionOutput | number:'1.0-0'}}</td>
+            {{baseLineResults.co2EmissionsOutput.electricityEmissionOutput | number:'1.0-3'}}</td>
           <td *ngFor="let mod of modificationResults; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
             <span
               *ngIf="mod.co2EmissionsOutput.electricityEmissionOutput">{{mod.co2EmissionsOutput.electricityEmissionOutput
               |
-              number:'1.0-0'}}</span>
+              number:'1.0-3'}}</span>
             <span *ngIf="!mod.co2EmissionsOutput.electricityEmissionOutput">&mdash; &mdash;</span>
           </td>
         </tr>
@@ -556,11 +556,11 @@
           <td *ngIf="settings.furnaceType === 'Electric Arc Furnace (EAF)'"> Natural Gas CO<sub>2</sub> Emissions </td>
           <td *ngIf="settings.furnaceType !== 'Electric Arc Furnace (EAF)'"> Fuel CO<sub>2</sub> Emissions </td>
           <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-            {{baseLineResults.co2EmissionsOutput.fuelEmissionOutput | number:'1.0-0'}}</td>
+            {{baseLineResults.co2EmissionsOutput.fuelEmissionOutput | number:'1.0-3'}}</td>
           <td *ngFor="let mod of modificationResults; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
             <span *ngIf="mod.co2EmissionsOutput.fuelEmissionOutput">{{mod.co2EmissionsOutput.fuelEmissionOutput |
-              number:'1.0-0'}}</span>
+              number:'1.0-3'}}</span>
             <span *ngIf="!mod.co2EmissionsOutput.fuelEmissionOutput">&mdash; &mdash;</span>
           </td>
         </tr>
@@ -570,13 +570,13 @@
           <tr>
             <td> Coal Carbon CO<sub>2</sub> Emissions </td>
             <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-              {{baseLineResults.co2EmissionsOutput.coalCarbonEmissionsOutput | number:'1.0-0'}}</td>
+              {{baseLineResults.co2EmissionsOutput.coalCarbonEmissionsOutput | number:'1.0-3'}}</td>
             <td *ngFor="let mod of modificationResults; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
               <span
                 *ngIf="mod.co2EmissionsOutput.coalCarbonEmissionsOutput">{{mod.co2EmissionsOutput.coalCarbonEmissionsOutput
                 |
-                number:'1.0-0'}}</span>
+                number:'1.0-3'}}</span>
               <span *ngIf="!mod.co2EmissionsOutput.coalCarbonEmissionsOutput">&mdash; &mdash;</span>
             </td>
           </tr>
@@ -584,12 +584,12 @@
           <tr>
             <td> Electrode CO<sub>2</sub> Emissions </td>
             <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-              {{baseLineResults.co2EmissionsOutput.electrodeEmissionsOutput | number:'1.0-0'}}</td>
+              {{baseLineResults.co2EmissionsOutput.electrodeEmissionsOutput | number:'1.0-3'}}</td>
             <td *ngFor="let mod of modificationResults; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
               <span
                 *ngIf="mod.co2EmissionsOutput.electrodeEmissionsOutput">{{mod.co2EmissionsOutput.electrodeEmissionsOutput
-                | number:'1.0-0'}}</span>
+                | number:'1.0-3'}}</span>
               <span *ngIf="!mod.co2EmissionsOutput.electrodeEmissionsOutput">&mdash; &mdash;</span>
             </td>
           </tr>
@@ -599,10 +599,10 @@
             <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
               {{baseLineResults.co2EmissionsOutput.otherFuelEmissionsOutput
               |
-              number:'1.0-0'}}</td>
+              number:'1.0-3'}}</td>
             <td *ngFor="let mod of modificationResults; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.co2EmissionsOutput.otherFuelEmissionsOutput">{{mod.co2EmissionsOutput.otherFuelEmissionsOutput | number:'1.0-0'}}</span>
+              <span *ngIf="mod.co2EmissionsOutput.otherFuelEmissionsOutput">{{mod.co2EmissionsOutput.otherFuelEmissionsOutput | number:'1.0-3'}}</span>
               <span *ngIf="!mod.co2EmissionsOutput.otherFuelEmissionsOutput">&mdash; &mdash;</span>
             </td>
           </tr>

--- a/src/app/phast/phast-report/results-data/results-data.component.ts
+++ b/src/app/phast/phast-report/results-data/results-data.component.ts
@@ -126,8 +126,9 @@ export class ResultsDataComponent implements OnInit {
         }
       } else if (this.modification && !this.inSetup && !this.inReport) {
         this.modification.phast.valid = this.phastValidService.checkValid(this.modification.phast, this.settings);
-        let tmpResults = this.phastResultsService.getResults(this.modification.phast, this.settings);
-        this.modificationResults.push(tmpResults);
+        let modificationResults: PhastResults = this.phastResultsService.getResults(this.modification.phast, this.settings);
+        modificationResults.co2EmissionsOutput.emissionsSavings = this.baseLineResults.co2EmissionsOutput.hourlyTotalEmissionOutput - modificationResults.co2EmissionsOutput.hourlyTotalEmissionOutput;
+        this.modificationResults.push(modificationResults);
       }
     } else {
       this.baseLineResults = this.phastResultsService.initResults();

--- a/src/app/phast/phast-report/results-data/results-data.component.ts
+++ b/src/app/phast/phast-report/results-data/results-data.component.ts
@@ -50,7 +50,6 @@ export class ResultsDataComponent implements OnInit {
   selectedPhastsSub: Subscription;
   constructor(private phastResultsService: PhastResultsService, 
               private executiveSummaryService: ExecutiveSummaryService,
-              private convertUnitsService: ConvertUnitsService,
               private convertPhastService: ConvertPhastService,
               private phastReportRollupService: PhastReportRollupService,
               private phastValidService: PhastValidService) { }

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -261,18 +261,21 @@ export class PhastResultsService {
       totalFuelEnergyUsed: undefined,
       electrodeHeatingValue: EAFInputs.electrodeHeatingValue,
       coalHeatingValue: EAFInputs.coalHeatingValue,
-      coalCarbonUsed: EAFInputs.coalCarbonInjection * EAFInputs.coalHeatingValue,
-      electrodeUsed: EAFInputs.electrodeUse * EAFInputs.electrodeHeatingValue,
+      // coalCarbonInjection is in lb/hr the coalHeatingValue is in btu/lb.  the pounds cancel and you have btu/hr
+      // coalCarbonUsed: EAFInputs.coalCarbonInjection * EAFInputs.coalHeatingValue,
+      // electrodeUsed: EAFInputs.electrodeUse * EAFInputs.electrodeHeatingValue,
+      coalCarbonUsed: EAFInputs.coalCarbonInjection,
+      electrodeUsed: EAFInputs.electrodeUse,
       otherFuelUsed: EAFInputs.otherFuels,
     };
     
-    if (settings.unitsOfMeasure == 'Metric') {
-      eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('kJ').to('GJ');
-      eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('kJ').to('GJ');
-    } else {
-      eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('Btu').to('MMBtu');
-      eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('Btu').to('MMBtu');
-    }
+    // if (settings.unitsOfMeasure == 'Metric') {
+    //   eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('kJ').to('GJ');
+    //   eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('kJ').to('GJ');
+    // } else {
+    //   eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('Btu').to('MMBtu');
+    //   eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('Btu').to('MMBtu');
+    // }
     
     eafResults.totalFuelEnergyUsed = eafResults.naturalGasUsed + eafResults.coalCarbonUsed + eafResults.electrodeUsed + eafResults.otherFuelUsed;
     phastResults.hourlyEAFResults = eafResults;

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -261,21 +261,18 @@ export class PhastResultsService {
       totalFuelEnergyUsed: undefined,
       electrodeHeatingValue: EAFInputs.electrodeHeatingValue,
       coalHeatingValue: EAFInputs.coalHeatingValue,
-      // coalCarbonInjection is in lb/hr the coalHeatingValue is in btu/lb.  the pounds cancel and you have btu/hr
-      // coalCarbonUsed: EAFInputs.coalCarbonInjection * EAFInputs.coalHeatingValue,
-      // electrodeUsed: EAFInputs.electrodeUse * EAFInputs.electrodeHeatingValue,
-      coalCarbonUsed: EAFInputs.coalCarbonInjection,
-      electrodeUsed: EAFInputs.electrodeUse,
+      // coalCarbonInjection is in lb/hr the coalHeatingValue is in btu/lb.  the lbs cancel and you have btu/hr
+      coalCarbonUsed: EAFInputs.coalCarbonInjection * EAFInputs.coalHeatingValue,
+      electrodeUsed: EAFInputs.electrodeUse * EAFInputs.electrodeHeatingValue,
       otherFuelUsed: EAFInputs.otherFuels,
     };
-    
-    // if (settings.unitsOfMeasure == 'Metric') {
-    //   eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('kJ').to('GJ');
-    //   eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('kJ').to('GJ');
-    // } else {
-    //   eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('Btu').to('MMBtu');
-    //   eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('Btu').to('MMBtu');
-    // }
+     if (settings.unitsOfMeasure == 'Metric') {
+      eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('kJ').to('GJ');
+      eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('kJ').to('GJ');
+    } else {
+      eafResults.coalCarbonUsed = this.convertUnitsService.value(eafResults.coalCarbonUsed).from('Btu').to('MMBtu');
+      eafResults.electrodeUsed = this.convertUnitsService.value(eafResults.electrodeUsed).from('Btu').to('MMBtu');
+    }
     
     eafResults.totalFuelEnergyUsed = eafResults.naturalGasUsed + eafResults.coalCarbonUsed + eafResults.electrodeUsed + eafResults.otherFuelUsed;
     phastResults.hourlyEAFResults = eafResults;

--- a/src/app/settings/phast-settings/phast-settings.component.html
+++ b/src/app/settings/phast-settings/phast-settings.component.html
@@ -2,13 +2,13 @@
   <div class="form-group">
     <label>Select Energy Source Type</label>
     <div class="form-check">
-      <input id="fuel" type="radio" name="energySourceType" formControlName="energySourceType" value="Fuel" (change)="startPolling()">
+      <input id="fuel" type="radio" name="energySourceType" formControlName="energySourceType" value="Fuel" (change)="setOptions()">
       <label for="fuel">Fuel-fired</label>
       <br>
       <input id="electricity" type="radio" name="energySourceType" formControlName="energySourceType" value="Electricity" (change)="setOptions()">
       <label for="electricity">Electrotechnology</label>
       <br>
-      <input type="radio" id="steam" name="energySourceType" formControlName="energySourceType" value="Steam" (change)="startPolling()">
+      <input type="radio" id="steam" name="energySourceType" formControlName="energySourceType" value="Steam" (change)="setOptions()">
       <label for="steam">Steam-based</label>
     </div>
   </div>

--- a/src/app/settings/phast-settings/phast-settings.component.ts
+++ b/src/app/settings/phast-settings/phast-settings.component.ts
@@ -73,8 +73,13 @@ export class PhastSettingsComponent implements OnInit {
         furnaceType: 'Electrical Infrared',
         energyResultUnit: 'kWh'
       });
-      this.startPolling();
+    } else if (this.settingsForm.controls.energySourceType.value === 'Fuel' || this.settingsForm.controls.energySourceType.value === 'Steam') {
+      this.settingsForm.patchValue({
+        furnaceType: null,
+        energyResultUnit: 'MMBtu'
+      });
     }
+    this.startPolling();
   }
 
 

--- a/src/app/shared/models/phast/phast.ts
+++ b/src/app/shared/models/phast/phast.ts
@@ -184,6 +184,7 @@ export interface ExecutiveSummary {
   annualEnergySavings?: number;
   annualCost?: number;
   annualCarbonCoalCost?: number,
+  annualNaturalGasCost?: number,
   annualElectrodeCost?: number,
   annualOtherFuelCost?: number,
   annualTotalFuelCost?: number,


### PR DESCRIPTION
connects #5267 #4923 #5325

fixed incorrect electricity use bug
fixed incorrect Nat gas cost bug
fixed coal carbon and electrode costs - no longer using cost conversion
changed coal carbon emission math and units to MMBtu
fixed - 'calculate net co2.. only appears when mixed selected'
added unit defaults for when fuel-fired/electro/steam is switched
fixed carbon emissions output number not updating
added input summary fields