### PR TITLE
Issue 5262 Hotfix

### DIFF
--- a/src/app/shared/assessment-co2-savings/assessment-co2-savings.component.ts
+++ b/src/app/shared/assessment-co2-savings/assessment-co2-savings.component.ts
@@ -74,7 +74,8 @@ export class AssessmentCo2SavingsComponent implements OnInit {
       this.assessmentCo2Service.modificationCo2SavingsData.next(this.co2SavingsData);
       this.co2SavingsDataSub = this.assessmentCo2Service.modificationCo2SavingsData.subscribe(modificationCo2SavingsData => {
         if (modificationCo2SavingsData) {
-          this.co2SavingsData = modificationCo2SavingsData
+          this.co2SavingsData.eGridSubregion = modificationCo2SavingsData.eGridSubregion;
+          this.co2SavingsData.zipcode = modificationCo2SavingsData.zipcode;
           this.initForm();
         }
       });
@@ -150,11 +151,6 @@ export class AssessmentCo2SavingsComponent implements OnInit {
           this.zipCodeSubRegionData.push(subregion);
         }
       });
-      if (this.inBaseline) {
-        this.setBaselineSubregionForm();
-      } else {
-        this.setModificationSubregionForm()
-      }
     } else {
       // not a valid zip, set emmissions to US Average
       subRegionData = _.find(this.egridService.subRegionsByZipcode, (val) => val.zip === '00000');
@@ -164,12 +160,14 @@ export class AssessmentCo2SavingsComponent implements OnInit {
         }
       });
       this.isUsAverage = true;
-      if (this.inBaseline) {
-        this.setBaselineSubregionForm();
-      } else {
-        this.setModificationSubregionForm()
-      }
     }
+
+    if (this.inBaseline) {
+      this.setBaselineSubregionForm();
+    } else {
+      this.setModificationSubregionForm()
+    }
+
     if (!isFormInit || this.isUsAverage) {
       this.calculate();
     }

--- a/src/app/shared/helper-services/update-data.service.ts
+++ b/src/app/shared/helper-services/update-data.service.ts
@@ -151,19 +151,6 @@ export class UpdateDataService {
             fsat.fsatOperations = {
                 operatingHours: operatingHours,
                 cost: cost,
-                cO2SavingsData: {
-                    energyType: 'electricity',
-                    energySource: '',
-                    fuelType: '',
-                    totalEmissionOutputRate: 0,
-                    electricityUse: 0,
-                    eGridRegion: '',
-                    eGridSubregion: 'SRTV',
-                    totalEmissionOutput: 0,
-                    userEnteredBaselineEmissions: false,
-                    userEnteredModificationEmissions: true,
-                    zipcode: '37830',
-                }, 
             }
         }
         return fsat;


### PR DESCRIPTION
connects #5458 

BugFix: only set locked values when co2 moddata sub emits.

Also move redundant if condition and unneed update data service object