### PR TITLE
Issue 5720: Remove operating costs tab in phast calculators

### DIFF
--- a/src/app/phast/phast-calculator-tabs/phast-calculator-tabs.component.html
+++ b/src/app/phast/phast-calculator-tabs/phast-calculator-tabs.component.html
@@ -15,9 +15,6 @@
     <li [ngClass]="{'active': calcTab == 'convert-units'}">
       <a (click)="changeCalcTab('convert-units')">Unit Converter</a>
     </li>
-    <li [ngClass]="{'active': calcTab == 'operating-cost'}">
-      <a (click)="changeCalcTab('operating-cost')">Operating Costs</a>
-    </li>
   </ul>
 </div>
 
@@ -42,9 +39,6 @@
     </div>
     <div [ngClass]="{'active': calcTab == 'convert-units', 'collapse': calcTabsCollapsed}">
       <a (click)="changeCalcTab('convert-units')">Unit Converter</a>
-    </div>
-    <div [ngClass]="{'active': calcTab == 'operating-cost', 'collapse': calcTabsCollapsed}">
-      <a (click)="changeCalcTab('operating-cost')">Operating Costs</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Connects #5720 