### PR TITLE
Issue 6296: Heat Cascading Modal backdrop bug

### DIFF
--- a/src/app/calculator/furnaces/air-heating/air-heating-form/air-heating-form.component.html
+++ b/src/app/calculator/furnaces/air-heating/air-heating-form/air-heating-form.component.html
@@ -36,7 +36,7 @@
     </div>
 
     <div class="form-group">
-      <label class="small" for="method">Type of fuel</label>
+      <label class="small" for="method">Type of Fuel</label>
       <select name="gasFuelType" class="form-control" formControlName="gasFuelType" id="gasFuelType"
         (change)="changeFuelType()">
         <option [ngValue]="true">Gas</option>

--- a/src/app/calculator/furnaces/air-heating/air-heating.component.html
+++ b/src/app/calculator/furnaces/air-heating/air-heating.component.html
@@ -38,7 +38,7 @@
 	<div class="panel-group" [ngStyle]="{'height.px': containerHeight}">
 		<!-- baseline -->
 		<div class="calculator-panel-container modification" [ngStyle]="{'height.px': containerHeight}"
-			[ngClass]="{'small-screen-tab': smallScreenTab === 'form'}">
+			[ngClass]="{'small-screen-tab': smallScreenTab === 'form', 'modal-open' : isModalOpen}">
 			<div class="d-flex flex-column m-4">
 				<app-air-heating-form [settings]="settings" [inTreasureHunt]="inTreasureHunt">
 				</app-air-heating-form>

--- a/src/app/calculator/furnaces/air-heating/air-heating.component.ts
+++ b/src/app/calculator/furnaces/air-heating/air-heating.component.ts
@@ -83,6 +83,8 @@ export class AirHeatingComponent implements OnInit {
     });
     this.modalSubscription = this.airHeatingService.modalOpen.subscribe(modalOpen => {
       this.isModalOpen = modalOpen;
+      console.log(this.isModalOpen);
+      console.log(this.modalSubscription);
     });
   }
 

--- a/src/app/calculator/furnaces/air-heating/air-heating.component.ts
+++ b/src/app/calculator/furnaces/air-heating/air-heating.component.ts
@@ -83,8 +83,6 @@ export class AirHeatingComponent implements OnInit {
     });
     this.modalSubscription = this.airHeatingService.modalOpen.subscribe(modalOpen => {
       this.isModalOpen = modalOpen;
-      console.log(this.isModalOpen);
-      console.log(this.modalSubscription);
     });
   }
 

--- a/src/app/calculator/furnaces/flue-gas/flue-gas.component.ts
+++ b/src/app/calculator/furnaces/flue-gas/flue-gas.component.ts
@@ -102,7 +102,10 @@ export class FlueGasComponent implements OnInit {
   initSubscriptions() {
     this.modalSubscription = this.flueGasService.modalOpen.subscribe(modalOpen => {
       this.isModalOpen = modalOpen;
+      console.log(this.isModalOpen);
+      console.log(this.modalSubscription);
     });
+
     this.baselineDataSub = this.flueGasService.baselineData.subscribe(baselineData => {
       if (baselineData) {
         this.setBaselineSelected();

--- a/src/app/calculator/furnaces/flue-gas/flue-gas.component.ts
+++ b/src/app/calculator/furnaces/flue-gas/flue-gas.component.ts
@@ -102,8 +102,6 @@ export class FlueGasComponent implements OnInit {
   initSubscriptions() {
     this.modalSubscription = this.flueGasService.modalOpen.subscribe(modalOpen => {
       this.isModalOpen = modalOpen;
-      console.log(this.isModalOpen);
-      console.log(this.modalSubscription);
     });
 
     this.baselineDataSub = this.flueGasService.baselineData.subscribe(baselineData => {

--- a/src/app/calculator/furnaces/heat-cascading/heat-cascading.component.html
+++ b/src/app/calculator/furnaces/heat-cascading/heat-cascading.component.html
@@ -37,7 +37,7 @@
 	<div class="panel-group" [ngStyle]="{'height.px': containerHeight}">
 		<!-- baseline -->
 		<div class="calculator-panel-container modification" [ngStyle]="{'height.px': containerHeight}"
-			[ngClass]="{'small-screen-tab': smallScreenTab === 'form'}">
+			[ngClass]="{'small-screen-tab': smallScreenTab === 'form', 'modal-open' : isModalOpen}">
 			<div class="d-flex flex-column mx-4 my-4">
 				<app-heat-cascading-form [settings]="settings" [inTreasureHunt]="inTreasureHunt"
 					[inModal]="isModalOpen"></app-heat-cascading-form>

--- a/src/app/phast/phast-report/phast-input-summary/flue-gas-summary/flue-gas-summary.component.html
+++ b/src/app/phast/phast-report/phast-input-summary/flue-gas-summary/flue-gas-summary.component.html
@@ -199,9 +199,7 @@
 
             <tr>
               <td [ngClass]="{'indicate-report-field-different':c2h6Diff[index] == true}">
-                C
-                <sub>2</sub>H
-                <sub>6</sub>
+                C<sub>2</sub>H<sub>6</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':c2h6Diff[index] == true}">
                 {{data.baseline.material.C2H6}}%
@@ -212,9 +210,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':c3h8Diff[index] == true}">
-                C
-                <sub>3</sub>H
-                <sub>8</sub>
+                C<sub>3</sub>H<sub>8</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':c3h8Diff[index] == true}">
                 {{data.baseline.material.C3H8}}%
@@ -225,10 +221,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':c4h10cnh2nDiff[index] == true}">
-                C
-                <sub>4</sub>H
-                <sub>10</sub>CnH
-                <sub>2</sub>N
+                C<sub>4</sub>H<sub>10</sub>CnH<sub>2</sub>N
               </td>
               <td [ngClass]="{'indicate-report-field-different':c4h10cnh2nDiff[index] == true}">
                 {{data.baseline.material.C4H10_CnH2n}}%
@@ -239,8 +232,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':ch4Diff[index] == true}">
-                CH
-                <sub>4</sub>
+                CH<sub>4</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':ch4Diff[index] == true}">
                 {{data.baseline.material.CH4}}%
@@ -262,8 +254,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':co2Diff[index] == true}">
-                CO
-                <sub>2</sub>
+                CO<sub>2</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':co2Diff[index] == true}">
                 {{data.baseline.material.CO2}}%
@@ -274,8 +265,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':h2Diff[index] == true}">
-                H
-                <sub>2</sub>
+                H<sub>2</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':h2Diff[index] == true}">
                 {{data.baseline.material.H2}}%
@@ -286,8 +276,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':h2oDiff[index] == true}">
-                H
-                <sub>2</sub>O
+                H<sub>2</sub>O
               </td>
               <td [ngClass]="{'indicate-report-field-different':h2oDiff[index] == true}">
                 {{data.baseline.material.H2O}}%
@@ -298,8 +287,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':n2Diff[index] == true}">
-                N
-                <sub>2</sub>
+                N<sub>2</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':n2Diff[index] == true}">
                 {{data.baseline.material.N2}}%
@@ -310,8 +298,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':o2Diff[index] == true}">
-                O
-                <sub>2</sub>
+                O<sub>2</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':o2Diff[index] == true}">
                 {{data.baseline.material.O2}}%
@@ -322,8 +309,7 @@
             </tr>
             <tr>
               <td [ngClass]="{'indicate-report-field-different':so2Diff[index] == true}">
-                SO
-                <sub>2</sub>
+                SO<sub>2</sub>
               </td>
               <td [ngClass]="{'indicate-report-field-different':so2Diff[index] == true}">
                 {{data.baseline.material.SO2}}%

--- a/src/app/suiteDb/custom-materials/custom-flue-gas-materials/custom-flue-gas-materials.component.html
+++ b/src/app/suiteDb/custom-materials/custom-flue-gas-materials/custom-flue-gas-materials.component.html
@@ -10,9 +10,7 @@
         <table class="table">
           <tr>
             <td>
-              C
-              <sub>2</sub>H
-              <sub>6</sub>:
+              C<sub>2</sub>H<sub>6</sub>:
             </td>
             <td>
               {{flueGasMaterial.C2H6 | sigFigs: '3'}} %
@@ -20,9 +18,7 @@
           </tr>
           <tr>
             <td>
-              C
-              <sub>3</sub>H
-              <sub>8</sub>:
+              C<sub>3</sub>H<sub>8</sub>:
             </td>
             <td>
               {{flueGasMaterial.C3H8 | sigFigs: '3'}} %
@@ -30,10 +26,7 @@
           </tr>
           <tr>
             <td>
-              C
-              <sub>4</sub>H
-              <sub>10</sub>CnH
-              <sub>2</sub>n:
+              C<sub>4</sub>H<sub>10</sub>CnH<sub>2</sub>n:
             </td>
             <td>
               {{flueGasMaterial.C4H10_CnH2n | sigFigs: '3'}} %
@@ -41,8 +34,7 @@
           </tr>
           <tr>
             <td>
-              CH
-              <sub>4</sub>:
+              CH<sub>4</sub>:
             </td>
             <td>
               {{flueGasMaterial.CH4 | sigFigs: '3'}} %
@@ -58,8 +50,7 @@
           </tr>
           <tr>
             <td>
-              CO
-              <sub>2</sub>:
+              CO<sub>2</sub>:
             </td>
             <td>
               {{flueGasMaterial.CO2 | sigFigs: '3'}} %
@@ -67,8 +58,7 @@
           </tr>
           <tr>
             <td>
-              H
-              <sub>2</sub>:
+              H<sub>2</sub>:
             </td>
             <td>
               {{flueGasMaterial.H2 | sigFigs: '3'}} %
@@ -76,8 +66,7 @@
           </tr>
           <tr>
             <td>
-              H
-              <sub>2</sub>O:
+              H<sub>2</sub>O:
             </td>
             <td>
               {{flueGasMaterial.H2O | sigFigs: '3'}} %
@@ -85,8 +74,7 @@
           </tr>
           <tr>
             <td>
-              N
-              <sub>2</sub>:
+              N<sub>2</sub>:
             </td>
             <td>
               {{flueGasMaterial.N2 | sigFigs: '3'}} %
@@ -94,8 +82,7 @@
           </tr>
           <tr>
             <td>
-              O
-              <sub>2</sub>:
+              O<sub>2</sub>:
             </td>
             <td>
               {{flueGasMaterial.O2 | sigFigs: '3'}} %
@@ -103,8 +90,7 @@
           </tr>
           <tr>
             <td>
-              SO
-              <sub>2</sub>:
+              SO<sub>2</sub>:
             </td>
             <td>
               {{flueGasMaterial.SO2 | sigFigs: '3'}} %

--- a/src/app/suiteDb/flue-gas-material/flue-gas-material.component.html
+++ b/src/app/suiteDb/flue-gas-material/flue-gas-material.component.html
@@ -35,9 +35,8 @@
               <span class="alert-warning pull-right small" *ngIf="nameError !== null">{{nameError}}</span>
             </div>
             <div class="form-group">
-              <label class="small" for="C2H6">C
-                <sub>2</sub>H
-                <sub>6</sub>
+              <label class="small" for="C2H6">
+                C<sub>2</sub>H<sub>6</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="C2H6" name="C2H6" class="form-control" [(ngModel)]="newMaterial.C2H6"
@@ -46,9 +45,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="C3H8">C
-                <sub>3</sub>H
-                <sub>8</sub>
+              <label class="small" for="C3H8">
+                C<sub>3</sub>H<sub>8</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="C3H8" name="C3H8" class="form-control" [(ngModel)]="newMaterial.C3H8"
@@ -57,10 +55,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="C4H10_CnH2n">C
-                <sub>4</sub>H
-                <sub>10</sub>CnH
-                <sub>2</sub>n</label>
+              <label class="small" for="C4H10_CnH2n">
+                C<sub>4</sub>H<sub>10</sub>CnH<sub>2</sub>n</label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="C4H10_CnH2n" name="C4H10_CnH2n" class="form-control" [(ngModel)]="newMaterial.C4H10_CnH2n"
                   (input)="setHHV()" (focus)="focusField('C4H10_CnH2n')" />
@@ -68,8 +64,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="CH4">CH
-                <sub>4</sub>
+              <label class="small" for="CH4">
+                CH<sub>4</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="CH4" name="CH4" class="form-control" [(ngModel)]="newMaterial.CH4"
@@ -86,8 +82,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="CO2">CO
-                <sub>2</sub>
+              <label class="small" for="CO2">
+                CO<sub>2</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="CO2" name="CO2" class="form-control" [(ngModel)]="newMaterial.CO2"
@@ -96,8 +92,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="H2">H
-                <sub>2</sub>
+              <label class="small" for="H2">
+                H<sub>2</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="H2" name="H2" class="form-control" [(ngModel)]="newMaterial.H2" (input)="setHHV()"
@@ -106,8 +102,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="H2O">H
-                <sub>2</sub>O</label>
+              <label class="small" for="H2O">
+                H<sub>2</sub>O</label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="H2O" name="H2OH2" class="form-control" [(ngModel)]="newMaterial.H2O"
                   (input)="setHHV()" (focus)="focusField('H2O')" />
@@ -115,8 +111,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="N2">N
-                <sub>2</sub>
+              <label class="small" for="N2">
+                N<sub>2</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="N2" name="N2" class="form-control" [(ngModel)]="newMaterial.N2" (input)="setHHV()"
@@ -125,8 +121,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="O2">O
-                <sub>2</sub>
+              <label class="small" for="O2">
+                O<sub>2</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="O2" name="O2" class="form-control" [(ngModel)]="newMaterial.O2" (input)="setHHV()"
@@ -135,8 +131,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="small" for="SO2">SO
-                <sub>2</sub>
+              <label class="small" for="SO2">
+                SO<sub>2</sub>
               </label>
               <div class="input-group">
                 <input type="number" step="any" min="0" max="100" id="SO2" name="SO2" class="form-control" [(ngModel)]="newMaterial.SO2"


### PR DESCRIPTION
Connects #6296 

(also some of the chemical formulas had extra space between the subscripts so I changed those as well)
![image](https://github.com/ORNL-AMO/AMO-Tools-Desktop/assets/107294012/e3b863b5-bec1-44ef-87f5-ac75c17927b1)


after change:
![image](https://github.com/ORNL-AMO/AMO-Tools-Desktop/assets/107294012/05c76db7-19ae-4738-853a-3910665a14c4)
