### PR TITLE
Issue 6266: Turn off tutorials if app is not running in production

### DIFF
--- a/src/app/dashboard/landing-screen/landing-screen.component.ts
+++ b/src/app/dashboard/landing-screen/landing-screen.component.ts
@@ -20,23 +20,28 @@ export class LandingScreenComponent implements OnInit {
     if (!environment.production)
     {
       let settings : Settings = this.settingsDbService.globalSettings;
-      settings.disableTutorial = true;
-      settings.disableDashboardTutorial = true;
-      settings.disablePsatTutorial = true;
-      settings.disableFansTutorial = true;
-      settings.disablePhastTutorial = true;
-      settings.disableWasteWaterTutorial = true;
-      settings.disableSteamTutorial = true;
-      settings.disableMotorInventoryTutorial = true;
-      settings.disableTreasureHuntTutorial = true;
-      settings.disableDataExplorerTutorial = true;
-      settings.disableCompressedAirTutorial = true;
-      this.settingsDbService.globalSettings = settings;
-      console.log('Running in development mode - turned off tutorials');
+      if (!settings.disableTutorial)
+      {
+        settings.disableTutorial = true;
+        settings.disableDashboardTutorial = true;
+        settings.disablePsatTutorial = true;
+        settings.disableFansTutorial = true;
+        settings.disablePhastTutorial = true;
+        settings.disableWasteWaterTutorial = true;
+        settings.disableSteamTutorial = true;
+        settings.disableMotorInventoryTutorial = true;
+        settings.disableTreasureHuntTutorial = false;
+        settings.disableDataExplorerTutorial = true;
+        settings.disableCompressedAirTutorial = true;
+        this.settingsDbService.globalSettings = settings;
+        console.log('Running in development mode - turned off tutorials');
+      }
     }
     if(!this.settingsDbService.globalSettings.disableTutorial){
       this.assessmentService.showTutorial.next('landing-screen');
     }
+
+
   }
 
   createAssessment(str?: string) {

--- a/src/app/dashboard/landing-screen/landing-screen.component.ts
+++ b/src/app/dashboard/landing-screen/landing-screen.component.ts
@@ -3,7 +3,6 @@ import { SettingsDbService } from '../../indexedDb/settings-db.service';
 import { AssessmentService } from '../assessment.service';
 import { DashboardService } from '../dashboard.service';
 import { Settings } from '../../shared/models/settings';
-import { AssessmentSettingsComponent } from '../../settings/assessment-settings/assessment-settings.component';
 import { environment } from '../../../environments/environment';
 
 @Component({
@@ -20,7 +19,7 @@ export class LandingScreenComponent implements OnInit {
     if (!environment.production)
     {
       let settings : Settings = this.settingsDbService.globalSettings;
-      if (!settings.disableTutorial)
+      if (settings.disableTutorial == undefined)
       {
         settings.disableTutorial = true;
         settings.disableDashboardTutorial = true;
@@ -30,7 +29,7 @@ export class LandingScreenComponent implements OnInit {
         settings.disableWasteWaterTutorial = true;
         settings.disableSteamTutorial = true;
         settings.disableMotorInventoryTutorial = true;
-        settings.disableTreasureHuntTutorial = false;
+        settings.disableTreasureHuntTutorial = true;
         settings.disableDataExplorerTutorial = true;
         settings.disableCompressedAirTutorial = true;
         this.settingsDbService.globalSettings = settings;

--- a/src/app/dashboard/landing-screen/landing-screen.component.ts
+++ b/src/app/dashboard/landing-screen/landing-screen.component.ts
@@ -39,8 +39,6 @@ export class LandingScreenComponent implements OnInit {
     if(!this.settingsDbService.globalSettings.disableTutorial){
       this.assessmentService.showTutorial.next('landing-screen');
     }
-
-
   }
 
   createAssessment(str?: string) {

--- a/src/app/dashboard/landing-screen/landing-screen.component.ts
+++ b/src/app/dashboard/landing-screen/landing-screen.component.ts
@@ -2,6 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { SettingsDbService } from '../../indexedDb/settings-db.service';
 import { AssessmentService } from '../assessment.service';
 import { DashboardService } from '../dashboard.service';
+import { Settings } from '../../shared/models/settings';
+import { AssessmentSettingsComponent } from '../../settings/assessment-settings/assessment-settings.component';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-landing-screen',
@@ -14,6 +17,23 @@ export class LandingScreenComponent implements OnInit {
     private assessmentService: AssessmentService) { }
 
   ngOnInit() {
+    if (!environment.production)
+    {
+      let settings : Settings = this.settingsDbService.globalSettings;
+      settings.disableTutorial = true;
+      settings.disableDashboardTutorial = true;
+      settings.disablePsatTutorial = true;
+      settings.disableFansTutorial = true;
+      settings.disablePhastTutorial = true;
+      settings.disableWasteWaterTutorial = true;
+      settings.disableSteamTutorial = true;
+      settings.disableMotorInventoryTutorial = true;
+      settings.disableTreasureHuntTutorial = true;
+      settings.disableDataExplorerTutorial = true;
+      settings.disableCompressedAirTutorial = true;
+      this.settingsDbService.globalSettings = settings;
+      console.log('Running in development mode - turned off tutorials');
+    }
     if(!this.settingsDbService.globalSettings.disableTutorial){
       this.assessmentService.showTutorial.next('landing-screen');
     }

--- a/src/app/dashboard/landing-screen/measur/measur.component.ts
+++ b/src/app/dashboard/landing-screen/measur/measur.component.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Settings } from '../../../shared/models/settings';
-
 
 @Component({
   selector: 'app-measur',

--- a/src/app/dashboard/landing-screen/measur/measur.component.ts
+++ b/src/app/dashboard/landing-screen/measur/measur.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Settings } from '../../../shared/models/settings';
+
 
 @Component({
   selector: 'app-measur',


### PR DESCRIPTION
Connects #6266 

(is this good practice? should I be editing the global settings directly? )