### PR TITLE
Issue 6108 - Fix doubled time-series segments when duplicate names present

### DIFF
--- a/src/app/log-tool/log-tool-data.service.ts
+++ b/src/app/log-tool/log-tool-data.service.ts
@@ -322,14 +322,14 @@ getCurrentIntervalStrings(currentInterval: number, useDayStartEndOffset: boolean
     return dateMoment;
   }
 
-  isValidDate(dateISOFormat: any) {
+  isValidDate(dateItem: any) {
+    let dateISOFormat = new Date(dateItem);
     return dateISOFormat instanceof Date && !isNaN(dateISOFormat.getTime());
   }
 
   formatDates(dataset: ExplorerDataSet) {
     dataset.csvImportData.data.map(dataItem => {
-      let dateISOFormat = new Date(dataItem[dataset.dateField.fieldName]);
-      let validDate: boolean = this.isValidDate(dateISOFormat);
+      let validDate: boolean = this.isValidDate(dataItem[dataset.dateField.fieldName]);
       let dateMoment: Moment;
       if (validDate) {
         dateMoment = moment(dataItem[dataset.dateField.fieldName]);

--- a/src/app/log-tool/visualize/visualize.service.ts
+++ b/src/app/log-tool/visualize/visualize.service.ts
@@ -95,14 +95,22 @@ export class VisualizeService {
     return tmpFields;
   }
 
-  // field == axis
+  
+  isValidDate(dateItem: any) {
+    let dateISOFormat = new Date(dateItem);
+    return dateISOFormat instanceof Date && !isNaN(dateISOFormat.getTime());
+  }
+  
   getAxisOptionGraphData(fieldName: string): Array<number> {
     let data: Array<any> = new Array();
-    // 6040 Perform different operation if is datefield - don't concat
     this.logToolService.individualDataFromCsv.forEach(individualDataItem => {
       let foundData = individualDataItem.csvImportData.meta.fields.find(field => { return field == fieldName });
-      if (foundData) {
+      // 6108 continue to concat time, don't allow concat of other data fields (breaks time segment display in non time-series visualizer)
+      if (foundData && fieldName === individualDataItem.dateField.fieldName) {
         data = _.concat(data, individualDataItem.csvImportData.data);
+      }
+      if (foundData) {
+        data = individualDataItem.csvImportData.data;
       }
     });
     
@@ -121,8 +129,12 @@ export class VisualizeService {
     return data;
   }
 
+  // Need to filter by unique identifiers for data fields here
   getTimeSeriesData(field: LogToolField): Array<number | string> {
-    let data: Array<number | string> = _.find(this.allDataByAxisField, (dataItem) => { return dataItem.dataField.csvId == field.csvId && dataItem.dataField.isDateField }).data;
+    let data: Array<number | string> = _.find(this.allDataByAxisField, (dataItem) => { 
+      let fieldData = dataItem.dataField.csvId == field.csvId && dataItem.dataField.isDateField
+      return fieldData;
+    }).data;
     return data;
   }
 


### PR DESCRIPTION
#6108 

- meaningful change is in getAxisOptionGraphData()
- keeping comments
- also streamlined some logic and changed naming while trying to understand what was going on here.