### PR TITLE
add warning about profile option for setting data from explorer

### DIFF
--- a/src/app/compressed-air-assessment/system-profile/profile-setup-form/profile-setup-form.component.html
+++ b/src/app/compressed-air-assessment/system-profile/profile-setup-form/profile-setup-form.component.html
@@ -19,7 +19,7 @@
                     <div class="form-group">
                         <label for="profileDataType">Profile Data Type</label>
                         <select class="form-control" id="profileDataType" formControlName="profileDataType"
-                            (focus)="focusField('profileDataType')" (change)="save()">
+                            (focus)="focusField('profileDataType')" (change)="changeProfileDataType()">
                             <option [ngValue]="'percentCapacity'">Airflow, % Capacity</option>
                             <option [ngValue]="'power'">Power, kW</option>
                             <option [ngValue]="'airflow'">Airflow,

--- a/src/app/compressed-air-assessment/system-profile/profile-setup-form/profile-setup-form.component.ts
+++ b/src/app/compressed-air-assessment/system-profile/profile-setup-form/profile-setup-form.component.ts
@@ -25,6 +25,7 @@ export class ProfileSetupFormComponent implements OnInit {
   settingsSub: Subscription;
   hourIntervalData: Array<ProfileSummary>;
   dayIntervalData: Array<ProfileSummary>;
+  isProfileDataTypeChange: boolean = false;
   constructor(private systemProfileService: SystemProfileService, private compressedAirAssessmentService: CompressedAirAssessmentService,
     private performancePointsFormService: PerformancePointsFormService) { }
 
@@ -65,6 +66,17 @@ export class ProfileSetupFormComponent implements OnInit {
       compressedAirAssessment.systemProfile.profileSummary = dataIntervalProfile;
     }
     compressedAirAssessment.systemProfile.systemProfileSetup = systemProfileSetup;
+
+    if (this.isProfileDataTypeChange) {
+      compressedAirAssessment.systemProfile.profileSummary.forEach(summary => {
+        summary.logToolFieldId = undefined;
+        summary.logToolFieldIdAmps = undefined;
+        summary.logToolFieldIdPowerFactor = undefined;
+        summary.logToolFieldIdVolts = undefined;
+      });
+      this.isProfileDataTypeChange = false;
+    }
+
     this.compressedAirAssessmentService.updateCompressedAir(compressedAirAssessment, true);
   }
 
@@ -119,6 +131,12 @@ export class ProfileSetupFormComponent implements OnInit {
         }
       }
     }
+  }
+
+
+  changeProfileDataType() {
+    this.isProfileDataTypeChange = true;
+    this.save();
   }
 
 }

--- a/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.html
+++ b/src/app/compressed-air-assessment/system-profile/system-profile-setup/operating-profile-table/operating-profile-table.component.html
@@ -18,7 +18,11 @@
             Hide Data Explorer Options
         </a>
     </div>
-
+    <div *ngIf="displayLogToolLink && showSelectField" class="pl-2 pr-2 border-right border-left">
+        <p class="alert-warning small m-0">
+            Select "Profile Data Type" for all Day Type's before setting Data Explorer Options
+        </p>
+    </div>
 </div>
 
 <div class="scroll-item">


### PR DESCRIPTION
connects #5580 

profile data is set dependent on the selected profile option for each day type. Added warning to indicate this.

Also resets selection when profile data option is changed