### PR TITLE
Issue 5741 Remove startup check for indexDB

### DIFF
--- a/src/app/core/core.component.ts
+++ b/src/app/core/core.component.ts
@@ -88,10 +88,7 @@ export class CoreComponent implements OnInit {
       }
     });
 
-    window.indexedDB.databases().then(db => {
-      this.initData();
-    });
-
+    this.initData();
 
     this.updateAvailableSubscription = this.assessmentService.updateAvailable.subscribe(val => {
       if (val == true && this.electronService.isElectronApp) {


### PR DESCRIPTION
#5741 

Since adding ngx-indexed-db, we don't need to check db startup before performing db transactions