### PR TITLE
fix min=1/min=0.1 forms causing increments to bork

### DIFF
--- a/src/app/calculator/motors/nema-energy-efficiency/nema-energy-efficiency-form/nema-energy-efficiency-form.component.html
+++ b/src/app/calculator/motors/nema-energy-efficiency/nema-energy-efficiency-form/nema-energy-efficiency-form.component.html
@@ -29,7 +29,7 @@
     <div class="form-group">
       <label for="motorRPM">Motor RPM</label>
       <div class="input-group calc-addon-group">
-        <input type="number" min="1" step="10" class="form-control addon-input" id="motorRPM" formControlName="motorRPM"
+        <input type="number" step="10" class="form-control addon-input" id="motorRPM" formControlName="motorRPM"
           onfocus="this.select();" (focus)="focusField('motorRPM')" (input)="calculate()">
         <div class="incrementor input-group-addon">
           <button class="btn" (click)="subtractNum('motorRPM')">

--- a/src/app/fsat/fan-field-data/fan-field-data.component.html
+++ b/src/app/fsat/fan-field-data/fan-field-data.component.html
@@ -177,7 +177,7 @@
       [ngClass]="{'indicate-different': isMeasuredVoltageDifferent(), 'error': warnings.voltageError !== null, 'invalid':fieldDataForm.controls.measuredVoltage.invalid}">
       <label for="{{'measuredVoltage_'+idString}}">Measured Voltage</label>
       <div class="input-group">
-        <input name="measuredVoltage" type="number" min="1" step="any" class="form-control"
+        <input name="measuredVoltage" type="number" step="10" class="form-control"
           formControlName="measuredVoltage" id="{{'measuredVoltage_'+idString}}" (input)="save()"
           (focus)="focusField('measuredVoltage')" onfocus="this.select();" [readonly]="!selected">
         <span class="units">V</span>

--- a/src/app/psat/field-data/field-data.component.html
+++ b/src/app/psat/field-data/field-data.component.html
@@ -40,7 +40,7 @@
           Head</a>
       </label>
       <div class="input-group">
-        <input [readonly]="!selected" name="head" type="number" min="0.1" step="10" class="form-control"
+        <input [readonly]="!selected" name="head" type="number" step="10" class="form-control"
           formControlName="head" id="{{'head_'+idString}}" (input)="save()" (focus)="focusField('head')"
           onfocus="this.select();">
         <span class="input-group-addon units" [innerHTML]="settings.distanceMeasurement | settingsLabel"></span>
@@ -105,7 +105,7 @@
       [ngClass]="{'indicate-different': isMotorFieldVoltageDifferent(), 'error': fieldDataWarnings.voltageError !== null, 'invalid': psatForm.controls.measuredVoltage.invalid}">
       <label for="{{'measuredVoltage_'+idString}}">Measured Voltage</label>
       <div class="input-group">
-        <input [readonly]="!selected" name="measuredVoltage" type="number" min="1" step="10" class="form-control"
+        <input [readonly]="!selected" name="measuredVoltage" type="number" step="10" class="form-control"
           formControlName="measuredVoltage" id="{{'measuredVoltage_'+idString}}" (input)="save()"
           (focus)="focusField('measuredVoltage')" onfocus="this.select();">
         <span class="units">V</span>


### PR DESCRIPTION
connects #5668 
we already have our own version of input min/max validation, so we don't need to depend on the browser's built-in validation