### PR TITLE
Issue 6508 - Fix new psat state

### DIFF
--- a/src/app/psat/integrate-pump-inventory/integrate-pump-inventory.component.ts
+++ b/src/app/psat/integrate-pump-inventory/integrate-pump-inventory.component.ts
@@ -36,9 +36,11 @@ export class IntegratePumpInventoryComponent {
     private integrationStateService: IntegrationStateService) { }
 
   ngOnInit() {
-    this.psatIntegrationService.setPSATConnectedInventoryData(this.assessment, this.settings);
-    this.savePsat.emit(this.assessment.psat);
-    this.saved.emit(true);
+    if (this.assessment.psat.connectedItem) {
+      this.psatIntegrationService.setPSATConnectedInventoryData(this.assessment, this.settings);
+      this.savePsat.emit(this.assessment.psat);
+      this.saved.emit(true);
+    }
     this.setInventorySelectOptions();
     this.connectedInventoryDataSub = this.integrationStateService.connectedInventoryData.subscribe(connectedInventoryData => {
         this.handleConnectedInventoryEvents(connectedInventoryData);

--- a/src/app/psat/modify-conditions/modify-conditions-tabs/modify-conditions-tabs.component.ts
+++ b/src/app/psat/modify-conditions/modify-conditions-tabs/modify-conditions-tabs.component.ts
@@ -219,18 +219,10 @@ export class ModifyConditionsTabsComponent implements OnInit {
   checkOperationsInputError(){
     let hasWarning: boolean = false;
     let baselineOperationsWarnings: OperationsWarnings = this.psatWarningService.checkPumpOperations(this.compareService.baselinePSAT, this.settings, true);
-    for (var key in baselineOperationsWarnings) {
-      if (baselineOperationsWarnings[key] !== null) {
-        hasWarning = true;
-      }
-    }
+    hasWarning = this.psatWarningService.checkWarningsExist(baselineOperationsWarnings);
     if (this.compareService.modifiedPSAT && !hasWarning) {
       let modifiedOperationsWarnings: OperationsWarnings = this.psatWarningService.checkPumpOperations(this.compareService.modifiedPSAT, this.settings);
-      for (var key in modifiedOperationsWarnings) {
-        if (modifiedOperationsWarnings[key] !== null) {
-          hasWarning = true;
-        }
-      }
+      hasWarning = this.psatWarningService.checkWarningsExist(modifiedOperationsWarnings);
     }
     return hasWarning;
   }

--- a/src/app/psat/psat-warning.service.ts
+++ b/src/app/psat/psat-warning.service.ts
@@ -405,11 +405,11 @@ export class PsatWarningService {
     }
   }
 
-  //Iterates warnings objects to see if any warnings are not null
+  //Iterates warnings objects to see if any warnings are not null/undefined
   checkWarningsExist(warnings: FieldDataWarnings | MotorWarnings | PumpFluidWarnings | OperationsWarnings): boolean {
     let hasWarning: boolean = false;
     for (var key in warnings) {
-      if (warnings[key] !== null && warnings[key] !== undefined) {
+      if (warnings[key]) {
         hasWarning = true;
       }
     }

--- a/src/app/psat/psat.component.ts
+++ b/src/app/psat/psat.component.ts
@@ -173,7 +173,7 @@ export class PsatComponent implements OnInit {
         this.modificationIndex = _.findIndex(this._psat.modifications, (val) => {
           return val.psat.name == mod.name
         })
-      } else {
+      } else {  
         this.modificationIndex = undefined;
       }
     })
@@ -240,6 +240,7 @@ export class PsatComponent implements OnInit {
     this.psatTabService.mainTab.next('system-setup');
     this.psatTabService.stepTab.next('system-basics');
     this.psatTabService.modifyConditionsTab.next('pump-fluid');
+    this.compareService.selectedModification.next(undefined);
     this.connectedInventoryDataSub.unsubscribe();
     this.integrationStateService.connectedInventoryData.next(this.integrationStateService.getEmptyConnectedInventoryData());
   }


### PR DESCRIPTION
#6508 

Use same check warnings method for baseline and mod
set selected mod undefined when leaving an assessment 
Don't save psat on connected item init if not connected item