### PR TITLE
Fix http error - don't send test calls in dev

### DIFF
--- a/src/app/shared/analytics/analytics.service.ts
+++ b/src/app/shared/analytics/analytics.service.ts
@@ -86,6 +86,7 @@ export class AnalyticsService {
     }
 
     let url: string = environment.measurUtilitiesApi + 'gamp';
+    if (environment.production) { 
       this.httpClient.post<any>(url, postBody, this.httpOptions)
       .pipe(catchError(error => [])).subscribe({
         next: (resp) => {
@@ -96,6 +97,7 @@ export class AnalyticsService {
           // for now all errors fail silently
         }
       });
+    }
   }
 
   setClientId(uuid: string) {


### PR DESCRIPTION
I accidentally removed this check so http errors pile up trying to connect to the dev server. Harmless but annoying