### PR TITLE
#5655: Help text for disabled fields

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ViewContainerRef } from '@angular/core';
+import { Component, ViewEncapsulation, ViewContainerRef, HostListener } from '@angular/core';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -9,6 +9,25 @@ export class AppComponent {
   private viewContainerRef: ViewContainerRef;
   constructor(viewContainerRef: ViewContainerRef) {
     this.viewContainerRef = viewContainerRef;
+  }
+  // Triggers the "focus" event for an input, or a label's associated input, even if it's disabled, to always show help text. (#5655)
+  @HostListener("click", ['$event']) onClick(e: MouseEvent){
+    let element = e.target;
+  
+    if (element instanceof HTMLElement) {
+      if (element.hasAttribute('disabled')) {
+        let evt = new Event('focus', {bubbles: false, cancelable: true});
+        element.dispatchEvent(evt);
+      }
+      else if (element.hasAttribute('for') && element.tagName === 'LABEL') {
+        let inputElem = document.getElementById(element.getAttribute('for'));
+  
+        if (inputElem && inputElem.hasAttribute('disabled')) {
+          let evt = new Event('focus', {bubbles: false, cancelable: true});
+          inputElem.dispatchEvent(evt);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
connects #5655
Testing note: It's easier to test in the branch `cooling-and-weather-2`, because the first two tests disable a few inputs when you set cooler type to Screw. Set the PR to merge into develop, however, because it's unrelated to cooling-and-weather.