### PR TITLE
Issue 6453 - Add Assessment Opportunities to TH

### DIFF
--- a/scripts/download-stats.js
+++ b/scripts/download-stats.js
@@ -30,7 +30,6 @@ async function main() {
     }
 
     const headers = getHeaders();
-    debugger;
     const releases = await getReleases(headers, API_URL_MEASUR, 'raw_MEASUR_data.json');
     // const releases = require('./download-stats/raw-data.json');
     const csv = parseReleases(releases);
@@ -82,7 +81,6 @@ async function getReleases(reqHeaders, URL, jsonURL) {
     }
 
     console.log(`Found ${releases.length} releases in total.`);
-    debugger;
     let outPath = path.join(OUTPUT_DIR, jsonURL);
     await fs.writeFileSync(outPath, JSON.stringify(releases));
     // await fs.writeFileSync(outPath, JSON.stringify(releases), { encoding: 'utf-8' });

--- a/src/app/compressed-air-assessment/compressed-air-assessment.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-assessment.component.ts
@@ -94,7 +94,7 @@ export class CompressedAirAssessmentComponent implements OnInit {
         this.setDisableNext();
       }
     })
-    let tmpTab: string = this.assessmentService.getTab();
+    let tmpTab: string = this.assessmentService.getStartingTab();
     if (tmpTab) {
       this.compressedAirAssessmentService.mainTab.next(tmpTab);
     }

--- a/src/app/dashboard/assessment.service.ts
+++ b/src/app/dashboard/assessment.service.ts
@@ -17,7 +17,7 @@ import { DashboardService } from './dashboard.service';
 export class AssessmentService {
 
   workingAssessment: Assessment;
-  tab: string;
+  startingTab: string;
   subTab: string;
   showLandingScreen: boolean = true;
 
@@ -31,9 +31,9 @@ export class AssessmentService {
 
   goToAssessment(assessment: Assessment, mainTab?: string, subTab?: string) {
     if (mainTab) {
-      this.tab = mainTab;
+      this.startingTab = mainTab;
     } else {
-      this.tab = 'system-setup';
+      this.startingTab = 'system-setup';
     }
 
     if (subTab) {
@@ -43,37 +43,37 @@ export class AssessmentService {
     let itemSegment: string;
     if (assessment.type === 'PSAT') {
       if (assessment.psat.setupDone && !mainTab && (!assessment.isExample)) {
-        this.tab = 'assessment';
+        this.startingTab = 'assessment';
       }
       itemSegment = '/psat/';
     } else if (assessment.type === 'PHAST') {
       if (assessment.phast.setupDone && !mainTab && (!assessment.isExample)) {
-        this.tab = 'assessment';
+        this.startingTab = 'assessment';
       }
       itemSegment = '/phast/';
     } else if (assessment.type === 'FSAT') {
       if (assessment.fsat.setupDone && !mainTab && !assessment.isExample) {
-        this.tab = 'assessment';
+        this.startingTab = 'assessment';
       }
       itemSegment = '/fsat/';
     } else if (assessment.type === 'SSMT') {
       if (assessment.ssmt.setupDone && !mainTab && !assessment.isExample) {
-        this.tab = 'assessment';
+        this.startingTab = 'assessment';
       }
       itemSegment = '/ssmt/';
     } else if (assessment.type == 'TreasureHunt') {
       if (assessment.treasureHunt.setupDone && !mainTab && !assessment.isExample) {
-        this.tab = 'treasure-chest';
+        this.startingTab = 'treasure-chest';
       }
       itemSegment = '/treasure-hunt/';
     } else if (assessment.type == 'WasteWater') {
       if (assessment.wasteWater.setupDone && !mainTab && !assessment.isExample) {
-        this.tab = 'assessment';
+        this.startingTab = 'assessment';
       }
       itemSegment = '/waste-water/';
     } else if (assessment.type == 'CompressedAir') {
       if (assessment.compressedAirAssessment.setupDone && !mainTab && !assessment.isExample) {
-        this.tab = 'assessment';
+        this.startingTab = 'assessment';
       }
       itemSegment = '/compressed-air/';
     }
@@ -158,8 +158,8 @@ export class AssessmentService {
     return this.workingAssessment;
   }
 
-  getTab() {
-    return this.tab;
+  getStartingTab() {
+    return this.startingTab;
   }
 
   getSubTab() {
@@ -174,9 +174,8 @@ export class AssessmentService {
     this.showLandingScreen = bool;
   }
 
-  setWorkingAssessment(assessment: Assessment, str?: string) {
-    this.tab = str;
-    this.workingAssessment = assessment;
+  setStartingTab(startingTab?: string) {
+    this.startingTab = startingTab;
   }
 
   getNewFsat(settings: Settings): FSAT {

--- a/src/app/examples/mockFsat.ts
+++ b/src/app/examples/mockFsat.ts
@@ -143,6 +143,7 @@ export const MockFsat: Assessment = {
                         measuredVoltage: 460
                     }
                 },
+                id: 'lorol3dhb',
                 exploreOpportunities: true
             },
             {
@@ -214,6 +215,7 @@ export const MockFsat: Assessment = {
                         measuredVoltage: 460
                     }
                 },
+                id: 'usbnl3dhb',
                 exploreOpportunities: true
             }
         ]

--- a/src/app/examples/mockPhast.ts
+++ b/src/app/examples/mockPhast.ts
@@ -37,6 +37,7 @@ export const MockPhast: Assessment = {
         },
         modifications: [
             {
+                id: "wjrkhj3dgb",              
                 phast: {
                     losses: {
                         chargeMaterials: [
@@ -217,6 +218,7 @@ export const MockPhast: Assessment = {
                 }
             },
             {
+                id: "ncokyj3dgb",              
                 phast: {
                     losses: {
                         chargeMaterials: [
@@ -397,6 +399,7 @@ export const MockPhast: Assessment = {
                 }
             },
             {
+                id: "nnrkhj3aji",
                 phast: {
                     losses: {
                         chargeMaterials: [
@@ -577,6 +580,7 @@ export const MockPhast: Assessment = {
                 }
             },
             {
+                id: "wjzkhj3mmc",
                 phast: {
                     losses: {
                         chargeMaterials: [
@@ -757,6 +761,7 @@ export const MockPhast: Assessment = {
                 }
             },
             {
+                id: "wjrk77sdgb",
                 phast: {
                     losses: {
                         chargeMaterials: [

--- a/src/app/examples/mockPsat.ts
+++ b/src/app/examples/mockPsat.ts
@@ -52,8 +52,9 @@ export const MockPsat: Assessment = {
             }
         },
         "modifications": [{
+            "id": "wjrol3dhb",              
             "psat": {
-                "name": "New Pump and Motor",                
+                "name": "New Pump and Motor",
                 "inputs": {
                     "pump_style": 6,
                     "pump_specified": 87.52,
@@ -106,6 +107,7 @@ export const MockPsat: Assessment = {
                 "systemBasicsNotes": ""
             }            
         }, {
+            "id": "uk0olxdjb",
             "psat": {
                 "name": "VFD reduce speed to 90%",
                 "inputs": {

--- a/src/app/examples/mockTreasureHunt.ts
+++ b/src/app/examples/mockTreasureHunt.ts
@@ -1156,6 +1156,7 @@ export const MockTreasureHunt: Assessment = {
             "date": new Date(),
             "owner": "Utilities",
             "businessUnits": "Reyes",
+            "iconString": "assets/images/calculator-icons/opportunity-sheet-icon.png",
             "opportunityCost": {
                 "engineeringServices": 100,
                 "material": 0,

--- a/src/app/fsat/fsat.component.ts
+++ b/src/app/fsat/fsat.component.ts
@@ -126,7 +126,7 @@ export class FsatComponent implements OnInit {
       }
       this.getSettings();
       this.initSankeyList();
-      let tmpTab: string = this.assessmentService.tab;
+      let tmpTab: string = this.assessmentService.getStartingTab();
       if (tmpTab) {
         this.fsatService.mainTab.next(tmpTab);
       }

--- a/src/app/phast/add-modification/add-modification.component.ts
+++ b/src/app/phast/add-modification/add-modification.component.ts
@@ -3,6 +3,7 @@ import { PHAST, Modification } from '../../shared/models/phast/phast';
 import { PhastService } from '../phast.service';
 import { Subscription } from 'rxjs';
 import { SavingsOpportunity } from '../../shared/models/explore-opps';
+import { HelperFunctionsService } from '../../shared/helper-services/helper-functions.service';
 
 @Component({
   selector: 'app-add-modification',
@@ -24,7 +25,7 @@ export class AddModificationComponent implements OnInit {
   newModificationName: string;
   currentTab: string;
   tabSubscription: Subscription;
-  constructor(private phastService: PhastService) { }
+  constructor(private phastService: PhastService, private helperFunctions: HelperFunctionsService) { }
 
   ngOnInit() {
     if (this.modifications) {
@@ -48,6 +49,7 @@ export class AddModificationComponent implements OnInit {
         losses: {},
         name: this.newModificationName,
       },
+      id: this.helperFunctions.getNewIdString(),
       notes: {
         chargeNotes: '',
         wallNotes: '',
@@ -65,6 +67,7 @@ export class AddModificationComponent implements OnInit {
         energyInputExhaustGasNotes: '',
         operationsNotes: ''
       },
+
       exploreOppsShowFlueGas: exploreOppsDefault,
       exploreOppsShowAirTemp: exploreOppsDefault,
       exploreOppsShowMaterial: exploreOppsDefault,

--- a/src/app/phast/modification-list/modification-list.component.ts
+++ b/src/app/phast/modification-list/modification-list.component.ts
@@ -6,6 +6,7 @@ import { PhastService } from '../phast.service';
 import { Subscription } from 'rxjs';
 import * as _ from 'lodash';
 import { SavingsOpportunity } from '../../shared/models/explore-opps';
+import { HelperFunctionsService } from '../../shared/helper-services/helper-functions.service';
 
 @Component({
   selector: 'app-modification-list',
@@ -30,7 +31,7 @@ export class ModificationListComponent implements OnInit {
   deleteArr: Array<boolean>;
   asssessmentTab: string;
   assessmentTabSubscription: Subscription;
-  constructor(private phastCompareService: PhastCompareService, private lossesService: LossesService, private phastService: PhastService) { }
+    constructor(private phastCompareService: PhastCompareService, private helperFunctions: HelperFunctionsService, private lossesService: LossesService, private phastService: PhastService) { }
 
   ngOnInit() {
     this.initDropdown();
@@ -162,6 +163,7 @@ export class ModificationListComponent implements OnInit {
         energyInputExhaustGasNotes: '',
         operationsNotes: ''
       },
+      id: this.helperFunctions.getNewIdString(),
       exploreOppsShowFlueGas: exploreOppsDefault,
       exploreOppsShowAirTemp: exploreOppsDefault,
       exploreOppsShowMaterial: exploreOppsDefault,

--- a/src/app/phast/phast-integration.service.spec.ts
+++ b/src/app/phast/phast-integration.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PhastIntegrationService } from './phast-integration.service';
+
+describe('PhastIntegrationService', () => {
+  let service: PhastIntegrationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PhastIntegrationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/phast/phast-integration.service.ts
+++ b/src/app/phast/phast-integration.service.ts
@@ -1,0 +1,175 @@
+import { Injectable } from '@angular/core';
+import { IntegratedAssessment, IntegratedEnergyOptions, ModificationEnergyOption } from '../shared/assessment-integration/assessment-integration.service';
+import { Settings } from '../shared/models/settings';
+import { EnergyUseReportData, ExecutiveSummary, PHAST, PhastResults } from '../shared/models/phast/phast';
+import { EnergyUseItem } from '../shared/models/treasure-hunt';
+import { ExecutiveSummaryService } from './phast-report/executive-summary.service';
+import { PhastResultsService } from './phast-results.service';
+import { ConvertUnitsService } from '../shared/convert-units/convert-units.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PhastIntegrationService {
+
+  constructor(private executiveSummaryService: ExecutiveSummaryService, private convertUnitsService: ConvertUnitsService,
+    private phastResultService: PhastResultsService) { }
+
+  setIntegratedAssessmentData(integratedAssessment: IntegratedAssessment, settings: Settings, treasureHuntSettings: Settings) {
+    let energyOptions: IntegratedEnergyOptions = {
+      baseline: undefined,
+      modifications: []
+    }
+    
+    let phast: PHAST = integratedAssessment.assessment.phast;
+    let baselinePhastResults: PhastResults = this.phastResultService.getResults(phast, settings);
+    
+    let energyUsed: EnergyUseReportData = this.phastResultService.getEnergyUseReportData(phast, baselinePhastResults, settings);
+    let baselineExecutiveSummary = this.executiveSummaryService.getSummary(phast, false, settings, phast);
+    let baselineEnergies: EnergyUseItem[] = this.setEnergyUseItems(energyUsed, baselinePhastResults, baselineExecutiveSummary, settings, treasureHuntSettings);
+    energyOptions.baseline = {
+      name: phast.name,
+      annualEnergy: baselinePhastResults.grossHeatInput,
+      annualCost: baselineExecutiveSummary.annualCost,
+      co2EmissionsOutput: baselineExecutiveSummary.co2EmissionsOutput.totalEmissionOutput,
+    };
+
+    integratedAssessment.hasModifications = integratedAssessment.assessment.phast.modifications && integratedAssessment.assessment.phast.modifications.length !== 0;
+    if (integratedAssessment.hasModifications) {
+      let modificationEnergyOptions: Array<ModificationEnergyOption> = [];
+
+      phast.modifications.map(modification => {
+        let modificationPhastResults: PhastResults = this.phastResultService.getResults(modification.phast, settings);
+        let energyUsed: EnergyUseReportData = this.phastResultService.getEnergyUseReportData(modification.phast, modificationPhastResults, settings);
+        let modificationExecutiveSummary: ExecutiveSummary = this.executiveSummaryService.getSummary(modification.phast, true, settings, phast);
+        let modificationEnergyUseItems: EnergyUseItem[] = this.setEnergyUseItems(energyUsed, modificationPhastResults, modificationExecutiveSummary, settings, treasureHuntSettings);
+
+        energyOptions.modifications.push({
+          name: modification.phast.name,
+          annualEnergy: modificationPhastResults.grossHeatInput,
+          annualCost: modificationExecutiveSummary.annualCost,
+          modificationId: modification.id,
+          co2EmissionsOutput: modificationExecutiveSummary.co2EmissionsOutput.totalEmissionOutput,
+        });
+
+        modificationEnergyOptions.push(
+          {
+            modificationId: modification.id,
+            energies: modificationEnergyUseItems
+          })
+      });
+      integratedAssessment.modificationEnergyUseItems = modificationEnergyOptions;
+    }
+
+    integratedAssessment.assessmentType = 'PHAST';
+    integratedAssessment.baselineEnergyUseItems = baselineEnergies;
+    integratedAssessment.thEquipmentType = 'processHeating';
+    integratedAssessment.energyOptions = energyOptions; 
+    integratedAssessment.navigation = {
+      queryParams: undefined,
+      url: '/phast/' + integratedAssessment.assessment.id
+    }
+  }
+
+  setEnergyUseItems(energyUsed: EnergyUseReportData, phastResults: PhastResults, executiveSummary: ExecutiveSummary, settings: Settings, treasureHuntSettings: Settings) {
+    let energies: EnergyUseItem[] = [];
+    let treasureHuntUnit: string = treasureHuntSettings.unitsOfMeasure === "Imperial"? 'MMBtu' : 'GJ';
+    let assessmentUnit: string = settings.unitsOfMeasure === "Imperial"? 'MMBtu' : 'GJ';
+    let shouldConvert: boolean = settings.unitsOfMeasure !== treasureHuntSettings.unitsOfMeasure;
+    
+    if (settings.energySourceType === 'Electricity') {
+      if (energyUsed.fuelEnergyUsed) {
+        let fuelEnergyUsed: number = energyUsed.fuelEnergyUsed;
+        if (shouldConvert) {
+          fuelEnergyUsed = this.convertUnitsService.convertValue(energyUsed.fuelEnergyUsed, assessmentUnit, treasureHuntUnit);
+        }
+        let energyUseItem: EnergyUseItem = {
+          type: 'Gas',
+          amount: fuelEnergyUsed,
+          integratedEnergyCost: executiveSummary.annualNaturalGasCost,
+          integratedEmissionRate: phastResults.co2EmissionsOutput.fuelEmissionOutput
+        }
+        energies.push(energyUseItem);
+      }
+      // units in kW only
+      let electricity: EnergyUseItem = {
+        type: 'Electricity',
+        amount: phastResults.electricalHeatDelivered,
+        integratedEnergyCost: executiveSummary.annualElectricityCost,
+        integratedEmissionRate: phastResults.co2EmissionsOutput.electricityEmissionOutput
+      };
+        
+      if (settings.furnaceType === 'Electric Arc Furnace (EAF)') {
+        electricity.amount = phastResults.hourlyEAFResults.electricEnergyUsed;
+
+
+        let coalCarbonUsed: number = phastResults.hourlyEAFResults.coalCarbonUsed
+        if (shouldConvert) {
+          coalCarbonUsed = this.convertUnitsService.convertValue(coalCarbonUsed, assessmentUnit, treasureHuntUnit);
+        }
+
+        let coalCarbon: EnergyUseItem = {
+          type: 'Other Fuel',
+          amount: coalCarbonUsed,
+          integratedEnergyCost: executiveSummary.annualCarbonCoalCost,
+          integratedEmissionRate: phastResults.co2EmissionsOutput.coalCarbonEmissionsOutput
+        };
+
+        let electrodeEnergyUsed: number = phastResults.hourlyEAFResults.electrodeEnergyUsed;
+        if (shouldConvert) {
+          electrodeEnergyUsed = this.convertUnitsService.convertValue(electrodeEnergyUsed, assessmentUnit, treasureHuntUnit);
+        }
+        let electrodeEnergy: EnergyUseItem = {
+          type: 'Other Fuel',
+          amount: electrodeEnergyUsed,
+          integratedEnergyCost: executiveSummary.annualElectrodeCost,
+          integratedEmissionRate: phastResults.co2EmissionsOutput.electrodeEmissionsOutput
+        };
+        
+
+        let otherFuelUsed: number = phastResults.hourlyEAFResults.otherFuelUsed;
+        if (shouldConvert) {
+          otherFuelUsed = this.convertUnitsService.convertValue(otherFuelUsed, assessmentUnit, treasureHuntUnit);
+        }
+        let otherFuel: EnergyUseItem = {
+          type: 'Other Fuel',
+          amount: otherFuelUsed,
+          integratedEnergyCost: executiveSummary.annualOtherFuelCost,
+          integratedEmissionRate: phastResults.co2EmissionsOutput.otherFuelEmissionsOutput
+        };
+        energies.push(coalCarbon, electrodeEnergy, otherFuel);
+      } 
+      energies.push(electricity);
+
+    } else if (settings.energySourceType === 'Steam') {
+      treasureHuntUnit = treasureHuntSettings.unitsOfMeasure === "Imperial"? 'klb' : 'tonne';
+      let steamUsed: number = energyUsed.steamEnergyUsed;
+      if (shouldConvert) {
+        steamUsed = this.convertUnitsService.convertValue(steamUsed, assessmentUnit, treasureHuntUnit);
+        this.convertUnitsService.convertValue(steamUsed, assessmentUnit, treasureHuntUnit);
+      }
+      // in steam assesment energy used is === grossHeatInput ... 
+      let steam: EnergyUseItem = {
+        type: 'Steam',
+        amount: steamUsed,
+        integratedEnergyCost: executiveSummary.annualCost,
+        integratedEmissionRate: undefined
+      };
+      energies.push(steam);
+      
+    } else {
+      treasureHuntUnit = treasureHuntSettings.unitsOfMeasure === "Imperial"? 'MMBtu' : 'GJ';
+      assessmentUnit = settings.unitsOfMeasure === "Imperial"? 'MMBtu' : 'GJ';
+      let energyUseItem: EnergyUseItem = {
+        type: 'Gas',
+        amount: energyUsed.fuelEnergyUsed,
+        integratedEnergyCost: executiveSummary.annualCost,
+        integratedEmissionRate: phastResults.co2EmissionsOutput.fuelEmissionOutput,
+      };
+      energies.push(energyUseItem);
+    }
+    return energies;
+  }
+
+  
+}

--- a/src/app/phast/phast-report/energy-used/energy-used.component.html
+++ b/src/app/phast/phast-report/energy-used/energy-used.component.html
@@ -13,16 +13,16 @@
       <tbody>
         <tr>
           <td>
-            <span *ngIf="fuelName">{{fuelName}}</span>
-            <span *ngIf="!fuelName">Fuel</span>
+            <span *ngIf="energyUsed.fuelName">{{energyUsed.fuelName}}</span>
+            <span *ngIf="!energyUsed.fuelName">Fuel</span>
           </td>
           <td>
-            <span *ngIf="fuelEnergyUsed">{{fuelEnergyUsed | sigFigs:'5'}} {{baseEnergyUnit}}</span>
-            <span *ngIf="!fuelEnergyUsed">&mdash; &mdash;</span>
+            <span *ngIf="energyUsed.fuelEnergyUsed">{{energyUsed.fuelEnergyUsed | sigFigs:'5'}} {{baseEnergyUnit}}</span>
+            <span *ngIf="!energyUsed.fuelEnergyUsed">&mdash; &mdash;</span>
           </td>
           <td>
-            <span *ngIf="fuelHeatingValue">{{fuelHeatingValue | sigFigs:'5'}} {{energyPerMassUnit}}</span>
-            <span *ngIf="!fuelHeatingValue">&mdash; &mdash;</span>
+            <span *ngIf="energyUsed.fuelHeatingValue">{{energyUsed.fuelHeatingValue | sigFigs:'5'}} {{energyPerMassUnit}}</span>
+            <span *ngIf="!energyUsed.fuelHeatingValue">&mdash; &mdash;</span>
           </td>
           <td>{{phast.operatingCosts.fuelCost | currency:'USD':'symbol':'1.2-2'}} {{energyCostUnit}}</td>
         </tr>
@@ -69,20 +69,20 @@
             <td>{{phast.operatingCosts.otherFuelCost | currency:'USD':'symbol':'1.2-2'}} {{energyCostUnit}}</td>
           </tr>
         </ng-container>
-        <tr>
+        <tr *ngIf="settings.energySourceType === 'Electricity'">
           <td>Electricity</td>
           <td>
-            <span *ngIf="electricEnergyUsed">{{electricEnergyUsed | sigFigs:'5'}} kW</span>
-            <span *ngIf="!electricEnergyUsed">&mdash; &mdash;</span>
+            <span *ngIf="energyUsed.electricEnergyUsed">{{energyUsed.electricEnergyUsed | sigFigs:'5'}} kW</span>
+            <span *ngIf="!energyUsed.electricEnergyUsed">&mdash; &mdash;</span>
           </td>
-          <td>{{electricityHeatingValue | sigFigs:'5'}} {{energyPerTimeUnit}}</td>
+          <td>{{energyUsed.electricityHeatingValue | sigFigs:'5'}} {{energyPerTimeUnit}}</td>
           <td>{{phast.operatingCosts.electricityCost | currency:'USD':'symbol':'1.2-2'}} /kWh</td>
         </tr>
         <tr>
           <td>Steam</td>
           <td>
-            <span *ngIf="steamEnergyUsed">{{steamEnergyUsed | sigFigs:'5'}} {{baseEnergyUnit}}</span>
-            <span *ngIf="!steamEnergyUsed">&mdash; &mdash;</span>
+            <span *ngIf="energyUsed.steamEnergyUsed">{{energyUsed.steamEnergyUsed | sigFigs:'5'}} {{baseEnergyUnit}}</span>
+            <span *ngIf="!energyUsed.steamEnergyUsed">&mdash; &mdash;</span>
           </td>
           <td>
             <span *ngIf="steamHeatingValue">{{steamHeatingValue | sigFigs:'5'}} {{energyPerMassUnit}}</span>

--- a/src/app/phast/phast-report/energy-used/energy-used.component.ts
+++ b/src/app/phast/phast-report/energy-used/energy-used.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Settings } from '../../../shared/models/settings';
-import { PHAST, PhastResults, CalculatedByPhast } from '../../../shared/models/phast/phast';
+import { PHAST, PhastResults, CalculatedByPhast, EnergyUseReportData } from '../../../shared/models/phast/phast';
 import { MeteredEnergyResults } from '../../../shared/models/phast/meteredEnergy';
 import { DesignedEnergyResults } from '../../../shared/models/phast/designedEnergy';
 import { MeteredEnergyService } from '../../metered-energy/metered-energy.service';
@@ -8,7 +8,6 @@ import { DesignedEnergyService } from '../../designed-energy/designed-energy.ser
 import { PhastResultsService } from '../../phast-results.service';
 import * as _ from 'lodash';
 import { ConvertUnitsService } from '../../../shared/convert-units/convert-units.service';
-import { FlueGasMaterial, SolidLiquidFlueGasMaterial } from '../../../shared/models/materials';
 import { SqlDbApiService } from '../../../tools-suite-api/sql-db-api.service';
 @Component({
   selector: 'app-energy-used',
@@ -21,6 +20,7 @@ export class EnergyUsedComponent implements OnInit {
   @Input()
   settings: Settings;
 
+  energyUsed: EnergyUseReportData;
   designedResults: DesignedEnergyResults = {
     designed: {
       hourlyEnergy: 0,
@@ -76,7 +76,6 @@ export class EnergyUsedComponent implements OnInit {
   constructor(private designedEnergyService: DesignedEnergyService, 
     private meteredEnergyService: MeteredEnergyService, 
     private phastResultsService: PhastResultsService, 
-    private sqlDbApiService: SqlDbApiService,
     private convertUnitsService: ConvertUnitsService) { }
 
   ngOnInit() {
@@ -85,15 +84,11 @@ export class EnergyUsedComponent implements OnInit {
     this.electricityHeatingValue = this.convertUnitsService.value(9800).from('Btu').to(this.settings.energyResultUnit);
     this.getUnits();
 
-    if (this.settings.energySourceType === 'Steam') {
-      this.setSteamVals();
-    } else if (this.settings.energySourceType === 'Electricity') {
-      this.setElectrotechVals();
-      this.setFuelVals();
-    } else if (this.settings.energySourceType === 'Fuel') {
-      this.setFuelVals();
-    }
-
+    this.energyUsed = this.phastResultsService.getEnergyUseReportData(this.phast, this.phastResults, this.settings);
+    this.baseEnergyUnit = this.energyUsed.baseEnergyUnit;
+    this.energyPerMassUnit = this.energyUsed.energyPerMassUnit;
+      
+    this.setMeteredEnergyVals();
     if (this.phast.designedEnergy) {
       if (this.phast.designedEnergy) {
         this.designedResults = this.designedEnergyService.calculateDesignedEnergy(this.phast, this.settings);
@@ -129,79 +124,19 @@ export class EnergyUsedComponent implements OnInit {
 
   }
 
-  setElectrotechVals() {
-    this.electricEnergyUsed = this.phastResults.electricalHeatDelivered;
-    if (this.settings.furnaceType === 'Electric Arc Furnace (EAF)') {
-      this.electricEnergyUsed = this.phastResults.hourlyEAFResults.electricEnergyUsed; 
-    }
+  setMeteredEnergyVals() {
     if (this.phast.meteredEnergy) {
       if (this.phast.meteredEnergy.meteredEnergyElectricity) {
         this.meteredResults = this.meteredEnergyService.calculateMeteredEnergy(this.phast, this.settings);
       }
-    }
-  }
-
-  setSteamVals() {
-    this.steamEnergyUsed = this.phastResults.grossHeatInput;
-    if (this.phast.meteredEnergy) {
       if (this.phast.meteredEnergy.meteredEnergySteam) {
         this.meteredResults = this.meteredEnergyService.calculateMeteredEnergy(this.phast, this.settings);
         this.steamHeatingValue = this.phast.meteredEnergy.meteredEnergySteam.totalHeatSteam;
       }
-    }
-  }
-
-  setFuelVals() {
-    this.fuelEnergyUsed = this.phastResults.grossHeatInput;
-    if (this.settings.energySourceType === 'Electricity') {
-      if (this.settings.furnaceType === 'Electric Arc Furnace (EAF)') {
-        this.fuelName = 'Natural Gas';
-        this.fuelHeatingValue = this.phastResults.hourlyEAFResults.naturalGasHeatingValue; 
-        this.fuelEnergyUsed = this.phastResults.hourlyEAFResults.naturalGasUsed;
-        if (this.settings.unitsOfMeasure == 'Imperial') {
-          this.energyPerMassUnit = 'Btu/lb';
-          this.baseEnergyUnit = 'MMBtu';
-        } else {
-          this.energyPerMassUnit = 'kJ/kg';
-          this.baseEnergyUnit = 'GJ';
-        }
-      } else {
-        this.fuelEnergyUsed = this.phastResults.energyInputHeatDelivered + this.phastResults.totalExhaustGas;
-      }
-    }
-
-    if (this.phast.meteredEnergy) {
       if (this.phast.meteredEnergy.meteredEnergyFuel) {
         this.meteredResults = this.meteredEnergyService.calculateMeteredEnergy(this.phast, this.settings);
       }
     }
-
-    if (this.phast.losses.flueGasLosses) {
-      if (this.phast.losses.flueGasLosses[0].flueGasType === 'By Mass') {
-        let gas: SolidLiquidFlueGasMaterial = this.sqlDbApiService.selectSolidLiquidFlueGasMaterialById(this.phast.losses.flueGasLosses[0].flueGasByMass.gasTypeId);
-        if (gas) {
-          this.fuelHeatingValue = gas.heatingValue;
-          this.fuelName = gas.substance;
-        }
-      } else if (this.phast.losses.flueGasLosses[0].flueGasType === 'By Volume') {
-        let gas: FlueGasMaterial = this.sqlDbApiService.selectGasFlueGasMaterialById(this.phast.losses.flueGasLosses[0].flueGasByVolume.gasTypeId);
-        if (gas) {
-          this.fuelHeatingValue = gas.heatingValue;
-          this.fuelName = gas.substance;
-        }
-      }
-      this.fuelHeatingValue = this.convertResult(this.fuelHeatingValue, this.settings);
-    }
-  }
-
-
-  convertResult(val: number, settings: Settings): number {
-    if (settings.unitsOfMeasure === 'Metric') {
-      val = this.convertUnitsService.value(val).from('kJ').to(settings.energyResultUnit);
-    } else {
-      val = this.convertUnitsService.value(val).from('Btu').to(settings.energyResultUnit);
-    }
-    return val;
   }
 
 }

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -654,7 +654,7 @@
             {{baselineExecutiveSummary.annualElectricityCost | currency:'USD':'symbol':'1.0-0'}}</td>
           <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-            <span *ngIf="mod.annualElectricityCost">{{baselineExecutiveSummary.annualElectricityCost |
+            <span *ngIf="mod.annualElectricityCost">{{mod.annualElectricityCost |
               currency:'USD':'symbol':'1.0-0'}}</span>
             <span *ngIf="!mod.annualElectricityCost">&mdash; &mdash;</span>
           </td>
@@ -665,7 +665,7 @@
             {{baselineExecutiveSummary.annualNaturalGasCost | currency:'USD':'symbol':'1.0-0'}}</td>
           <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-            <span *ngIf="mod.annualNaturalGasCost">{{baselineExecutiveSummary.annualNaturalGasCost |
+            <span *ngIf="mod.annualNaturalGasCost">{{mod.annualNaturalGasCost |
               currency:'USD':'symbol':'1.0-0'}}</span>
             <span *ngIf="!mod.annualNaturalGasCost">&mdash; &mdash;</span>
           </td>
@@ -677,7 +677,7 @@
             {{baselineExecutiveSummary.annualTotalFuelCost | currency:'USD':'symbol':'1.0-0'}}</td>
           <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-            <span *ngIf="mod.annualTotalFuelCost">{{baselineExecutiveSummary.annualTotalFuelCost |
+            <span *ngIf="mod.annualTotalFuelCost">{{mod.annualTotalFuelCost |
               currency:'USD':'symbol':'1.0-0'}}</span>
             <span *ngIf="!mod.annualTotalFuelCost">&mdash; &mdash;</span>
           </td>
@@ -701,7 +701,7 @@
               {{baselineExecutiveSummary.annualElectrodeCost | currency:'USD':'symbol':'1.0-0'}}</td>
             <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.annualElectrodeCost">{{baselineExecutiveSummary.annualElectrodeCost |
+              <span *ngIf="mod.annualElectrodeCost">{{mod.annualElectrodeCost |
                 currency:'USD':'symbol':'1.0-0'}}</span>
               <span *ngIf="!mod.annualElectrodeCost">&mdash; &mdash;</span>
             </td>
@@ -712,7 +712,7 @@
               {{baselineExecutiveSummary.annualOtherFuelCost | currency:'USD':'symbol':'1.0-0'}}</td>
             <td *ngFor="let mod of modExecutiveSummaries; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.annualOtherFuelCost">{{baselineExecutiveSummary.annualOtherFuelCost |
+              <span *ngIf="mod.annualOtherFuelCost">{{mod.annualOtherFuelCost |
                 currency:'USD':'symbol':'1.0-0'}}</span>
               <span *ngIf="!mod.annualOtherFuelCost">&mdash; &mdash;</span>
             </td>

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { PHAST, PhastResults, ShowResultsCategories, CalculatedByPhast, EAFResults } from '../shared/models/phast/phast';
+import { PHAST, PhastResults, ShowResultsCategories, CalculatedByPhast, EAFResults, EnergyUseReportData } from '../shared/models/phast/phast';
 import { PhastService } from './phast.service';
 import { Settings } from '../shared/models/settings';
 import { AuxEquipmentService } from './aux-equipment/aux-equipment.service';
@@ -10,9 +10,9 @@ import { FlueGasFormService } from '../calculator/furnaces/flue-gas/flue-gas-for
 import { Co2SavingsPhastService } from './losses/operations/co2-savings-phast/co2-savings-phast.service';
 import { EnergyInputEAF } from '../shared/models/phast/losses/energyInputEAF';
 import { FlueGasByVolumeSuiteResults, MaterialInputProperties } from '../shared/models/phast/losses/flueGas';
-import { SolidLiquidFlueGasMaterial } from '../shared/models/materials';
-import { EnInputResultsObj } from './losses/energy-input/energy-input.component';
 import { SqlDbApiService } from '../tools-suite-api/sql-db-api.service';
+import { FlueGasMaterial, SolidLiquidFlueGasMaterial } from '../shared/models/materials';
+
 
 
 @Injectable()
@@ -254,6 +254,69 @@ export class PhastResultsService {
 
     return results;
   }
+
+  
+  getEnergyUseReportData(phast: PHAST, phastResults: PhastResults, settings: Settings): EnergyUseReportData {
+    let energyUseReportData: EnergyUseReportData = {
+      fuelName: undefined,
+      fuelEnergyUsed: undefined,
+      fuelHeatingValue: undefined,
+      energyPerMassUnit: undefined,
+      electricEnergyUsed: undefined,
+      baseEnergyUnit: undefined,
+      steamEnergyUsed: undefined
+    };
+
+    if (settings.energySourceType === 'Electricity') {
+      energyUseReportData.electricEnergyUsed = phastResults.electricalHeatDelivered;
+      if (settings.furnaceType === 'Electric Arc Furnace (EAF)') {
+        energyUseReportData.fuelName = 'Natural Gas';
+        energyUseReportData.electricEnergyUsed = phastResults.hourlyEAFResults.electricEnergyUsed;
+        energyUseReportData.fuelHeatingValue = phastResults.hourlyEAFResults.naturalGasHeatingValue;
+        energyUseReportData.fuelEnergyUsed = phastResults.hourlyEAFResults.naturalGasUsed;
+        if (settings.unitsOfMeasure == 'Imperial') {
+          energyUseReportData.energyPerMassUnit = 'Btu/lb';
+          energyUseReportData.baseEnergyUnit = 'MMBtu';
+        } else {
+          energyUseReportData.energyPerMassUnit = 'kJ/kg';
+          energyUseReportData.baseEnergyUnit = 'GJ';
+        }
+      } else {
+        energyUseReportData.fuelEnergyUsed = phastResults.energyInputHeatDelivered + phastResults.totalExhaustGas;
+      }
+    } else if (settings.energySourceType === 'Steam') {
+      energyUseReportData.steamEnergyUsed = phastResults.grossHeatInput;
+    } else { 
+      energyUseReportData.fuelEnergyUsed = phastResults.grossHeatInput;
+    }
+
+    if (phast.losses.flueGasLosses) {
+      if (phast.losses.flueGasLosses[0].flueGasType === 'By Mass') {
+        let gas: SolidLiquidFlueGasMaterial = this.sqlDbApiService.selectSolidLiquidFlueGasMaterialById(phast.losses.flueGasLosses[0].flueGasByMass.gasTypeId);
+        if (gas) {
+          energyUseReportData.fuelHeatingValue = gas.heatingValue;
+          energyUseReportData.fuelName = gas.substance;
+        }
+      } else if (phast.losses.flueGasLosses[0].flueGasType === 'By Volume') {
+        let gas: FlueGasMaterial = this.sqlDbApiService.selectGasFlueGasMaterialById(phast.losses.flueGasLosses[0].flueGasByVolume.gasTypeId);
+        if (gas) {
+          energyUseReportData.fuelHeatingValue = gas.heatingValue;
+          energyUseReportData.fuelName = gas.substance;
+        }
+      }
+
+      if (settings.unitsOfMeasure === 'Metric') {
+        energyUseReportData.fuelHeatingValue = this.convertUnitsService.value(energyUseReportData.fuelHeatingValue).from('kJ').to(settings.energyResultUnit);
+      } else {
+        energyUseReportData.fuelHeatingValue = this.convertUnitsService.value(energyUseReportData.fuelHeatingValue).from('Btu').to(settings.energyResultUnit);
+      }
+    }
+
+    return energyUseReportData;
+  }  
+
+
+
   setEAFResults(phast: PHAST, phastResults: PhastResults, settings: Settings): PhastResults {
     let EAFInputs: EnergyInputEAF = JSON.parse(JSON.stringify(phast.losses.energyInputEAF[0]));
     let naturalGasHeatingValue: number = 22030.7;

--- a/src/app/phast/phast.module.ts
+++ b/src/app/phast/phast.module.ts
@@ -91,7 +91,7 @@ import { ImportExportModule } from '../shared/import-export/import-export.module
     PhastValidService,
     PhastResultsService,
     ConvertPhastService,
-    PhastCompareService
+    PhastCompareService,
   ]
 })
 

--- a/src/app/psat/add-modification/add-modification.component.ts
+++ b/src/app/psat/add-modification/add-modification.component.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs';
 import { PsatTabService } from '../psat-tab.service';
 import { PsatService } from '../psat.service';
 import { Settings } from '../../shared/models/settings';
+import { HelperFunctionsService } from '../../shared/helper-services/helper-functions.service';
 
 @Component({
   selector: 'app-add-modification',
@@ -28,7 +29,7 @@ export class AddModificationComponent implements OnInit {
   newModificationName: string;
   currentTab: string;
   tabSubscription: Subscription;
-  constructor(private psatTabService: PsatTabService, private psatService: PsatService) { }
+  constructor(private psatTabService: PsatTabService, private helperFunctions: HelperFunctionsService, private psatService: PsatService) { }
 
   ngOnInit() {
     if (this.modifications) {
@@ -51,6 +52,7 @@ export class AddModificationComponent implements OnInit {
       psat: {
         name: this.newModificationName,
       },
+      id: this.helperFunctions.getNewIdString(),
       notes: {
         fieldDataNotes: '',
         motorNotes: '',

--- a/src/app/psat/modification-list/modification-list.component.ts
+++ b/src/app/psat/modification-list/modification-list.component.ts
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 import { Modification } from '../../shared/models/psat';
 import { PsatTabService } from '../psat-tab.service';
 import { Settings } from '../../shared/models/settings';
-import { FormControl, FormGroup } from '@angular/forms';
+import { HelperFunctionsService } from '../../shared/helper-services/helper-functions.service';
 
 @Component({
   selector: 'app-modification-list',
@@ -33,7 +33,8 @@ export class ModificationListComponent implements OnInit {
   asssessmentTab: string;
   assessmentTabSubscription: Subscription;
   
-  constructor(private compareService: CompareService, private psatService: PsatService, private psatTabService: PsatTabService) { }
+  constructor(private compareService: CompareService, private helperFunctions: HelperFunctionsService, 
+    private psatService: PsatService, private psatTabService: PsatTabService) { }
 
   ngOnInit() {
     this.initDropdown();
@@ -147,6 +148,7 @@ export class ModificationListComponent implements OnInit {
       psat: {
         name: this.newModificationName,
       },
+      id: this.helperFunctions.getNewIdString(),
       notes: {
         fieldDataNotes: '',
         motorNotes: '',

--- a/src/app/psat/modify-conditions/modify-conditions.component.ts
+++ b/src/app/psat/modify-conditions/modify-conditions.component.ts
@@ -47,7 +47,6 @@ export class ModifyConditionsComponent implements OnInit {
     if (tmpTab) {
       this.psatTabService.modifyConditionsTab.next(tmpTab);
     }
-
     this.modifyConditionsSub = this.psatTabService.modifyConditionsTab.subscribe(val => {
       this.modifyTab = val;
     })

--- a/src/app/psat/psat.component.ts
+++ b/src/app/psat/psat.component.ts
@@ -143,7 +143,7 @@ export class PsatComponent implements OnInit {
         this.initSankeyList();
       }
     })
-    let tmpTab = this.assessmentService.getTab();
+    let tmpTab = this.assessmentService.getStartingTab();
     if (tmpTab) {
       this.psatTabService.mainTab.next(tmpTab);
     }
@@ -429,6 +429,7 @@ export class PsatComponent implements OnInit {
       psat: {
         name: modName,
       },
+      id: this.helperFunctionService.getNewIdString(),
       notes: {
         fieldDataNotes: '',
         motorNotes: '',

--- a/src/app/psat/psat.service.ts
+++ b/src/app/psat/psat.service.ts
@@ -13,6 +13,8 @@ import { PSAT } from '../shared/models/psat';
 import { MotorPerformanceResults } from '../calculator/motors/motor-performance/motor-performance.service';
 import { AssessmentCo2SavingsService } from '../shared/assessment-co2-savings/assessment-co2-savings.service';
 import { PumpsSuiteApiService } from '../tools-suite-api/pumps-suite-api.service';
+import { IntegratedAssessment, IntegratedEnergyOptions, ModificationEnergyOption } from '../shared/assessment-integration/assessment-integration.service';
+import { EnergyUseItem } from '../shared/models/treasure-hunt';
 
 @Injectable()
 export class PsatService {
@@ -106,6 +108,73 @@ export class PsatService {
       return this.emptyResults();
     }
   }
+
+  setIntegratedAssessmentData(integratedAssessment: IntegratedAssessment, settings: Settings) {
+    let energyOptions: IntegratedEnergyOptions = {
+      baseline: undefined,
+      modifications: []
+    }
+
+    let psat: PSAT = integratedAssessment.assessment.psat;
+    let baselineOutputs: PsatOutputs = this.resultsExisting(psat.inputs, settings);
+    baselineOutputs.annual_energy = this.convertUnitsService.value(baselineOutputs.annual_energy).from('MWh').to('kWh');
+    baselineOutputs.annual_energy = this.convertUnitsService.roundVal(baselineOutputs.annual_energy, 0)
+    
+    energyOptions.baseline = {
+      name: psat.name,
+      annualEnergy: baselineOutputs.annual_energy,
+      annualCost: baselineOutputs.annual_cost,
+      co2EmissionsOutput: baselineOutputs.co2EmissionsOutput,
+    };
+
+    let baselineEnergy: EnergyUseItem = {
+      type: 'Electricity',
+      amount: baselineOutputs.annual_energy,
+      integratedEnergyCost: baselineOutputs.annual_cost,
+      integratedEmissionRate: baselineOutputs.co2EmissionsOutput
+    };
+
+    integratedAssessment.hasModifications = integratedAssessment.assessment.psat.modifications && integratedAssessment.assessment.psat.modifications.length !== 0;
+    if (integratedAssessment.hasModifications) {
+      let modificationEnergyOptions: Array<ModificationEnergyOption> = [];
+      psat.modifications.forEach(modification => {
+        let modificationOutputs = this.resultsModified(modification.psat.inputs, settings);
+        modificationOutputs.annual_energy = this.convertUnitsService.value(modificationOutputs.annual_energy).from('MWh').to('kWh');
+        modificationOutputs.annual_energy = this.convertUnitsService.roundVal(modificationOutputs.annual_energy, 0);
+        
+        energyOptions.modifications.push({
+          name: modification.psat.name,
+          annualEnergy: modificationOutputs.annual_energy,
+          annualCost: modificationOutputs.annual_cost,
+          modificationId: modification.id,
+          co2EmissionsOutput: modificationOutputs.co2EmissionsOutput
+        });
+
+        let modificationEnergy: EnergyUseItem = {
+          type: 'Electricity',
+          amount: modificationOutputs.annual_energy,
+          integratedEnergyCost: modificationOutputs.annual_cost,
+          integratedEmissionRate: modificationOutputs.co2EmissionsOutput
+        }
+        modificationEnergyOptions.push(
+          {
+            modificationId: modification.id,
+            energies: [modificationEnergy]
+          })
+        });
+        integratedAssessment.modificationEnergyUseItems = modificationEnergyOptions;
+    }
+
+    integratedAssessment.assessmentType = 'PSAT';
+    integratedAssessment.baselineEnergyUseItems = [baselineEnergy];
+    integratedAssessment.energyOptions = energyOptions; 
+    integratedAssessment.thEquipmentType = 'pump';
+    integratedAssessment.navigation = {
+      queryParams: undefined,
+      url: '/psat/' + integratedAssessment.assessment.id
+    }
+  }
+  
 
   setCo2SavingsEmissionsResult(psatInputs: PsatInputs, psatOutputs: PsatOutputs, settings: Settings): PsatOutputs {
     if (psatInputs.co2SavingsData) {

--- a/src/app/report-rollup/treasure-hunt-report-rollup.service.ts
+++ b/src/app/report-rollup/treasure-hunt-report-rollup.service.ts
@@ -30,7 +30,7 @@ export class TreasureHuntReportRollupService {
     thuntItems.forEach(item => {
       if (item.assessment.treasureHunt) {
         let opportunitySummaries: Array<OpportunitySummary> = this.opportunitySummaryService.getOpportunitySummaries(item.assessment.treasureHunt, item.settings)
-        let thuntResults: TreasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, item.assessment.treasureHunt.currentEnergyUsage, item.settings);
+        let thuntResults: TreasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, item.assessment.treasureHunt, item.settings);
         let opportunityCardsData: Array<OpportunityCardData> = this.opportunityCardsService.getOpportunityCardsData(item.assessment.treasureHunt, item.settings);
         let opportunitiesPaybackDetails: OpportunitiesPaybackDetails = this.opportunityPaybackService.getOpportunityPaybackDetails(thuntResults.opportunitySummaries, settings);
         tmpResultsArr.push(

--- a/src/app/shared/assessment-integration/assessment-integration.component.css
+++ b/src/app/shared/assessment-integration/assessment-integration.component.css
@@ -1,0 +1,51 @@
+
+.table {
+    font-size: small;
+}
+ .table th {
+    border: none;
+    padding: 0px 10px;
+}
+.table td {
+    padding: 2px 8px;
+    vertical-align: middle;
+}
+
+tr > td:not(:first-child),
+tr > th:not(:first-child){
+    text-align: center;
+}
+
+
+.graph-col{
+    padding-left: 0px;
+}
+
+.selected-modification{
+    z-index: 2;
+    background: #e5efe9;
+}
+
+.row-stripe{
+    border-bottom: solid;
+}
+
+
+div.integration-container {
+    overflow-x: auto;
+}
+
+
+
+.modal-dialog{
+    max-width: 100vw;
+    margin: 10px;
+    top: 0px;
+}
+
+.modal-body{
+    height: 75vh;
+    overflow: auto;
+    padding: 0px;
+  }
+  

--- a/src/app/shared/assessment-integration/assessment-integration.component.html
+++ b/src/app/shared/assessment-integration/assessment-integration.component.html
@@ -1,0 +1,241 @@
+<div class="integration-container p-3">
+    <div *ngIf="hasUpdatedEnergyData" class="d-flex flex-row alert alert-info p-2">
+        <label class="w-50">
+            <span class="integration-label border-0 pr-3">
+                Updated energy use data can be retrieved from changes made to the integrated assessment.
+            </span>
+        </label>
+        <div class="w-50 input-group justify-content-center m-1 mt-2 mb-0">
+            <div>
+                <button class="btn btn-primary p-2" (click)="updateExistingIntegrationData()">
+                    Update Energy Use Data
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <form [formGroup]="assessmentIntegrationForm" (click)="focusField('')">
+        <div class="form-group">
+            <label>Assessment Type</label>
+            <select class="form-control type-select" name="assessmentType" id="assessmentType"
+                formControlName="assessmentType" (change)="setAssessmentOptions()">
+                <option [ngValue]="'PSAT'">Pump</option>
+                <option [ngValue]="'PHAST'">Process Heating</option>
+                <option [ngValue]="'FSAT'">Fan</option>
+                <!-- <option [ngValue]="'SSMT'">Steam</option>
+                <option [ngValue]="'WasteWater'">Wastewater</option>
+                <option [ngValue]="'CompressedAir'">Compressed Air</option> -->
+            </select>
+        </div>
+
+        <div *ngIf="!existingIntegrationData" class="form-group">
+            <label for="integratedAssessment">Select Assessment</label>
+            <select formControlName="integratedAssessment" class="form-control" id="integratedAssessment"
+                (change)="setNewIntegratedAssessment()">
+                <option selected [ngValue]="null">Select Assessment</option>
+                <option *ngFor="let assessment of assessmentOptions" [ngValue]="assessment.id">
+                    {{assessment.display}}</option>
+            </select>
+        </div>
+
+
+        <div *ngIf="existingIntegrationData && integratedAssessment" class="d-flex flex-row">
+            <ng-container *ngIf="integratedAssessment.assessment">
+                <label class="w-50">
+                    <span>Selected Assessment</span>
+                </label>
+                <div class="w-50 input-group justify-content-between">
+                    <div>
+                        <a class="click-link connected-inventory p-1 small" (click)="goToAssessment()">
+                            <span>{{integratedAssessment.assessment.name}}</span>
+                        </a>
+                    </div>
+                </div>
+            </ng-container>
+            <ng-container *ngIf="!integratedAssessment.assessment">
+                <div class="w-100 alert alert-warning text-center p-2 small">
+                    {{integratedAssessment.name}} no longer exists
+                </div>
+            </ng-container>
+        </div>
+
+
+        <ng-container *ngIf="!existingIntegrationData && integratedAssessment && integratedAssessment.assessment">
+            <hr>
+            <ng-container *ngIf="integratedAssessment.energyOptions.modifications">
+                <div class="d-flex flex-row mb-3">
+                    <label *ngIf="integratedAssessment.hasModifications" class="w-50">
+                        <span>Select a Modification to use for the opportunity:</span>
+                    </label>
+                    <div class="w-50 text-right">
+                        <a class="click-link small" (click)="showReportModal()">
+                            View Assessment Report
+                        </a>
+                    </div>
+                </div>
+
+                <div class="integration-container pt-2 m-0 pb-0">
+                    <table class="table table-hover table-striped">
+                        <thead>
+                            <tr>
+                                <th
+                                    [ngStyle]="{'width.%': 100 / (integratedAssessment.energyOptions.modifications.length+2)}">
+                                </th>
+                                <th
+                                    [ngStyle]="{'width.%': 100 / (integratedAssessment.energyOptions.modifications.length+2)}">
+                                    Baseline</th>
+                                <th [ngStyle]="{'width.%': 100 /(integratedAssessment.energyOptions.modifications.length+2)}"
+                                    *ngFor="let modification of integratedAssessment.energyOptions.modifications;"
+                                    [ngClass]="{'selected-modification': modification.modificationId === integratedAssessment.selectedModificationId}">
+                                    {{modification.name}}
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="bold">Use for Opportunity</td>
+                                <td></td>
+                                <td *ngFor="let modification of integratedAssessment.energyOptions.modifications; let i = index;"
+                                    [ngClass]="{'selected-modification': modification.modificationId === integratedAssessment.selectedModificationId}">
+                                    <input name="selectedModificationId" type="radio"
+                                        (change)="setSelectedModification()" value="{{modification.modificationId}}"
+                                        formControlName="selectedModificationId">
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="bold">Annual Energy (MWh)</td>
+                                <td>
+                                    {{integratedAssessment.energyOptions.baseline.annualEnergy | number:'2.0-0'}}</td>
+                                <td *ngFor="let modification of integratedAssessment.energyOptions.modifications;"
+                                    [ngClass]="{'selected-modification': modification.modificationId == integratedAssessment.selectedModificationId}">
+                                    <span *ngIf="modification.annualEnergy">{{modification.annualEnergy |
+                                        number:'2.0-0'}}</span>
+                                    <span *ngIf="!modification.annualEnergy">&mdash;</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="bold">Annual CO2 Emissions (tonne CO<sub>2</sub>)</td>
+                                <td>
+                                    {{integratedAssessment.energyOptions.baseline.co2EmissionsOutput | number:'1.1-1'}}
+                                </td>
+                                <td *ngFor="let modification of integratedAssessment.energyOptions.modifications;"
+                                    [ngClass]="{'selected-modification': modification.modificationId == integratedAssessment.selectedModificationId}">
+                                    <span *ngIf="modification.co2EmissionsOutput">{{modification.co2EmissionsOutput |
+                                        number:'1.1-1'}}</span>
+                                    <span *ngIf="!modification.co2EmissionsOutput">&mdash;</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="bold">Annual Cost ({{settings.currency}})</td>
+                                <td>
+                                    {{integratedAssessment.energyOptions.baseline.annualCost | number: '2.0-0'}}</td>
+                                <td *ngFor="let modification of integratedAssessment.energyOptions.modifications;"
+                                    [ngClass]="{'selected-modification': modification.modificationId == integratedAssessment.selectedModificationId}">
+                                    <span *ngIf="modification.annualCost">{{modification.annualCost | number:
+                                        '2.0-0'}}</span>
+                                    <span *ngIf="!modification.annualCost">&mdash;</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </ng-container>
+
+        </ng-container>
+
+        <ng-container *ngIf="existingIntegrationData">
+            <div class="integration-container pt-2 mb-0 pb-0">
+                <table class="table table-hover table-striped">
+                    <thead>
+                        <tr>
+                            <th
+                                [ngStyle]="{'width.%': 100 / (existingIntegrationData.energyOptions.modifications.length+2)}">
+                            </th>
+                            <th
+                                [ngStyle]="{'width.%': 100 / (existingIntegrationData.energyOptions.modifications.length+2)}">
+                                Baseline</th>
+                            <th [ngStyle]="{'width.%': 100 /(existingIntegrationData.energyOptions.modifications.length+2)}"
+                                *ngFor="let modification of existingIntegrationData.energyOptions.modifications;">
+                                {{modification.name}}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="bold">Annual Energy (MWh)</td>
+                            <td>
+                                {{existingIntegrationData.energyOptions.baseline.annualEnergy | number:'2.0-0'}}</td>
+                            <td *ngFor="let modification of existingIntegrationData.energyOptions.modifications;">
+                                <span *ngIf="modification.annualEnergy">{{modification.annualEnergy |
+                                    number:'2.0-0'}}</span>
+                                <span *ngIf="!modification.annualEnergy">&mdash;</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="bold">Annual CO2 Emissions (tonne CO<sub>2</sub>)</td>
+                            <td>
+                                {{existingIntegrationData.energyOptions.baseline.co2EmissionsOutput | number:'1.1-1'}}
+                            </td>
+                            <td *ngFor="let modification of existingIntegrationData.energyOptions.modifications;">
+                                <span *ngIf="modification.co2EmissionsOutput">{{modification.co2EmissionsOutput |
+                                    number:'1.1-1'}}</span>
+                                <span *ngIf="!modification.co2EmissionsOutput">&mdash;</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="bold">Annual Cost ({{settings.currency}})</td>
+                            <td>
+                                {{existingIntegrationData.energyOptions.baseline.annualCost | number: '2.0-0'}}</td>
+                            <td *ngFor="let modification of existingIntegrationData.energyOptions.modifications;">
+                                <span *ngIf="modification.annualCost">{{modification.annualCost | number:
+                                    '2.0-0'}}</span>
+                                <span *ngIf="!modification.annualCost">&mdash;</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </ng-container>
+    </form>
+</div>
+
+
+
+
+
+
+<div bsModal #reportModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="reportModalLabel"
+    aria-hidden="true" [config]="{backdrop: 'static'}">
+    <div class="modal-dialog modal-lg">
+        <div #modalDialog class="modal-content">
+            <div class="modal-header p-2">
+                <button class="close pull-right" (click)="hideReportModal()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body scroll-item" *ngIf="showReport">
+                <!-- <div class="modal-body scroll-item" *ngIf="showReport" [ngStyle]="{'width.px': modalDialogWidth}"> -->
+                <app-phast-report *ngIf="integratedAssessment.assessmentType === 'PHAST'"
+                    [assessment]="integratedAssessment.assessment" [settings]="settings"
+                    [phast]="integratedAssessment.assessment.phast" [inRollup]="false" [inPhast]="true"
+                    [quickReport]="true"></app-phast-report>
+
+                <app-psat-report *ngIf="integratedAssessment.assessmentType === 'PSAT'"
+                    [assessment]="integratedAssessment.assessment" [settings]="settings" [inRollup]="false"
+                    [inPsat]="true" [quickReport]="true"></app-psat-report>
+
+                <app-fsat-report *ngIf="integratedAssessment.assessmentType === 'FSAT'"
+                    [assessment]="integratedAssessment.assessment" [settings]="settings" [inRollup]="false"
+                    [inFsat]="true" [quickReport]="true"></app-fsat-report>
+
+                <!-- <app-compressed-air-report *ngIf="integratedAssessment.assessmentType === 'CompressedAir'" [assessment]="assessment" [inAssessment]="false" [inRollup]="false"
+                    [quickReport]="true"></app-compressed-air-report>
+
+                <app-waste-water-report *ngIf="integratedAssessment.assessmentType === 'WasteWater'" [assessment]="assessment" [quickReport]="true"></app-waste-water-report>
+
+                <app-ssmt-report *ngIf="integratedAssessment.assessmentType === 'SSMT'" [assessment]="assessment" [settings]="settings"></app-ssmt-report> -->
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/shared/assessment-integration/assessment-integration.component.spec.ts
+++ b/src/app/shared/assessment-integration/assessment-integration.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AssessmentIntegrationComponent } from './assessment-integration.component';
+
+describe('AssessmentIntegrationComponent', () => {
+  let component: AssessmentIntegrationComponent;
+  let fixture: ComponentFixture<AssessmentIntegrationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AssessmentIntegrationComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AssessmentIntegrationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/assessment-integration/assessment-integration.component.ts
+++ b/src/app/shared/assessment-integration/assessment-integration.component.ts
@@ -1,0 +1,116 @@
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { AssessmentIntegrationService, ExistingIntegrationData, IntegratedAssessment } from './assessment-integration.service';
+import { FormControl, FormGroup } from '@angular/forms';
+import { AssessmentOption, AssessmentType } from '../connected-inventory/integrations';
+import { Assessment } from '../models/assessment';
+import * as _ from 'lodash';
+import { Settings } from '../models/settings';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TreasureHuntService } from '../../treasure-hunt/treasure-hunt.service';
+
+@Component({
+  selector: 'app-assessment-integration',
+  templateUrl: './assessment-integration.component.html',
+  styleUrls: ['./assessment-integration.component.css']
+})
+export class AssessmentIntegrationComponent implements OnInit {
+  @Input()
+  existingIntegrationData: ExistingIntegrationData;
+  @Input()
+  settings: Settings;
+  @Output('integratedAssessmentSelected')
+  integratedAssessmentSelected = new EventEmitter<IntegratedAssessment>();
+  assessmentIntegrationForm: FormGroup;
+  assessmentOptions: AssessmentOption[];
+  assessments: Assessment[];
+  integratedAssessment: IntegratedAssessment;
+  hasUpdatedEnergyData: boolean;
+
+  @ViewChild('reportModal', { static: false }) public reportModal: ModalDirective;
+  @ViewChild('modalDialog', { static: false }) public modalDialog: ElementRef;
+  showReport: boolean;
+
+
+  constructor(private assessmentIntegrationService: AssessmentIntegrationService, private treasureHuntService: TreasureHuntService) { }
+
+  async ngOnInit() {
+    let defaultAssessmentType: AssessmentType = 'PSAT';
+    this.assessmentIntegrationForm = new FormGroup({
+      assessmentType: new FormControl<string>(defaultAssessmentType),
+      integratedAssessment: new FormControl<any>({ value: null, disabled: false }),
+      selectedModificationId: new FormControl<string>({ value: null, disabled: false }),
+    });
+    if (this.existingIntegrationData) {
+      await this.setExistingIntegratedAssessment();
+    } else {
+      await this.setAssessmentOptions();
+    }
+  }  
+  
+  async setAssessmentOptions() {
+    this.assessmentOptions = await this.assessmentIntegrationService.getAssessmentOptionsByType(this.assessmentIntegrationForm.controls.assessmentType.value);
+  }
+  
+  async setExistingIntegratedAssessment() {
+    this.integratedAssessment = await this.assessmentIntegrationService.setIntegratedAssessment(this.existingIntegrationData.assessmentId, this.existingIntegrationData.assessmentType, this.settings);
+    this.integratedAssessment.selectedModificationId = this.existingIntegrationData.selectedModificationId;
+    this.assessmentIntegrationForm.controls.assessmentType.patchValue(this.existingIntegrationData.assessmentType);
+    this.assessmentIntegrationForm.controls.assessmentType.disable();
+
+    if (!this.integratedAssessment.assessment) {
+      this.integratedAssessment.name = this.existingIntegrationData.assessmentName
+    } else {
+      this.hasUpdatedEnergyData = this.assessmentIntegrationService.checkHasUpdatedEnergyData(this.existingIntegrationData.energyOptions, this.integratedAssessment.energyOptions);
+    }
+  }
+
+  async updateExistingIntegrationData() {
+    this.existingIntegrationData.energyOptions.baseline = this.integratedAssessment.energyOptions.baseline;
+    if (this.integratedAssessment.hasModifications) {
+      this.integratedAssessment.energyOptions.modifications.forEach((modification) => {
+        if (modification.modificationId === this.existingIntegrationData.energyOptions.modifications[0].modificationId) {
+          this.existingIntegrationData.energyOptions.modifications[0].annualEnergy = modification.annualEnergy;
+          this.existingIntegrationData.energyOptions.modifications[0].co2EmissionsOutput = modification.co2EmissionsOutput;
+          this.existingIntegrationData.energyOptions.modifications[0].annualCost = modification.annualCost;
+          this.existingIntegrationData.energyOptions.modifications[0].name = modification.name;
+        }
+      });
+    }
+    this.hasUpdatedEnergyData = false;
+    this.integratedAssessmentSelected.emit(this.integratedAssessment);
+  }
+
+  async setNewIntegratedAssessment() {
+    this.integratedAssessment = await this.assessmentIntegrationService.setIntegratedAssessment(this.assessmentIntegrationForm.controls.integratedAssessment.value, this.assessmentIntegrationForm.controls.assessmentType.value, this.settings);
+    if (this.integratedAssessment.hasModifications) {
+      let defaultSelectedId: string = this.integratedAssessment.energyOptions.modifications[0].modificationId;
+      this.assessmentIntegrationForm.controls.selectedModificationId.patchValue(defaultSelectedId);
+      this.integratedAssessment.selectedModificationId = defaultSelectedId;
+    }
+    this.integratedAssessmentSelected.emit(this.integratedAssessment);
+  }
+
+  setSelectedModification() {
+    this.integratedAssessment.selectedModificationId = this.assessmentIntegrationForm.controls.selectedModificationId.value;
+    this.integratedAssessmentSelected.emit(this.integratedAssessment);
+  }
+  
+  goToAssessment() {
+    this.assessmentIntegrationService.navigateToIntegratedAssessment(this.integratedAssessment);
+  }
+
+  focusField(focusedField: string) {}
+
+  showReportModal() {
+    this.showReport = true;
+    this.reportModal.show();
+    this.treasureHuntService.modalOpen.next(true);
+  }
+  
+  hideReportModal() {
+    this.reportModal.hide();
+    this.treasureHuntService.modalOpen.next(false)
+    this.showReport = false;
+  }
+
+}

--- a/src/app/shared/assessment-integration/assessment-integration.module.ts
+++ b/src/app/shared/assessment-integration/assessment-integration.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AssessmentIntegrationComponent } from './assessment-integration.component';
+import { AssessmentIntegrationService } from './assessment-integration.service';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { PhastReportModule } from '../../phast/phast-report/phast-report.module';
+import { PsatModule } from '../../psat/psat.module';
+import { FsatReportModule } from '../../fsat/fsat-report/fsat-report.module';
+
+
+
+@NgModule({
+  declarations: [
+    AssessmentIntegrationComponent
+  ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    ModalModule,
+    PhastReportModule,
+    PsatModule,
+    FsatReportModule
+  ],
+  providers: [
+    AssessmentIntegrationService
+  ],
+  exports: [
+    AssessmentIntegrationComponent
+  ]
+})
+export class AssessmentIntegrationModule { }

--- a/src/app/shared/assessment-integration/assessment-integration.service.spec.ts
+++ b/src/app/shared/assessment-integration/assessment-integration.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AssessmentIntegrationService } from './assessment-integration.service';
+
+describe('AssessmentIntegrationService', () => {
+  let service: AssessmentIntegrationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AssessmentIntegrationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/assessment-integration/assessment-integration.service.ts
+++ b/src/app/shared/assessment-integration/assessment-integration.service.ts
@@ -1,0 +1,154 @@
+import { Injectable } from '@angular/core';
+import { Assessment } from '../models/assessment';
+import { EnergyUseItem } from '../models/treasure-hunt';
+import { AssessmentDbService } from '../../indexedDb/assessment-db.service';
+import * as _ from 'lodash';
+import { AssessmentOption, AssessmentType } from '../connected-inventory/integrations';
+import { PsatService } from '../../psat/psat.service';
+import { Settings } from '../models/settings';
+import { firstValueFrom } from 'rxjs';
+import { Router } from '@angular/router';
+import { SettingsDbService } from '../../indexedDb/settings-db.service';
+import { FsatService } from '../../fsat/fsat.service';
+import { PhastIntegrationService } from '../../phast/phast-integration.service';
+import { AssessmentService } from '../../dashboard/assessment.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AssessmentIntegrationService {
+  assessmentsByType: Assessment[];
+  constructor(private assessmentDbService: AssessmentDbService,
+    private assessmentService: AssessmentService,
+    private router: Router, 
+    private settingsDbService: SettingsDbService,
+    private psatService: PsatService,
+    private fsatService: FsatService,
+    private phastIntegrationService: PhastIntegrationService,
+    ) { }
+
+  async getExistingIntegratedAssessment(existingIntegrationData: ExistingIntegrationData) {
+    let allAssessments: Array<Assessment> = await firstValueFrom(this.assessmentDbService.getAllAssessments());
+    this.assessmentDbService.setAll(allAssessments);
+    this.assessmentsByType = allAssessments.filter(assessment => { return assessment.type == existingIntegrationData.assessmentType });
+    let assessment = this.assessmentsByType.find(assessment => {assessment.id === existingIntegrationData.assessmentId});
+    return assessment;
+  }
+
+  async setIntegratedAssessment(integratedAssessmentId: number, assessmentType: AssessmentType, treasureHuntSettings: Settings): Promise<IntegratedAssessment> {
+    let allAssessments: Array<Assessment> = await firstValueFrom(this.assessmentDbService.getAllAssessments());
+    this.assessmentDbService.setAll(allAssessments);
+    let assessment: Assessment = allAssessments.find(assessment => assessment.id === integratedAssessmentId);
+    let integratedAssessment: IntegratedAssessment = {
+      assessment: undefined,
+      name: undefined,
+      assessmentType: assessmentType,
+      selectedModificationId: undefined,
+    }
+
+    if (assessment) {
+      integratedAssessment.assessment = assessment;
+      let assessmentSettings: Settings = this.settingsDbService.getByAssessmentId(assessment);
+      if (assessmentType === 'PHAST') {
+        this.phastIntegrationService.setIntegratedAssessmentData(integratedAssessment, assessmentSettings, treasureHuntSettings);
+      } else if (assessmentType === 'PSAT') {
+        this.psatService.setIntegratedAssessmentData(integratedAssessment, assessmentSettings);
+      } else if (assessmentType === 'FSAT') {
+        this.fsatService.setIntegratedAssessmentData(integratedAssessment, assessmentSettings);
+      } else if (assessmentType === 'SSMT') {
+      } else if (assessmentType === 'WasteWater') {
+      } else if (assessmentType === 'CompressedAir') {
+      }
+    }
+
+    return integratedAssessment;
+  }
+
+  checkHasUpdatedEnergyData(existingOptions: IntegratedEnergyOptions, updatedOptions: IntegratedEnergyOptions) {
+    let hasUpdatedBaseline = this.checkisOptionDifferent(existingOptions.baseline, updatedOptions.baseline);
+    let hasUpdatedModification: boolean = false;
+    let existingMod = existingOptions.modifications[0];
+    let updatedMod = updatedOptions.modifications.find(mod => mod.modificationId === existingMod.modificationId);
+    if (updatedMod) {
+     hasUpdatedModification = this.checkisOptionDifferent(existingMod, updatedMod);
+    } 
+    return hasUpdatedBaseline || hasUpdatedModification;
+  }
+
+  checkisOptionDifferent(existingOption: AssessmentEnergyOption, updatedOption: AssessmentEnergyOption) {
+    let isEnergyDifferent: boolean = existingOption.annualEnergy !== updatedOption.annualEnergy;
+    let isCostDifferent: boolean = existingOption.annualCost !== updatedOption.annualCost;
+    let isCo2Different: boolean = existingOption.co2EmissionsOutput !== updatedOption.co2EmissionsOutput;
+    let differs: boolean = isEnergyDifferent || isCo2Different || isCostDifferent;
+    return differs;
+  }
+
+  async getAssessmentOptionsByType(assessmentType: AssessmentType): Promise<AssessmentOption[]> {
+    let allAssessments: Array<Assessment> = await firstValueFrom(this.assessmentDbService.getAllAssessments());
+    this.assessmentDbService.setAll(allAssessments);
+    this.assessmentsByType = allAssessments.filter(assessment => { return assessment.type == assessmentType });
+    this.assessmentsByType = _.orderBy(this.assessmentsByType, 'modifiedDate');
+    let assessmentOptions = this.assessmentsByType.map(assessment => { return { display: assessment.name, id: assessment.id } });
+    return assessmentOptions;
+  }
+  
+
+  navigateToIntegratedAssessment(integratedAssessment: IntegratedAssessment) {
+    if (integratedAssessment) {
+      let url: string = integratedAssessment.navigation.url;
+
+      if (url) {
+        this.assessmentService.setStartingTab('assessment')
+        this.router.navigate([url], {
+          queryParams: integratedAssessment.navigation.queryParams
+        }
+        );
+      }
+
+    }
+  }
+
+}
+
+
+export interface IntegratedAssessment {
+  assessment: Assessment,
+  name: string,
+  hasModifications?: boolean,
+  assessmentType: AssessmentType,
+  thEquipmentType?: string,
+  energyOptions?: IntegratedEnergyOptions,
+  baselineEnergyUseItems?: Array<EnergyUseItem>,
+  modificationEnergyUseItems?: Array<ModificationEnergyOption>,
+  selectedModificationId: string,
+  navigation?: {
+    queryParams: any,
+    url: string
+  }
+}
+
+export interface IntegratedEnergyOptions {
+  baseline: AssessmentEnergyOption;
+  modifications: AssessmentEnergyOption[],
+}
+
+export interface AssessmentEnergyOption {
+  name: string,
+  modificationId?: string,
+  annualEnergy: number,
+  co2EmissionsOutput: number,
+  annualCost: number
+}
+
+export interface ModificationEnergyOption {
+  modificationId: string,
+  energies: Array<EnergyUseItem>
+}
+
+export interface ExistingIntegrationData {
+  assessmentId: number,
+  assessmentType: AssessmentType,
+  assessmentName: string,
+  selectedModificationId: string,
+  energyOptions: IntegratedEnergyOptions,
+}

--- a/src/app/shared/connected-inventory/integration-help/integration-help.component.html
+++ b/src/app/shared/connected-inventory/integration-help/integration-help.component.html
@@ -39,43 +39,4 @@
 
 </ng-container>
 
-<ng-container *ngIf="connectionType === 'PSAT'">
-    PUMP HELP
-    <!-- <div class="my-2">
-        <h6>
-            <span *ngIf="focusedField == 'select-item'">Connect an Existing Motor Inventory</span>
-            <span *ngIf="focusedField != 'select-item'">Connected Inventory</span>
-            <br>
-            <small class="text-muted">
-            <span *ngIf="focusedField == 'select-item'">
-                Connect this pump to an existing motor inventory item. Changes made to the connected motor item Nameplate Data will be reflected in Pump Motor fields:
-            </span>
-            <div *ngIf="focusedField == 'connected-owner-inventory'" class="alert-info p-2 mt-2 w-100">
-                 This motor is connected to a pump inventory item. 
-                 Changes made to Nameplate Data will be reflected in the pump item's Pump Motor fields: 
-            </div>
-            <div *ngIf="focusedField == 'connected-item'" class="alert-info p-2 mt-2 w-100">
-                This pump is connected to a motor inventory item. 
-                Changes made to the motor item Nameplate Data will be reflected in the Pump Motor fields: 
-           </div>
-           </small>
-        </h6>
-        <div class="w-100 justify-content-center">
-            <table class="table table-hover table-striped">
-                <tbody>
-                    <tr>
-                        <th class="text-center">Motor Field </th>
-                        <th class="text-center">Pump Field</th>
-                    </tr>
-                    <tr><td class="text-center">Efficiency Class</td><td class="text-center">Efficiency Class</td></tr>
-                    <tr><td class="text-center">Rated Motor Power</td><td class="text-center">Rated Power</td></tr>
-                    <tr><td class="text-center">Line Frequency</td><td class="text-center">Line Frequency</td></tr>
-                    <tr><td class="text-center">Rated Voltage</td><td class="text-center">Rated Voltage</td></tr>
-                    <tr><td class="text-center">Full-Load Speed</td><td class="text-center">RPM</td></tr>
-                    <tr><td class="text-center">Full-Load Amps</td><td class="text-center">Full-Load Amps</td></tr>
-                </tbody>
-            </table>
-        </div>
-    </div> -->
-
-</ng-container>
+<ng-container *ngIf="connectionType === 'PSAT'"></ng-container>

--- a/src/app/shared/create-assessment-modal/create-assessment-modal.component.ts
+++ b/src/app/shared/create-assessment-modal/create-assessment-modal.component.ts
@@ -96,7 +96,7 @@ export class CreateAssessmentModalComponent {
 
   async createAssessment() {
     if (this.newAssessmentForm.valid) {
-      this.assessmentService.tab = 'system-setup';
+      this.assessmentService.startingTab = 'system-setup';
       if (this.newAssessmentForm.controls.assessmentType.value === 'Pump') {
         let psatAssessment: Assessment = this.assessmentService.getNewAssessment('PSAT');
         psatAssessment.name = this.newAssessmentForm.controls.assessmentName.value;

--- a/src/app/shared/helper-services/helper-functions.service.ts
+++ b/src/app/shared/helper-services/helper-functions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { cloneDeep } from 'lodash';
 
+// todo move to non ng service file
 @Injectable()
 export class HelperFunctionsService {
 
@@ -17,5 +18,9 @@ export class HelperFunctionsService {
     } else {
       return text;
     }
+  }
+
+  getNewIdString() {
+   return Math.random().toString(36).substr(2, 9);
   }
 }

--- a/src/app/shared/helper-services/update-data.service.ts
+++ b/src/app/shared/helper-services/update-data.service.ts
@@ -10,11 +10,12 @@ import { PHAST } from '../models/phast/phast';
 import { ConvertUnitsService } from '../convert-units/convert-units.service';
 import { FlueGasByMass, FlueGasByVolume } from '../models/phast/losses/flueGas';
 import { environment } from '../../../environments/environment';
+import { HelperFunctionsService } from './helper-functions.service';
 
 @Injectable()
 export class UpdateDataService {
 
-    constructor(private convertUnitsService: ConvertUnitsService) { }
+    constructor(private convertUnitsService: ConvertUnitsService, private helperFunctions: HelperFunctionsService) { }
 
     updateAssessmentVersion(assessment: Assessment): Assessment {
         if (assessment.type === 'PSAT') {
@@ -149,7 +150,13 @@ export class UpdateDataService {
 
 
     updatePsat(assessment: Assessment): Assessment {
-        //logic for updating psat data
+        if (assessment.psat.modifications && assessment.psat.modifications.length > 0) {
+            assessment.psat.modifications.map(mod => {
+                if (mod.id === undefined || mod.id === null) {
+                    mod.id = this.helperFunctions.getNewIdString();
+                }
+            });
+        }
         assessment.appVersion = environment.version;
 
         if (assessment.psat.inputs.line_frequency === 0){
@@ -181,7 +188,13 @@ export class UpdateDataService {
     }
 
     updateFsat(assessment: Assessment): Assessment {
-        //logic for updating fsat data
+        if (assessment.fsat.modifications && assessment.fsat.modifications.length > 0) {
+            assessment.fsat.modifications.map(mod => {
+                if (mod.id === undefined || mod.id === null) {
+                    mod.id = this.helperFunctions.getNewIdString();
+                }
+            });
+        }
         assessment.appVersion = environment.version;
         if (assessment.fsat.fieldData && !assessment.fsat.fieldData.inletVelocityPressure) {
             assessment.fsat.fieldData.inletVelocityPressure = 0;
@@ -235,7 +248,14 @@ export class UpdateDataService {
     }
 
     updatePhast(assessment: Assessment): Assessment {
-        //logic for updating phast data
+        if (assessment.phast.modifications && assessment.phast.modifications.length > 0) {
+            assessment.phast.modifications.map(mod => {
+                if (mod.id === undefined || mod.id === null) {
+                    mod.id = this.helperFunctions.getNewIdString();
+                }
+            });
+        }
+
         if (!assessment.phast.operatingHours) {
             assessment.phast.operatingHours = {
                 weeksPerYear: 52.14,

--- a/src/app/shared/models/fans.ts
+++ b/src/app/shared/models/fans.ts
@@ -44,6 +44,7 @@ export interface FsatValid {
 export interface Modification {
   notes?: Notes;
   fsat?: FSAT;
+  id: string,
   exploreOpportunities?: boolean;
   exploreOppsShowVfd?: SavingsOpportunity,
   exploreOppsShowDrive?: SavingsOpportunity,

--- a/src/app/shared/models/phast/phast.ts
+++ b/src/app/shared/models/phast/phast.ts
@@ -67,6 +67,7 @@ export interface Losses {
 
 export interface Modification {
   phast?: PHAST;
+  id: string,
   notes?: Notes;
   exploreOpportunities?: boolean;
   exploreOppsShowFlueGas?: SavingsOpportunity;
@@ -140,6 +141,16 @@ export interface PhastResults {
   availableHeatPercent: number;
   electricalHeatDelivered?: number;
   co2EmissionsOutput?: PhastCo2EmissionsOutput
+}
+
+export interface EnergyUseReportData {
+  fuelName: string,
+  fuelEnergyUsed: number,
+  fuelHeatingValue: number,
+  energyPerMassUnit: string,
+  electricEnergyUsed?: number,
+  baseEnergyUnit: string,
+  steamEnergyUsed: number
 }
 
 export interface EAFResults {

--- a/src/app/shared/models/psat.ts
+++ b/src/app/shared/models/psat.ts
@@ -109,6 +109,7 @@ export interface PsatCalcResults {
 export interface Modification {
   notes?: Notes;
   psat?: PSAT;
+  id: string,
   exploreOpportunities?: boolean;
   exploreOppsShowVfd?: SavingsOpportunity,
   exploreOppsShowMotorDrive?: SavingsOpportunity;

--- a/src/app/shared/models/treasure-hunt.ts
+++ b/src/app/shared/models/treasure-hunt.ts
@@ -18,11 +18,13 @@ import { Co2SavingsData } from "../../calculator/utilities/co2-savings/co2-savin
 import { ChillerPerformanceInput, CoolingTowerBasinInput, CoolingTowerData, CoolingTowerFanInput } from "./chillers";
 import { ChillerStagingInput } from "./chillers";
 import { WeatherBinsInput } from "../../calculator/utilities/weather-bins/weather-bins.service";
+import { ExistingIntegrationData } from "../assessment-integration/assessment-integration.service";
 
 export interface TreasureHunt {
     name: string,
     lightingReplacements?: Array<LightingReplacementTreasureHunt>;
     opportunitySheets?: Array<OpportunitySheet>;
+    assessmentOpportunities?: Array<AssessmentOpportunity>;
     replaceExistingMotors?: Array<ReplaceExistingMotorTreasureHunt>;
     motorDrives?: Array<MotorDriveInputsTreasureHunt>;
     naturalGasReductions?: Array<NaturalGasReductionTreasureHunt>;
@@ -82,7 +84,8 @@ export enum Treasure {
     chillerStaging = 'chiller-staging',
     chillerPerformance = 'chiller-performance',
     coolingTowerFan = 'cooling-tower-fan',
-    coolingTowerBasin = 'cooling-tower-basin'
+    coolingTowerBasin = 'cooling-tower-basin',
+    assessmentOpportunity ='assessment-opportunity'
 }
 
 export interface FilterOption {
@@ -167,15 +170,47 @@ export interface OpportunitySheet extends TreasureHuntOpportunity {
     date: Date,
     owner?: string,
     businessUnits?: string,
+    iconString?: string,
     opportunityCost: OpportunityCost,
     baselineEnergyUseItems?: Array<EnergyUseItem>,
     modificationEnergyUseItems?: Array<EnergyUseItem>,
     selected?: boolean
 }
 
+export interface AssessmentOpportunity extends TreasureHuntOpportunity {
+    name: string,
+    existingIntegrationData: ExistingIntegrationData,
+    equipment: string,
+    description: string,
+    originator?: string,
+    date: Date,
+    owner?: string,
+    iconString?: string,
+    businessUnits?: string,
+    opportunityCost: OpportunityCost,
+    baselineEnergyUseItems?: Array<EnergyUseItem>,
+    modificationEnergyUseItems?: Array<EnergyUseItem>,
+    selected?: boolean,
+}
+
+
+
+export interface UtilityTypeTreasureHuntEmissions {
+    electricityEmissions: number,
+    naturalGasEmissions: number,
+    otherFuelEmissions: number,
+    waterEmissions: number,
+    wasteWaterEmissions: number,
+    compressedAirEmissions: number,
+    steamEmissions: number,
+}
+
 export interface EnergyUseItem {
     type: string, 
-    amount: number
+    amount: number,
+    integratedUnit?: string,
+    integratedEmissionRate?: number,
+    integratedEnergyCost?: number
 }
 
 export interface OpportunityCost {
@@ -397,6 +432,30 @@ export interface OpportunitySheetResults {
     totalEnergySavings: number,
     totalCostSavings: number,
     totalImplementationCost: number
+}
+
+export interface AssessmentOpportunityResults {
+    electricityResults: AssessmentOpportunityResult,
+    gasResults: AssessmentOpportunityResult,
+    compressedAirResults: AssessmentOpportunityResult,
+    otherFuelResults: AssessmentOpportunityResult,
+    steamResults: AssessmentOpportunityResult,
+    waterResults: AssessmentOpportunityResult,
+    wasteWaterResults: AssessmentOpportunityResult,
+    totalEnergySavings: number,
+    totalCostSavings: number,
+    totalImplementationCost: number
+}
+
+export interface AssessmentOpportunityResult {
+    baselineEnergyUse: number,
+    baselineEnergyCost: number,
+    baselineItems: number,
+    modificationEnergyUse: number,
+    modificationEnergyCost: number,
+    modificationItems: number,
+    energySavings: number,
+    energyCostSavings: number,
 }
 
 export interface OpportunitySheetResult {

--- a/src/app/ssmt/ssmt.component.ts
+++ b/src/app/ssmt/ssmt.component.ts
@@ -127,7 +127,7 @@ export class SsmtComponent implements OnInit {
         this._ssmt = (JSON.parse(JSON.stringify(this.assessment.ssmt)));
         this.getSettings();
         this.initSankeyList();
-        let tmpTab = this.assessmentService.getTab();
+        let tmpTab = this.assessmentService.getStartingTab();
         if (tmpTab) {
           this.ssmtService.mainTab.next(tmpTab);
         }

--- a/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.css
+++ b/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.css
@@ -1,0 +1,31 @@
+.assessment-opp-icon {
+    width: 40px;
+}
+
+.calculator-panel-container.modification {
+    width: 60%;
+}
+
+.calculator-panel-container.help-panel {
+    width: 40%;
+}
+
+@media screen and (max-width: 1024) {
+    .fa-save, .fa-times, .fa-edit {
+        font-size: 18px;
+    }
+    .calculator-container .header h3 {
+        font-size: 14px !important;
+    }
+
+}
+
+span.fa.fa-save:hover,
+span.fa.fa-times:hover {
+    cursor: pointer;
+}
+
+
+.modal-open {
+    z-index: initial !important;
+}

--- a/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.html
+++ b/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.html
@@ -1,0 +1,111 @@
+<div class="custom-opportunity calculator-container modify-conditions general standalone-calculator" #contentContainer>
+    <div #leftPanelHeader class="d-flex header pb-1 pt-1 bg-white align-items-center justify-content-between">
+      <div class="pl-2 align-items-center d-none d-sm-flex">
+        <img src="assets/images/app-icon.png" class="assessment-opp-icon">
+      </div>
+      <div class="mx-auto">
+        <h3>Assessment Savings opportunity</h3>
+      </div>
+      <div class="d-flex pr-2 pl-2">
+        <div class="d-none d-lg-flex help-holder">
+          <p class="help-text treasure-hunt-help">Once you've found some treasure, click the save icon to add the
+            treasure to your chest!
+            Click cancel to discard changes and return to method selection.</p>
+        </div>
+        <div class="pl-2 pr-2 border-right action-item" (click)="save()">
+          <span class="fa fa-save"></span>
+        </div>
+        <div class="pl-2 pr-2 border-right border-left action-item" (click)="cancel()">
+          <span class="fa fa-times"></span>
+        </div>
+      </div>
+    </div>
+    <div class="small-tab-select nav-pills nav-fill" #smallTabSelect>
+      <div class="nav-item" (click)="setSmallScreenTab('form')"
+        [ngClass]="{'small-screen-active': smallScreenTab === 'form'}">
+        <a class="nav-link">Assessment Savings opportunity</a>
+      </div>
+      <div class="nav-item" (click)="setSmallScreenTab('details')"
+        [ngClass]="{'small-screen-active': smallScreenTab === 'details'}">
+        <a class="nav-link">Details</a>
+      </div>
+    </div>
+    <div class="panel-group">
+      <div class="calculator-panel-container modification" [ngStyle]="{'height.px': containerHeight}"
+        [ngClass]="{'small-screen-tab w-100': smallScreenTab === 'form', 'modal-open': isModalOpen}">
+        <div class="d-block m-2">
+
+          <div class="col-12">
+            <div class="header">
+              <h3 class="ml-0">Integrate Data From Assessment</h3>
+            </div>
+            <div class="d-block">
+              <app-assessment-integration
+                [settings]="settings"
+                [existingIntegrationData]="assessmentOpportunity.existingIntegrationData"
+                (integratedAssessmentSelected)="setIntegratedAssessment($event)"></app-assessment-integration>              
+            </div>
+          </div>
+
+          <app-general-details-form class="w-100" [(opportunitySheet)]="assessmentOpportunity" [isAssessmentOpportunity]="true"
+            (emitChangeField)="changeField($event)"></app-general-details-form>
+
+          <div class="col-12">
+            <div class="header">
+              <h3 class="ml-0">Energy Use</h3>
+            </div>
+          </div>
+
+          <div class="d-block d-lg-flex col-12">
+            <div class="p-2 flex-grow-1">
+              <label class="group-label">Baseline</label>
+              <app-energy-use-form [(energyItems)]="assessmentOpportunity.baselineEnergyUseItems" [settings]="settings"
+              [isAssessmentOpportunity]="true" (emitSave)="saveBaseline($event)" (emitChangeField)="changeField($event)">
+              </app-energy-use-form>
+            </div>
+            <!-- Modifications Start -->
+            <div class="p-2 flex-grow-1">
+              <label class="group-label">Modification</label>
+              <app-energy-use-form *ngIf="assessmentOpportunity.modificationEnergyUseItems.length != 0"
+              [isAssessmentOpportunity]="true" [allowCreateModifiedEnergy]="allowCreateModifiedEnergy" [(energyItems)]="assessmentOpportunity.modificationEnergyUseItems" [settings]="settings"
+                (emitSave)="saveModification($event)" (emitChangeField)="changeField($event)">
+              </app-energy-use-form>
+              <div class="p-3 no-data" (click)="addModification()"
+                *ngIf="assessmentOpportunity.modificationEnergyUseItems.length == 0">
+                <h3>Once you've added your baseline energy use.
+                </h3>
+                <button type="button" class="btn btn-primary">Add Modified Condition</button>
+                <p>Data will be copied from your current baseline condition.</p>
+              </div>
+            </div>
+          </div>
+
+          <app-costs-form class="w-100" [(opportunityCost)]="assessmentOpportunity.opportunityCost"
+            (emitChangeField)="changeField($event)"></app-costs-form>
+
+        </div>
+      </div>
+      <div class="calculator-panel-container help-panel" [ngStyle]="{'height.px': containerHeight}"
+        [ngClass]="{'small-screen-tab w-100': smallScreenTab === 'details', 'modal-open': isModalOpen}">
+        <div class="d-flex flex-wrap tabs primary sticky-top">
+          <div class="flex-fill panel-tab-item h-100" [ngClass]="{'active': tabSelect == 'results'}">
+            <a class="border-left-0 h-100 d-flex justify-content-center align-items-center" (click)="setTab('results')">
+              <div>Results</div>
+            </a>
+          </div>
+          <div class="flex-fill panel-tab-item h-100" [ngClass]="{'active': tabSelect == 'help'}">
+            <a class="h-100 d-flex justify-content-center align-items-center" (click)="setTab('help')">
+              <div>Help</div>
+            </a>
+          </div>
+        </div>
+        <div class="d-flex pl-2 pr-2">
+          <app-opportunity-sheet-help *ngIf="tabSelect == 'help'" [currentField]="currentField">
+          </app-opportunity-sheet-help>
+          <app-opportunity-sheet-results *ngIf="tabSelect == 'results'" class="w-100"
+            [opportunitySheetResults]="assessmentOpportunityResults" [opportunitySheet]="assessmentOpportunity">
+          </app-opportunity-sheet-results>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.spec.ts
+++ b/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AssessmentOpportunityComponent } from './assessment-opportunity.component';
+
+describe('AssessmentOpportunityComponent', () => {
+  let component: AssessmentOpportunityComponent;
+  let fixture: ComponentFixture<AssessmentOpportunityComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AssessmentOpportunityComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AssessmentOpportunityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.ts
+++ b/src/app/treasure-hunt/calculators/assessment-opportunity/assessment-opportunity.component.ts
@@ -1,0 +1,150 @@
+import { Component, ElementRef, EventEmitter, HostListener, Input, Output, ViewChild } from '@angular/core';
+import { Settings } from '../../../shared/models/settings';
+import { AssessmentOpportunity, OpportunitySheetResults } from '../../../shared/models/treasure-hunt';
+import { AssessmentOpportunityService } from '../../treasure-hunt-calculator-services/assessment-opportunity.service';
+import { AssessmentEnergyOption, IntegratedAssessment, ModificationEnergyOption } from '../../../shared/assessment-integration/assessment-integration.service';
+import { HelperFunctionsService } from '../../../shared/helper-services/helper-functions.service';
+import { Subscription } from 'rxjs';
+import { TreasureHuntService } from '../../treasure-hunt.service';
+
+@Component({
+  selector: 'app-assessment-opportunity',
+  templateUrl: './assessment-opportunity.component.html',
+  styleUrls: ['./assessment-opportunity.component.css']
+})
+export class AssessmentOpportunityComponent {
+  @Output('emitCancel')
+  emitCancel = new EventEmitter<boolean>();
+  @Output('emitSave')
+  emitSave = new EventEmitter<AssessmentOpportunity>();
+  @Input()
+  settings: Settings;
+
+  @ViewChild('leftPanelHeader', { static: false }) leftPanelHeader: ElementRef;
+  @ViewChild('contentContainer', { static: false }) contentContainer: ElementRef;
+  @ViewChild('smallTabSelect', { static: false }) smallTabSelect: ElementRef;
+
+  @HostListener('window:resize', ['$event'])
+  onResize(event) {
+    setTimeout(() => {
+      this.resizeTabs();
+    }, 100);
+  }
+
+  smallScreenTab: string = 'form';
+  containerHeight: number;
+  tabSelect: string = 'help';
+  assessmentOpportunityResults: OpportunitySheetResults;
+  currentField: string = 'default';
+  assessmentOpportunity: AssessmentOpportunity;
+  integratedAssessment: IntegratedAssessment;
+  isModalOpen: boolean;
+  modalOpenSub: Subscription;
+  allowCreateModifiedEnergy: boolean = false;
+  constructor(private assessmentOpportunityService: AssessmentOpportunityService, private treasureHuntService: TreasureHuntService, private helperFunctions: HelperFunctionsService) { }
+
+  ngOnInit() {
+    if (this.assessmentOpportunityService.assessmentOpportunity) {
+      this.assessmentOpportunity = this.helperFunctions.copyObject(this.assessmentOpportunityService.assessmentOpportunity);
+    } else {
+      this.assessmentOpportunity = this.assessmentOpportunityService.initAssessmentOpportunity();
+    }
+
+    this.modalOpenSub = this.treasureHuntService.modalOpen.subscribe(val => {
+      this.isModalOpen = val;
+    });
+
+    this.getResults();
+  }
+
+  ngOnDestroy() {
+    this.modalOpenSub.unsubscribe();
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => {
+      this.resizeTabs();
+    }, 100);
+  }
+
+  resizeTabs() {
+    if (this.leftPanelHeader.nativeElement.clientHeight) {
+      this.containerHeight = this.contentContainer.nativeElement.clientHeight - this.leftPanelHeader.nativeElement.clientHeight;
+      if (this.smallTabSelect && this.smallTabSelect.nativeElement) {
+        this.containerHeight = this.containerHeight - this.smallTabSelect.nativeElement.offsetHeight;
+      }
+    }
+  }
+
+  addModification() {
+    this.assessmentOpportunity.modificationEnergyUseItems = JSON.parse(JSON.stringify(this.assessmentOpportunity.baselineEnergyUseItems));
+    this.allowCreateModifiedEnergy = true;
+  }
+
+  save() {
+    if (this.integratedAssessment && !this.assessmentOpportunity.existingIntegrationData) {
+      this.updatedIntegratedAssessment();
+    }
+    this.emitSave.emit(this.assessmentOpportunity);
+  }
+
+  cancel() {
+    this.assessmentOpportunity = this.assessmentOpportunityService.assessmentOpportunity;
+    this.emitCancel.emit(true);
+  }
+
+  setTab(str: string) {
+    this.tabSelect = str;
+  }
+
+  saveBaseline(baselineData: Array<{ type: string, amount: number }>) {
+    this.assessmentOpportunity.baselineEnergyUseItems = baselineData;
+    this.getResults();
+  }
+
+  saveModification(modificationData: Array<{ type: string, amount: number }>) {
+    this.assessmentOpportunity.modificationEnergyUseItems = modificationData;
+    this.getResults();
+  }
+
+  getResults() {
+    this.assessmentOpportunityResults = this.assessmentOpportunityService.getResults(this.assessmentOpportunity, this.settings);
+  }
+
+  setIntegratedAssessment(integratedAssessment: IntegratedAssessment) {
+    this.integratedAssessment = integratedAssessment;
+    this.assessmentOpportunity.baselineEnergyUseItems = integratedAssessment.baselineEnergyUseItems;
+    if (this.integratedAssessment.hasModifications) {
+      let selectedModification: ModificationEnergyOption = integratedAssessment.modificationEnergyUseItems.find(item => item.modificationId === integratedAssessment.selectedModificationId);
+      this.assessmentOpportunity.modificationEnergyUseItems = selectedModification.energies;
+    }
+    this.assessmentOpportunity.equipment = integratedAssessment.thEquipmentType;
+    this.assessmentOpportunity.name = integratedAssessment.assessment.name;
+    this.getResults();
+  }
+
+  updatedIntegratedAssessment() {
+    this.assessmentOpportunity.existingIntegrationData = {
+      assessmentId: this.integratedAssessment.assessment.id,
+      assessmentType: this.integratedAssessment.assessmentType,
+      assessmentName: this.integratedAssessment.assessment.name,
+      energyOptions: this.integratedAssessment.energyOptions,
+      selectedModificationId: this.integratedAssessment.selectedModificationId
+    }
+
+    if (this.integratedAssessment.hasModifications) {
+      let selectedModificationEnergyOptions: AssessmentEnergyOption[] = this.integratedAssessment.energyOptions.modifications.filter(option => {
+        return option.modificationId == this.integratedAssessment.selectedModificationId 
+      });
+      this.assessmentOpportunity.existingIntegrationData.energyOptions.modifications = selectedModificationEnergyOptions;
+    }
+  }
+  
+  changeField(str: string) {
+    this.currentField = str;
+  }
+
+  setSmallScreenTab(selectedTab: string) {
+    this.smallScreenTab = selectedTab;
+  }
+}

--- a/src/app/treasure-hunt/calculators/calculators.component.html
+++ b/src/app/treasure-hunt/calculators/calculators.component.html
@@ -90,9 +90,14 @@
 [operatingHours]="treasureHunt.operatingHours"></app-water-reduction>
 
 <app-standalone-opportunity-sheet *ngIf="selectedCalc == 'opportunity-sheet'"
-  (emitCancel)="cancelTreasureHuntOpportunity()" (emitSave)="saveStandaloneOpportunitySheet($event)"
+  (emitCancel)="cancelTreasureHuntOpportunity()" (emitSave)="saveCustomOpportunity($event)"
   [settings]="settings">
 </app-standalone-opportunity-sheet>
+
+<app-assessment-opportunity *ngIf="selectedCalc == 'assessment-opportunity'"
+  (emitCancel)="cancelTreasureHuntOpportunity()" (emitSave)="saveCustomOpportunity($event)"
+  [settings]="settings">
+</app-assessment-opportunity>
 
 <app-cooling-tower *ngIf="selectedCalc == 'cooling-tower-makeup'"
   [inTreasureHunt]="true" (emitSave)="saveOpportunity($event)" 
@@ -128,7 +133,7 @@
           <span aria-hidden="true">&times;</span>
         </button> -->
       </div>
-      <div class="modal-body text-center" *ngIf="selectedCalc != 'opportunity-sheet'">
+      <div class="modal-body text-center">
         <p class="help-text" *ngIf="!calculatorOpportunitySheet">There is no opportunity sheet filled out for this
           opportunity. Would you like to add one
           before saving?</p>

--- a/src/app/treasure-hunt/calculators/calculators.component.ts
+++ b/src/app/treasure-hunt/calculators/calculators.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, ViewChild } from '@angular/core';
 import { CalculatorsService } from './calculators.service';
 import { Subscription } from 'rxjs';
-import { TreasureHunt, TreasureHuntOpportunity, OpportunitySheet, Treasure } from '../../shared/models/treasure-hunt';
+import { TreasureHunt, TreasureHuntOpportunity, OpportunitySheet, Treasure, AssessmentOpportunity } from '../../shared/models/treasure-hunt';
 import { Settings } from '../../shared/models/settings';
 import { TreasureHuntService } from '../treasure-hunt.service';
 import { ModalDirective } from 'ngx-bootstrap/modal';
@@ -28,7 +28,7 @@ export class CalculatorsComponent implements OnInit {
   mainTab: string;
   mainTabSub: Subscription;
   currentOpportunity: TreasureHuntOpportunity;
-  standaloneOpportunitySheet: OpportunitySheet;
+  customOpportunity: OpportunitySheet | AssessmentOpportunity;
 
   constructor(private calculatorsService: CalculatorsService, 
     private treasureHuntOpportunityService: TreasureHuntOpportunityService,
@@ -53,12 +53,6 @@ export class CalculatorsComponent implements OnInit {
     this.mainTabSub.unsubscribe();
   }
 
-  showSaveCalcModal() {
-    this.saveCalcModal.show();
-  }
-  hideSaveCalcModal() {
-    this.saveCalcModal.hide();
-  }
   showOpportunitySheetModal() {
     this.calculatorOpportunitySheet = this.calculatorsService.calcOpportunitySheet;
     this.opportunitySheetModal.show();
@@ -67,72 +61,51 @@ export class CalculatorsComponent implements OnInit {
     this.opportunitySheetModal.hide();
   }
 
+  hideSaveCalcModal() {
+    this.saveCalcModal.hide();
+  }
+
   saveItemOpportunitySheet(updatedOpportunitySheet: OpportunitySheet) {
     this.calculatorOpportunitySheet = updatedOpportunitySheet;
     this.calculatorsService.calcOpportunitySheet = updatedOpportunitySheet;
     this.hideOpportunitySheetModal();
-    if (this.mainTab == 'find-treasure') {
-      this.confirmSaveCalc();
-    }
+    this.confirmSaveCalc();
   }
 
+  saveCustomOpportunity(customOpportunity: OpportunitySheet | AssessmentOpportunity) {
+    this.customOpportunity = customOpportunity;
+    this.calculatorOpportunitySheet = this.calculatorsService.calcOpportunitySheet;
+    this.confirmSaveCalc();
+  }
 
   saveOpportunity(treasureHuntOpportunity: TreasureHuntOpportunity) {
     this.currentOpportunity = treasureHuntOpportunity;
     this.calculatorOpportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    if (this.mainTab == 'find-treasure' && this.selectedCalc !== Treasure.opportunitySheet) {
+    if (this.mainTab == 'find-treasure') {
       this.showOpportunitySheetModal();
     } else {
-      this.showSaveCalcModal();
+      this.saveCalcModal.show();
     }
-  }
-
-  confirmSaveCalc() {
-    if (this.selectedCalc === Treasure.opportunitySheet) {
-      this.standaloneOpportunitySheet.selected = true;
-    } else {
-      this.currentOpportunity.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
-      this.currentOpportunity.selected = true;
-    }
-
-    if (this.calculatorsService.isNewOpportunity == true) {
-      this.saveTreasureHuntOpportunity();
-    } else {
-      this.updateTreasureHuntOpportunity();
-    }
-    this.finishSaveCalc();
-  }
-
-  initSaveCalc() {
-    this.calculatorOpportunitySheet = this.calculatorsService.calcOpportunitySheet;
-    if (this.mainTab == 'find-treasure' && this.selectedCalc !== Treasure.opportunitySheet) {
-      this.showOpportunitySheetModal();
-    } else {
-      this.showSaveCalcModal();
-    }
-  }
-
-  finishSaveCalc() {
-    this.hideSaveCalcModal();
-    this.calculatorsService.selectedCalc.next('none');
-  }
-
-  saveTreasureHuntOpportunity() {
-    this.treasureHuntOpportunityService.saveTreasureHuntOpportunity(this.currentOpportunity, this.selectedCalc, this.standaloneOpportunitySheet)
   }
 
   cancelTreasureHuntOpportunity() {
     this.treasureHuntOpportunityService.cancelTreasureHuntOpportunity(this.selectedCalc);
   }
 
-  updateTreasureHuntOpportunity() {
-    this.treasureHuntOpportunityService.updateTreasureHuntOpportunity(this.currentOpportunity, this.selectedCalc, this.settings, this.standaloneOpportunitySheet);
+  confirmSaveCalc() {
+    if (this.selectedCalc === Treasure.opportunitySheet || this.selectedCalc === Treasure.assessmentOpportunity) {
+      this.customOpportunity.selected = true;
+    } else {
+      this.currentOpportunity.opportunitySheet = this.calculatorsService.calcOpportunitySheet;
+      this.currentOpportunity.selected = true;
+    }
+    if (this.calculatorsService.isNewOpportunity == true) {
+      this.treasureHuntOpportunityService.saveTreasureHuntOpportunity(this.currentOpportunity, this.selectedCalc, this.customOpportunity)
+    } else {
+      this.treasureHuntOpportunityService.updateTreasureHuntOpportunity(this.currentOpportunity, this.selectedCalc, this.settings, this.customOpportunity);
+    }
+    this.saveCalcModal.hide(); 
+    this.calculatorsService.selectedCalc.next('none');
   }
-
-  saveStandaloneOpportunitySheet(opportunitySheet: OpportunitySheet) {
-    this.standaloneOpportunitySheet = opportunitySheet;
-    this.initSaveCalc();
-  }
-
 
 }

--- a/src/app/treasure-hunt/calculators/calculators.module.ts
+++ b/src/app/treasure-hunt/calculators/calculators.module.ts
@@ -38,6 +38,8 @@ import { ChillerStagingModule } from '../../calculator/process-cooling/chiller-s
 import { ChillerPerformanceModule } from '../../calculator/process-cooling/chiller-performance/chiller-performance.module';
 import { CoolingTowerFanModule } from '../../calculator/process-cooling/cooling-tower-fan/cooling-tower-fan.module';
 import { CoolingTowerBasinModule } from '../../calculator/process-cooling/cooling-tower-basin/cooling-tower-basin.module';
+import { AssessmentOpportunityComponent } from './assessment-opportunity/assessment-opportunity.component';
+import { AssessmentIntegrationModule } from '../../shared/assessment-integration/assessment-integration.module';
 
 @NgModule({
   declarations: [
@@ -48,7 +50,8 @@ import { CoolingTowerBasinModule } from '../../calculator/process-cooling/coolin
     EnergyUseFormComponent,
     CostsFormComponent,
     GeneralDetailsFormComponent,
-    OpportunitySheetComponent
+    OpportunitySheetComponent,
+    AssessmentOpportunityComponent
   ],
   imports: [
     CommonModule,
@@ -78,7 +81,8 @@ import { CoolingTowerBasinModule } from '../../calculator/process-cooling/coolin
     ChillerStagingModule,
     ChillerPerformanceModule,
     CoolingTowerFanModule,
-    CoolingTowerBasinModule
+    CoolingTowerBasinModule,
+    AssessmentIntegrationModule
   ],
   providers: [
     CalculatorsService,

--- a/src/app/treasure-hunt/calculators/calculators.service.ts
+++ b/src/app/treasure-hunt/calculators/calculators.service.ts
@@ -31,6 +31,7 @@ import { ChillerStagingTreasureHuntService } from '../treasure-hunt-calculator-s
 import { ChillerPerformanceTreasureHuntService } from '../treasure-hunt-calculator-services/chiller-performance-treasure-hunt.service';
 import { CoolingTowerFanTreasureHuntService } from '../treasure-hunt-calculator-services/cooling-tower-fan-treasure-hunt.service';
 import { CoolingTowerBasinTreasureHuntService } from '../treasure-hunt-calculator-services/cooling-tower-basin-treasure-hunt.service';
+import { AssessmentOpportunityService } from '../treasure-hunt-calculator-services/assessment-opportunity.service';
 
 @Injectable()
 export class CalculatorsService {
@@ -68,7 +69,8 @@ export class CalculatorsService {
     private chillerStagingTreasureHuntService: ChillerStagingTreasureHuntService,
     private chillerPerformanceTreasureHuntService: ChillerPerformanceTreasureHuntService,
     private coolingTowerFanTreasureHuntService: CoolingTowerFanTreasureHuntService,
-    private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService
+    private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService,
+    private assessmentOpportunityService: AssessmentOpportunityService
     ) {
     this.selectedCalc = new BehaviorSubject<string>('none');
   }
@@ -133,6 +135,8 @@ export class CalculatorsService {
       this.coolingTowerFanTreasureHuntService.initNewCalculator()
     } else if (calculatorType === Treasure.coolingTowerBasin) {
       this.coolingTowerBasinTreasureHuntService.initNewCalculator()
+    } else if (calculatorType === Treasure.assessmentOpportunity) {
+      this.assessmentOpportunityService.assessmentOpportunity = undefined;
     }
     this.selectedCalc.next(calculatorType);
   }
@@ -154,7 +158,8 @@ export class CalculatorsService {
       opportunityCardData.opportunitySheet = this.updateCopyName(opportunityCardData.opportunitySheet);
       this.standaloneOpportunitySheetService.saveTreasureHuntOpportunity(opportunityCardData.opportunitySheet, treasureHunt);
       opportunityCardData = this.opportunityCardsService.getOpportunitySheetCardData(opportunityCardData.opportunitySheet, settings, opportunityCardData.opportunityIndex, treasureHunt.currentEnergyUsage);
-    
+      opportunityCardData.opportunityType = Treasure.opportunitySheet;
+      
     } else if (opportunityCardData.opportunityType === Treasure.lightingReplacement) {
       opportunityCardData.lightingReplacement.opportunitySheet = this.updateCopyName(opportunityCardData.lightingReplacement.opportunitySheet);
       this.lightingTreasureHuntService.saveTreasureHuntOpportunity(opportunityCardData.lightingReplacement, treasureHunt);
@@ -293,7 +298,11 @@ export class CalculatorsService {
       let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getIndividualOpportunitySummary(opportunityCardData.coolingTowerBasin, settings);
       opportunityCardData = this.coolingTowerBasinTreasureHuntService.getCoolingTowerBasinCardData(opportunityCardData.coolingTowerBasin, opportunitySummary, treasureHunt.coolingTowerBasinOpportunities.length - 1, treasureHunt.currentEnergyUsage, settings);
     
-    }
+    } else if (opportunityCardData.opportunityType == Treasure.assessmentOpportunity) {
+      opportunityCardData.opportunitySheet = this.updateCopyName(opportunityCardData.opportunitySheet);
+      this.assessmentOpportunityService.saveTreasureHuntOpportunity(opportunityCardData.assessmentOpportunity, treasureHunt);
+      opportunityCardData = this.opportunityCardsService.getAssessmentOpportunityCardData(opportunityCardData.assessmentOpportunity, settings, opportunityCardData.opportunityIndex, treasureHunt.currentEnergyUsage);
+    } 
     return opportunityCardData;
   }
 
@@ -354,7 +363,9 @@ export class CalculatorsService {
       this.coolingTowerFanTreasureHuntService.setCalculatorInputFromOpportunity(opportunityCardData.coolingTowerFan);
     } else if (opportunityCardData.opportunityType === Treasure.coolingTowerBasin) {
       this.coolingTowerBasinTreasureHuntService.setCalculatorInputFromOpportunity(opportunityCardData.coolingTowerBasin);
-    }
+    } else if (opportunityCardData.opportunityType === Treasure.assessmentOpportunity) {
+      this.assessmentOpportunityService.assessmentOpportunity = opportunityCardData.assessmentOpportunity;
+    } 
 
     this.selectedCalc.next(opportunityCardData.opportunityType);
   }
@@ -510,7 +521,11 @@ export class CalculatorsService {
       treasureHunt.coolingTowerBasinOpportunities[opportunityCardData.opportunityIndex] = opportunityCardData.coolingTowerBasin;
       let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getIndividualOpportunitySummary(opportunityCardData.coolingTowerBasin, settings);
       updatedCard = this.coolingTowerBasinTreasureHuntService.getCoolingTowerBasinCardData(opportunityCardData.coolingTowerBasin, opportunitySummary, opportunityCardData.opportunityIndex, treasureHunt.currentEnergyUsage, settings);
-    }
+    } else if (opportunityCardData.opportunityType === Treasure.assessmentOpportunity) {
+      opportunityCardData.assessmentOpportunity.selected = opportunityCardData.selected;
+      treasureHunt.assessmentOpportunities[opportunityCardData.opportunityIndex] = opportunityCardData.assessmentOpportunity;
+      updatedCard = this.opportunityCardsService.getAssessmentOpportunityCardData(opportunityCardData.assessmentOpportunity, settings, opportunityCardData.opportunityIndex, treasureHunt.currentEnergyUsage);
+    } 
     
     this.opportunityCardsService.updatedOpportunityCard.next(updatedCard);
     return treasureHunt;
@@ -569,6 +584,8 @@ export class CalculatorsService {
       this.coolingTowerFanTreasureHuntService.deleteOpportunity(deleteOpportunity.opportunityIndex, treasureHunt)
     } else if (deleteOpportunity.opportunityType === Treasure.coolingTowerBasin) {
       this.coolingTowerBasinTreasureHuntService.deleteOpportunity(deleteOpportunity.opportunityIndex, treasureHunt)
+    }  else if (deleteOpportunity.opportunityType === Treasure.assessmentOpportunity) {
+      this.assessmentOpportunityService.deleteOpportunity(deleteOpportunity.opportunityIndex, treasureHunt)
     } 
 
     return treasureHunt;

--- a/src/app/treasure-hunt/calculators/opportunity-sheet/general-details-form/general-details-form.component.html
+++ b/src/app/treasure-hunt/calculators/opportunity-sheet/general-details-form/general-details-form.component.html
@@ -14,7 +14,7 @@
       <label for="opportunitySheetEquipment">Equipment</label>
       <!-- <input type="text" class="form-control" [(ngModel)]="opportunitySheet.equipment" name="opportunitySheetEquipment"
         id="opportunitySheetEquipment" (focus)="focusField('opportunitySheetEquipment')"> -->
-      <select class="form-control" [(ngModel)]="opportunitySheet.equipment" name="opportunitySheetEquipment"
+      <select class="form-control" [disabled]="isAssessmentOpportunity" [(ngModel)]="opportunitySheet.equipment" name="opportunitySheetEquipment"
         id="opportunitySheetEquipment" (focus)="focusField('opportunitySheetEquipment')">
         <option *ngFor="let option of processEquipmentOptions" [ngValue]="option.value">{{option.display}}</option>
       </select>

--- a/src/app/treasure-hunt/calculators/opportunity-sheet/general-details-form/general-details-form.component.ts
+++ b/src/app/treasure-hunt/calculators/opportunity-sheet/general-details-form/general-details-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output, OnChanges } from '@angular/core';
 import { OpportunitySheet } from '../../../../shared/models/treasure-hunt';
 import { processEquipmentOptions } from './processEquipmentOptions';
 
@@ -12,13 +12,15 @@ export class GeneralDetailsFormComponent implements OnInit {
   opportunitySheet: OpportunitySheet;
   @Output('emitChangeField')
   emitChangeField = new EventEmitter<string>();
+  @Input()
+  isAssessmentOpportunity: boolean;
 
   processEquipmentOptions: Array<{ value: string, display: string }>;
   constructor() { 
-    this.processEquipmentOptions = processEquipmentOptions;
   }
-
+  
   ngOnInit() {
+    this.processEquipmentOptions = processEquipmentOptions;
   }
 
   focusField(str: string) {

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/energy-use-form/energy-use-form.component.css
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/energy-use-form/energy-use-form.component.css
@@ -1,4 +1,13 @@
+.units.remove-item {
+    margin-left: .5rem;
+    border-left: 1px solid #9c9c9c;
+}
+
 .units.remove-item:hover{
     cursor: pointer;
     background-color: #efefef;
+}
+
+.fa.fa-times {
+    font-size: 16px;
 }

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/energy-use-form/energy-use-form.component.html
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/energy-use-form/energy-use-form.component.html
@@ -4,7 +4,7 @@
     <label class="pl-2">Utility Consumption</label>
   </div>
   <div class="form-group" *ngFor="let energyItem of energyItems; let index = index;">
-    <select class="form-control" [(ngModel)]="energyItem.type" name="{{'type_'+index}}" (change)="save()"
+    <select class="form-control" [(ngModel)]="energyItem.type" name="{{'type_'+index}}" (change)="save()" [disabled]="isAssessmentOpportunity && !allowCreateModifiedEnergy"
       (focus)="focusField('energyUseType')">
       <option [ngValue]="'Electricity'">Electricity</option>
       <option [ngValue]="'Gas'">Gas</option>
@@ -15,15 +15,15 @@
       <option [ngValue]="'WWT'">WWT</option>
     </select>
     <div class="input-group pl-2">
-      <input type="number" class="form-control" [(ngModel)]="energyItem.amount" name="{{'amount_'+index}}"
+      <input type="number" class="form-control" [(ngModel)]="energyItem.amount" name="{{'amount_'+index}}" [disabled]="isAssessmentOpportunity && !allowCreateModifiedEnergy"
         (input)="save()" (focus)="focusField('energyUseAmount')">
       <span class="input-group-addon units" [innerHTML]="getEnergyUnit(energyItem.type) + '/yr'"></span>
-      <span class="input-group-addon units remove-item" (click)="removeEnergyItem(index)">
+      <span class="input-group-addon units remove-item" *ngIf="!isAssessmentOpportunity || allowCreateModifiedEnergy" (click)="removeEnergyItem(index)">
         <span class="fa fa-times"></span>
       </span>
     </div>
   </div>
-  <div class="w-100 text-center p-2">
+  <div *ngIf="!isAssessmentOpportunity || allowCreateModifiedEnergy" class="w-100 text-center p-2">
     <a class="click-link small" (click)="addEnergyField()">+Add Energy Use</a>
   </div>
 </form>

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/energy-use-form/energy-use-form.component.ts
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/energy-use-form/energy-use-form.component.ts
@@ -15,6 +15,11 @@ export class EnergyUseFormComponent implements OnInit {
   emitSave = new EventEmitter<Array<{ type: string, amount: number }>>();
   @Output('emitChangeField')
   emitChangeField = new EventEmitter<string>();
+  @Input()
+  isAssessmentOpportunity: boolean;
+  @Input()
+  allowCreateModifiedEnergy: boolean;
+  
   constructor() { }
 
   ngOnInit() {

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/opportunity-sheet-results/opportunity-sheet-results.component.ts
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/opportunity-sheet-results/opportunity-sheet-results.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { OpportunitySheetResults, OpportunitySheet } from '../../../../shared/models/treasure-hunt';
+import { OpportunitySheetResults, OpportunitySheet, AssessmentOpportunity } from '../../../../shared/models/treasure-hunt';
 
 @Component({
   selector: 'app-opportunity-sheet-results',
@@ -10,7 +10,7 @@ export class OpportunitySheetResultsComponent implements OnInit {
   @Input()
   opportunitySheetResults: OpportunitySheetResults;
   @Input()
-  opportunitySheet: OpportunitySheet;
+  opportunitySheet: OpportunitySheet | AssessmentOpportunity;
   constructor() { }
 
   ngOnInit() {

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/opportunity-sheet.service.ts
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/opportunity-sheet.service.ts
@@ -19,6 +19,7 @@ export class OpportunitySheetService {
       date: new Date(),
       owner: '',
       businessUnits: '',
+      iconString: "assets/images/calculator-icons/opportunity-sheet-icon.png",
       opportunityCost: {
         engineeringServices: 0,
         material: 0,

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/standalone-opportunity-sheet.component.css
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/standalone-opportunity-sheet.component.css
@@ -36,23 +36,11 @@
     background: #efefef;
 }
 
-/* .form-width{
-    width: 60%;
-} */
-
-/* .help-panel{
-    width: 40%;
-}
-
-.help-holder{
-    max-width: 500px;
-} */
-
 .opp-sheet-icon{
     height: 55px;
 }
 
-@media screen and (max-width: 575px) {
+@media screen and (max-width: 1024) {
     .fa-save, .fa-times, .fa-edit {
         font-size: 18px;
     }
@@ -60,4 +48,12 @@
         font-size: 14px !important;
     }
 
+}
+
+.calculator-panel-container.modification {
+    width: 60%;
+}
+
+.calculator-panel-container.help-panel {
+    width: 40%;
 }

--- a/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/standalone-opportunity-sheet.component.html
+++ b/src/app/treasure-hunt/calculators/standalone-opportunity-sheet/standalone-opportunity-sheet.component.html
@@ -32,24 +32,25 @@
   </div>
   <div class="panel-group">
     <div class="calculator-panel-container modification" [ngStyle]="{'height.px': containerHeight}"
-      [ngClass]="{'small-screen-tab': smallScreenTab === 'form'}">
-      <div class="d-flex flex-column m-2">
+      [ngClass]="{'small-screen-tab w-100': smallScreenTab === 'form'}">
+      <div class="d-block m-2">
         <app-general-details-form class="w-100" [(opportunitySheet)]="opportunitySheet"
           (emitChangeField)="changeField($event)"></app-general-details-form>
+
         <div class="col-12">
           <div class="header">
             <h3 class="ml-0">Energy Use</h3>
           </div>
         </div>
-        <div class="d-block d-lg-flex">
-          <div class="p-2">
+
+        <div class="d-block d-lg-flex col-12">
+          <div class="p-2 flex-grow-1">
             <label class="group-label">Baseline</label>
             <app-energy-use-form [(energyItems)]="opportunitySheet.baselineEnergyUseItems" [settings]="settings"
               (emitSave)="saveBaseline($event)" (emitChangeField)="changeField($event)">
             </app-energy-use-form>
           </div>
-          <!-- Modifications Start -->
-          <div class="p-2">
+          <div class="p-2 flex-grow-1">
             <label class="group-label">Modification</label>
             <app-energy-use-form *ngIf="opportunitySheet.modificationEnergyUseItems.length != 0"
               [(energyItems)]="opportunitySheet.modificationEnergyUseItems" [settings]="settings"
@@ -62,9 +63,6 @@
               <button type="button" class="btn btn-primary">Add Modified Condition</button>
               <p>Data will be copied from your current baseline condition.</p>
             </div>
-            <!-- <div class="p-3 w-100 justify-content-center" *ngIf="modificationEnergyUse.length == 0">
-            <button class="btn btn-primary btn-sm" (click)="addModification()">Add Modification</button>
-          </div> -->
           </div>
         </div>
         <app-costs-form class="w-100" [(opportunityCost)]="opportunitySheet.opportunityCost"
@@ -72,7 +70,7 @@
       </div>
     </div>
     <div class="calculator-panel-container help-panel" [ngStyle]="{'height.px': containerHeight}"
-      [ngClass]="{'small-screen-tab': smallScreenTab === 'details'}">
+      [ngClass]="{'small-screen-tab w-100': smallScreenTab === 'details'}">
       <div class="d-flex flex-wrap tabs primary sticky-top">
         <div class="flex-fill panel-tab-item h-100" [ngClass]="{'active': tabSelect == 'results'}">
           <a class="border-left-0 h-100 d-flex justify-content-center align-items-center" (click)="setTab('results')">

--- a/src/app/treasure-hunt/convert-input-data.service.ts
+++ b/src/app/treasure-hunt/convert-input-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { TreasureHunt, OpportunitySheet, EnergyUseItem, EnergyUsage, HeatCascadingTreasureHunt,  } from '../shared/models/treasure-hunt';
+import { TreasureHunt, OpportunitySheet, EnergyUseItem, EnergyUsage, HeatCascadingTreasureHunt, AssessmentOpportunity,  } from '../shared/models/treasure-hunt';
 import { ConvertUnitsService } from '../shared/convert-units/convert-units.service';
 import { Settings } from '../shared/models/settings';
 import { AirLeakTreasureHuntService } from './treasure-hunt-calculator-services/air-leak-treasure-hunt.service';
@@ -59,7 +59,12 @@ export class ConvertInputDataService {
   convertTreasureHuntInputData(treasureHunt: TreasureHunt, oldSettings: Settings, newSettings: Settings): TreasureHunt {
     //no conversion for lighting needed..
     if (treasureHunt.opportunitySheets != undefined) {
-      treasureHunt.opportunitySheets = this.convertOpportunitySheets(treasureHunt.opportunitySheets, oldSettings, newSettings);
+      let opportunitySheets = this.convertCustomOpportunity(treasureHunt.opportunitySheets, oldSettings, newSettings);
+      treasureHunt.opportunitySheets = opportunitySheets as OpportunitySheet[];
+    }
+    if (treasureHunt.assessmentOpportunities != undefined) {
+      let assessmentOpportunities = this.convertCustomOpportunity(treasureHunt.assessmentOpportunities, oldSettings, newSettings);
+      treasureHunt.assessmentOpportunities = assessmentOpportunities as AssessmentOpportunity[];
     }
     if (treasureHunt.replaceExistingMotors != undefined) {
       treasureHunt.replaceExistingMotors = this.replaceExistingTreasureService.convertReplaceExistingMotors(treasureHunt.replaceExistingMotors, oldSettings, newSettings);
@@ -134,7 +139,7 @@ export class ConvertInputDataService {
   }
 
 
-  convertOpportunitySheets(opportunitySheets: Array<OpportunitySheet>, oldSettings: Settings, newSettings: Settings): Array<OpportunitySheet> {
+  convertCustomOpportunity(opportunitySheets: Array<OpportunitySheet | AssessmentOpportunity>, oldSettings: Settings, newSettings: Settings): Array<OpportunitySheet | AssessmentOpportunity> {
     opportunitySheets.forEach(sheet => {
       sheet.baselineEnergyUseItems.forEach(item => {
         item = this.convertEnergyUseItem(item, oldSettings, newSettings);
@@ -148,7 +153,7 @@ export class ConvertInputDataService {
 
   convertEnergyUseItem(energyUseItem: EnergyUseItem, oldSettings: Settings, newSettings: Settings): EnergyUseItem {
     if (energyUseItem.type == 'Gas' || energyUseItem.type == 'Other Fuel') {
-      //imperial: MMBtu, metric: MJ
+      //imperial: MMBtu, metric: GJ
       energyUseItem.amount = this.convertUnitsService.convertMMBtuAndGJValue(energyUseItem.amount, oldSettings, newSettings);
     } else if (energyUseItem.type == 'Water' || energyUseItem.type == 'WWT') {
       //imperial: gal, metric: L 

--- a/src/app/treasure-hunt/find-treasure/find-treasure.component.html
+++ b/src/app/treasure-hunt/find-treasure/find-treasure.component.html
@@ -440,6 +440,19 @@
         </p>
       </div>
     </div>
+
+    <div class="card calc-card-item m-2" (click)="openCalculator('assessment-opportunity')">
+      <div class="card-body d-flex flex-sm-column p-2 align-items-center">
+        <div class="calc-icon d-flex justify-content-center align-items-center">
+          <img src="assets/images/app-icon.png" class="calc-img">
+        </div>
+        <a class="pt-2">Assessment Opportunity</a>
+        <p class="mb-0 text-center help-text d-none d-sm-flex">
+          Create a Treasure Hunt Opportunity from an existing assessment. Baseline and Modification Utility use will be used to calculate savings.
+        </p>
+      </div>
+    </div>
+
   </div>
 </div>
 

--- a/src/app/treasure-hunt/operation-costs/operation-costs.component.ts
+++ b/src/app/treasure-hunt/operation-costs/operation-costs.component.ts
@@ -169,7 +169,7 @@ export class OperationCostsComponent implements OnInit {
 
   save() {
     if (this.treasureHuntResults){
-      this.treasureHuntResults.co2EmissionsResults = this.treasureHuntReportService.getCO2EmissionsResults(this.treasureHunt.currentEnergyUsage, this.treasureHuntResults, this.settings);
+      this.treasureHuntResults.co2EmissionsResults = this.treasureHuntReportService.getCO2EmissionsResults(this.treasureHunt, this.treasureHuntResults, this.settings);
     }   
     this.treasureHuntService.treasureHunt.next(this.treasureHunt);
   }

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.html
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.html
@@ -86,7 +86,7 @@
         <div class="col-12 col-lg-2 pr-0">
           <div class="d-none d-lg-flex flex-column h-100 align-items-center w-100 justify-content-center">
             <div class="d-flex flex-column w-100 align-items-center"
-              *ngIf="cardData.opportunityType != 'opportunity-sheet'"
+              *ngIf="cardData.opportunityType != 'opportunity-sheet' && cardData.opportunityType != 'assessment-opportunity'"
               [ngClass]="{'no-opp-sheet': !cardData.opportunitySheet,'opp-sheet-exists': cardData.opportunitySheet }"
               (click)="editOpportunitySheet(cardData)">
               <img src="assets/images/calculator-icons/opportunity-sheet-icon.png" class="edit-sheet-icon" />
@@ -99,14 +99,6 @@
             <a class="click-link danger" (click)="setDeleteOpportunity(cardData)">Delete</a>
           </div>
           <div class="d-flex d-lg-none h-100 w-100 justify-content-center">
-            <!-- <div class="d-flex flex-column w-100 align-items-center"
-              *ngIf="cardData.opportunityType != 'opportunity-sheet'"
-              [ngClass]="{'no-opp-sheet': !cardData.opportunitySheet,'opp-sheet-exists': cardData.opportunitySheet }"
-              (click)="editOpportunitySheet(cardData)">
-              <img src="assets/images/calculator-icons/opportunity-sheet-icon.png" class="calc-icon" />
-              <a class="text-center" *ngIf="!cardData.opportunitySheet">Add Opportunity Sheet</a>
-              <a class="text-center" *ngIf="cardData.opportunitySheet">Edit Opportunity Sheet</a>
-            </div> -->
             <div class="px-1" (click)="editOpportunitySheet(cardData)">
               <img src="assets/images/calculator-icons/opportunity-sheet-icon.png" class="edit-sheet-icon pull-right" />
             </div>

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
@@ -144,6 +144,12 @@ export class OpportunityCardsComponent implements OnInit {
     this.showOpportunitySheetModal();
   }
 
+  editAssessmentOpportunity(cardData: OpportunityCardData) {
+    this.modifyDataIndex = cardData.index;
+    this.editOpportunitySheetCardData = cardData;
+    this.showOpportunitySheetModal();
+  }
+
   showOpportunitySheetModal() {
     this.opportunitySheetModal.show();
   }

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.service.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { TreasureHunt, LightingReplacementTreasureHunt, OpportunitySheet, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt, CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, EnergyUsage, OpportunitySheetResults, OpportunitySummary, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, WallLossTreasureHunt, EnergySourceData, FlueGasTreasureHunt, LeakageLossTreasureHunt, OpeningLossTreasureHunt, WasteHeatTreasureHunt, HeatCascadingTreasureHunt, WaterHeatingTreasureHunt, AirHeatingTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ChillerStagingTreasureHunt, ChillerPerformanceTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerBasinTreasureHunt } from '../../../shared/models/treasure-hunt';
+import { TreasureHunt, LightingReplacementTreasureHunt, OpportunitySheet, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt, CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, EnergyUsage, OpportunitySheetResults, OpportunitySummary, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, WallLossTreasureHunt, EnergySourceData, FlueGasTreasureHunt, LeakageLossTreasureHunt, OpeningLossTreasureHunt, WasteHeatTreasureHunt, HeatCascadingTreasureHunt, WaterHeatingTreasureHunt, AirHeatingTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ChillerStagingTreasureHunt, ChillerPerformanceTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerBasinTreasureHunt, AssessmentOpportunity, AssessmentOpportunityResults, Treasure } from '../../../shared/models/treasure-hunt';
 import *  as _ from 'lodash';
 import { Settings } from '../../../shared/models/settings';
 import { ConvertUnitsService } from '../../../shared/convert-units/convert-units.service';
@@ -31,6 +31,7 @@ import { ChillerStagingTreasureHuntService } from '../../treasure-hunt-calculato
 import { ChillerPerformanceTreasureHuntService } from '../../treasure-hunt-calculator-services/chiller-performance-treasure-hunt.service';
 import { CoolingTowerFanTreasureHuntService } from '../../treasure-hunt-calculator-services/cooling-tower-fan-treasure-hunt.service';
 import { CoolingTowerBasinTreasureHuntService } from '../../treasure-hunt-calculator-services/cooling-tower-basin-treasure-hunt.service';
+import { AssessmentOpportunityService } from '../../treasure-hunt-calculator-services/assessment-opportunity.service';
 
 @Injectable()
 export class OpportunityCardsService {
@@ -38,8 +39,8 @@ export class OpportunityCardsService {
   updatedOpportunityCard: BehaviorSubject<OpportunityCardData>;
   opportunityCards: BehaviorSubject<Array<OpportunityCardData>>;
   updateOpportunityCards: BehaviorSubject<boolean>;
-  currCurrency: string = "$"; 
-  constructor(private opportunitySheetService: OpportunitySheetService, 
+  currCurrency: string = "$";
+  constructor(private opportunitySheetService: OpportunitySheetService,
     private opportunitySummaryService: OpportunitySummaryService,
     private airLeakTreasureService: AirLeakTreasureHuntService,
     private tankInsulationTreasureHuntService: TankInsulationTreasureHuntService,
@@ -64,10 +65,11 @@ export class OpportunityCardsService {
     private waterHeatingTreasureHuntService: WaterHeatingTreasureHuntService,
     private coolingTowerMakeupTreasureHuntService: CoolingTowerMakeupTreasureHuntService,
     private chillerStagingTreasureHuntService: ChillerStagingTreasureHuntService,
-    private chillerPerformanceTreasureHuntService : ChillerPerformanceTreasureHuntService,
+    private chillerPerformanceTreasureHuntService: ChillerPerformanceTreasureHuntService,
     private coolingTowerFanTreasureHuntService: CoolingTowerFanTreasureHuntService,
-    private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService
-    ) {
+    private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService,
+    private assessmentOpportunityService: AssessmentOpportunityService
+  ) {
     this.updatedOpportunityCard = new BehaviorSubject<OpportunityCardData>(undefined);
     this.opportunityCards = new BehaviorSubject(new Array());
     this.updateOpportunityCards = new BehaviorSubject<boolean>(true);
@@ -83,7 +85,6 @@ export class OpportunityCardsService {
     let compressedAirReductionData: Array<OpportunityCardData> = this.getCompressedAirReductions(treasureHunt.compressedAirReductions, treasureHunt.currentEnergyUsage, settings);
     let compressedAirPressureReductionData: Array<OpportunityCardData> = this.getCompressedAirPressureReductions(treasureHunt.compressedAirPressureReductions, treasureHunt.currentEnergyUsage, settings);
     let waterReductionData: Array<OpportunityCardData> = this.getWaterReductions(treasureHunt.waterReductions, treasureHunt.currentEnergyUsage, settings);
-    let standaloneOpportunitySheetData: Array<OpportunityCardData> = this.getStandaloneOpportunitySheets(treasureHunt.opportunitySheets, treasureHunt.currentEnergyUsage, settings)
     let steamReductionData: Array<OpportunityCardData> = this.getSteamReductions(treasureHunt.steamReductions, treasureHunt.currentEnergyUsage, settings);
     let pipeInsulationReductionData: Array<OpportunityCardData> = this.getPipeInsulationReductions(treasureHunt.pipeInsulationReductions, treasureHunt.currentEnergyUsage, settings);
     let tankInsulationReductionData: Array<OpportunityCardData> = this.getTankInsulationReductions(treasureHunt.tankInsulationReductions, treasureHunt.currentEnergyUsage, settings);
@@ -102,19 +103,22 @@ export class OpportunityCardsService {
     let coolingTowerFan: Array<OpportunityCardData> = this.getCoolingTowerFanOpportunities(treasureHunt.coolingTowerFanOpportunities, treasureHunt.currentEnergyUsage, settings);
     let coolingTowerBasin: Array<OpportunityCardData> = this.getCoolingTowerBasinOpportunities(treasureHunt.coolingTowerBasinOpportunities, treasureHunt.currentEnergyUsage, settings);
 
+    let standaloneOpportunitySheetData: Array<OpportunityCardData> = this.getStandaloneOpportunitySheets(treasureHunt.opportunitySheets, treasureHunt.currentEnergyUsage, settings)
+    let assessmentOpportunityData: Array<OpportunityCardData> = this.getAssessmentOpportunities(treasureHunt.assessmentOpportunities, treasureHunt.currentEnergyUsage, settings)
+
     opportunityCardsData = _.union(
-      lightingReplacementsCardData, 
-      replaceExistingData, 
-      naturalGasReductionData, 
-      electricityReductionData, 
-      compressedAirReductionData, 
-      compressedAirPressureReductionData, 
-      waterReductionData, 
-      standaloneOpportunitySheetData, 
-      steamReductionData, 
-      motorDrivesCardData, 
-      pipeInsulationReductionData, 
-      tankInsulationReductionData, 
+      lightingReplacementsCardData,
+      replaceExistingData,
+      naturalGasReductionData,
+      electricityReductionData,
+      compressedAirReductionData,
+      compressedAirPressureReductionData,
+      waterReductionData,
+      standaloneOpportunitySheetData,
+      steamReductionData,
+      motorDrivesCardData,
+      pipeInsulationReductionData,
+      tankInsulationReductionData,
       airLeakSurveyData,
       openingLossData,
       wallLossData,
@@ -128,8 +132,9 @@ export class OpportunityCardsService {
       chillerStaging,
       chillerPerformance,
       coolingTowerFan,
-      coolingTowerBasin
-      );
+      coolingTowerBasin,
+      assessmentOpportunityData
+    );
     let index: number = 0;
     opportunityCardsData.forEach(card => {
       card.index = index;
@@ -140,11 +145,10 @@ export class OpportunityCardsService {
         card.percentSavings.forEach(saving => {
           saving.baselineCost = this.convertUnitsService.convertValue(saving.baselineCost, this.currCurrency, settings.currency);
           saving.modificationCost = this.convertUnitsService.convertValue(saving.modificationCost, this.currCurrency, settings.currency);
-        }); 
+        });
       }
     });
-    // this.currCurrency = settings.currency;
-    // this.opportunityCards.next(opportunityCardsData);
+
 
     return opportunityCardsData;
   }
@@ -171,6 +175,7 @@ export class OpportunityCardsService {
       let index: number = 0;
       opportunitySheets.forEach(oppSheet => {
         let cardData: OpportunityCardData = this.getOpportunitySheetCardData(oppSheet, settings, index, currentEnergyUsage);
+        cardData.opportunityType = Treasure.opportunitySheet;
         opportunityCardsData.push(cardData);
         index++;
       })
@@ -178,24 +183,80 @@ export class OpportunityCardsService {
     return opportunityCardsData;
   }
 
-  getOpportunitySheetCardData(oppSheet: OpportunitySheet, settings: Settings, index: number, currentEnergyUsage: EnergyUsage): OpportunityCardData {
-    let results: OpportunitySheetResults = this.opportunitySheetService.getResults(oppSheet, settings);
-    let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getOpportunitySheetSummary(oppSheet, settings);
+  getAssessmentOpportunities(assessmentOpportunities: Array<AssessmentOpportunity>, currentEnergyUsage: EnergyUsage, settings: Settings): Array<OpportunityCardData> {
+    let opportunityCardsData: Array<OpportunityCardData> = new Array();
+    if (assessmentOpportunities) {
+      let index: number = 0;
+      assessmentOpportunities.forEach(opp => {
+        let results: OpportunitySheetResults = this.assessmentOpportunityService.getResults(opp, settings);
+        let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getOpportunitySheetSummary(opp, settings);
+        let energyData = this.getOpportunitySheetEnergySavings(results, currentEnergyUsage, settings);
+        let cardData: OpportunityCardData = {
+          implementationCost: opportunitySummary.totalCost,
+          paybackPeriod: opportunitySummary.payback,
+          selected: opp.selected,
+          opportunityType: Treasure.assessmentOpportunity,
+          assessmentOpportunity: opp,
+          opportunityIndex: index,
+          annualCostSavings: results.totalCostSavings,
+          annualEnergySavings: energyData.annualEnergySavings,
+          percentSavings: energyData.percentSavings,
+          opportunitySheet: opp as OpportunitySheet,
+          name: opportunitySummary.opportunityName,
+          iconString: opp.iconString,
+          utilityType: energyData.utilityTypes,
+          teamName: this.getTeamName(opp)
+        }
+        opportunityCardsData.push(cardData);
+        index++;
+      })
+    }
+
+    return opportunityCardsData;
+  }
+
+
+  getOpportunitySheetCardData(opportunity: OpportunitySheet, settings: Settings, index: number, currentEnergyUsage: EnergyUsage): OpportunityCardData {
+    let results: OpportunitySheetResults = this.opportunitySheetService.getResults(opportunity, settings);
+    let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getOpportunitySheetSummary(opportunity, settings);
     let energyData = this.getOpportunitySheetEnergySavings(results, currentEnergyUsage, settings);
     let cardData: OpportunityCardData = {
       implementationCost: opportunitySummary.totalCost,
       paybackPeriod: opportunitySummary.payback,
-      selected: oppSheet.selected,
-      opportunityType: 'opportunity-sheet',
+      selected: opportunity.selected,
+      opportunityType: Treasure.opportunitySheet,
       opportunityIndex: index,
       annualCostSavings: results.totalCostSavings,
       annualEnergySavings: energyData.annualEnergySavings,
       percentSavings: energyData.percentSavings,
-      opportunitySheet: oppSheet,
+      opportunitySheet: opportunity,
       name: opportunitySummary.opportunityName,
-      iconString: 'assets/images/calculator-icons/opportunity-sheet-icon.png',
+      iconString: opportunity.iconString,
       utilityType: energyData.utilityTypes,
-      teamName: this.getTeamName(oppSheet)
+      teamName: this.getTeamName(opportunity)
+    }
+    return cardData;
+  }
+
+  getAssessmentOpportunityCardData(opportunity: AssessmentOpportunity, settings: Settings, index: number, currentEnergyUsage: EnergyUsage): OpportunityCardData {
+    let results: AssessmentOpportunityResults = this.assessmentOpportunityService.getResults(opportunity, settings);
+    let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getOpportunitySheetSummary(opportunity, settings);
+    let energyData = this.getOpportunitySheetEnergySavings(results, currentEnergyUsage, settings);
+    let cardData: OpportunityCardData = {
+      implementationCost: opportunitySummary.totalCost,
+      paybackPeriod: opportunitySummary.payback,
+      selected: opportunity.selected,
+      opportunityType: Treasure.assessmentOpportunity,
+      opportunityIndex: index,
+      annualCostSavings: results.totalCostSavings,
+      annualEnergySavings: energyData.annualEnergySavings,
+      percentSavings: energyData.percentSavings,
+      assessmentOpportunity: opportunity,
+      opportunitySheet: opportunity as OpportunitySheet,
+      name: opportunitySummary.opportunityName,
+      iconString: opportunity.iconString,
+      utilityType: energyData.utilityTypes,
+      teamName: this.getTeamName(opportunity)
     }
     return cardData;
   }
@@ -735,15 +796,11 @@ export interface OpportunityCardData {
     label: string,
     energyUnit: string
   }>;
-  percentSavings: Array<{
-    percent: number,
-    label: string,
-    baselineCost: number,
-    modificationCost: number,
-  }>;
+  percentSavings: Array<PercentEnergySavings>;
   utilityType: Array<string>;
   name: string;
   opportunitySheet: OpportunitySheet,
+  assessmentOpportunity?: AssessmentOpportunity;
   iconString: string,
   lightingReplacement?: LightingReplacementTreasureHunt;
   opportunitySheets?: OpportunitySheet;
@@ -773,4 +830,11 @@ export interface OpportunityCardData {
   coolingTowerBasin?: CoolingTowerBasinTreasureHunt;
   iconCalcType?: string;
   needBackground?: boolean;
+}
+
+export interface PercentEnergySavings {
+  percent: number,
+  label: string,
+  baselineCost: number,
+  modificationCost: number,
 }

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/sort-cards.service.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/sort-cards.service.ts
@@ -5,7 +5,7 @@ import { SortCardsData } from './sort-cards-by.pipe';
 import * as _ from 'lodash';
 import {
   TreasureHunt, LightingReplacementTreasureHunt, OpportunitySheet, ReplaceExistingMotorTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, ElectricityReductionTreasureHunt,
-  CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, FlueGasTreasureHunt, WallLossTreasureHunt, OpportunitySummary, Treasure, LeakageLossTreasureHunt, OpeningLossTreasureHunt, WasteHeatTreasureHunt, HeatCascadingTreasureHunt, WaterHeatingTreasureHunt, AirHeatingTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ChillerStagingTreasureHunt, ChillerPerformanceTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerBasinTreasureHunt
+  CompressedAirReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, WaterReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, FlueGasTreasureHunt, WallLossTreasureHunt, OpportunitySummary, Treasure, LeakageLossTreasureHunt, OpeningLossTreasureHunt, WasteHeatTreasureHunt, HeatCascadingTreasureHunt, WaterHeatingTreasureHunt, AirHeatingTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ChillerStagingTreasureHunt, ChillerPerformanceTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerBasinTreasureHunt, AssessmentOpportunity
 } from '../../../shared/models/treasure-hunt';
 import { Settings } from '../../../shared/models/settings';
 
@@ -110,6 +110,7 @@ export class SortCardsService {
     let allCalcTypes = calculatorTypes.length == 0;
     let hasLightingReplacement = calculatorTypes.includes(Treasure.lightingReplacement);
     let hasOppSheet: boolean = calculatorTypes.includes(Treasure.opportunitySheet);
+    let hasAssessmentOpportunities: boolean = calculatorTypes.includes(Treasure.assessmentOpportunity);
     let hasReplaceExisting: boolean = calculatorTypes.includes(Treasure.replaceExisting);
     let hasMotorDrive: boolean = calculatorTypes.includes(Treasure.motorDrive);
     let hasNaturalGasReduction: boolean = calculatorTypes.includes(Treasure.naturalGasReduction);
@@ -145,6 +146,12 @@ export class SortCardsService {
     if (allCalcTypes || hasOppSheet) {
       if (treasureHunt.opportunitySheets && treasureHunt.opportunitySheets.length != 0) {
         opportunitySheets = this.sortOpportunitySheets(treasureHunt.opportunitySheets, sortBy, treasureHunt, settings);
+      }
+    }
+    let assessmentOpportunities: Array<AssessmentOpportunity> = [];
+    if (allCalcTypes || hasAssessmentOpportunities) {
+      if (treasureHunt.assessmentOpportunities && treasureHunt.assessmentOpportunities.length != 0) {
+        assessmentOpportunities = this.sortAssessmentOpportunities(treasureHunt.assessmentOpportunities, sortBy, treasureHunt, settings);
       }
     }
     let replaceExistingMotors: Array<ReplaceExistingMotorTreasureHunt> = [];
@@ -296,6 +303,7 @@ export class SortCardsService {
       name: treasureHunt.name,
       lightingReplacements: lightingReplacements,
       opportunitySheets: opportunitySheets,
+      assessmentOpportunities: assessmentOpportunities,
       replaceExistingMotors: replaceExistingMotors,
       motorDrives: motorDrives,
       naturalGasReductions: naturalGasReductions,
@@ -367,8 +375,14 @@ export class SortCardsService {
 
   sortOpportunitySheets(items: Array<OpportunitySheet>, sortBy: SortCardsData, treasureHunt: TreasureHunt, settings: Settings): Array<OpportunitySheet> {
     return items.filter(item => {
-      // let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getIndividualOpportunitySummary(item, settings);
       let cardItem: OpportunityCardData = this.opportunityCardsService.getOpportunitySheetCardData(item, settings, 0, treasureHunt.currentEnergyUsage);
+      return this.checkCardItemIncluded(cardItem, sortBy);
+    });
+  }
+
+  sortAssessmentOpportunities(items: Array<AssessmentOpportunity>, sortBy: SortCardsData, treasureHunt: TreasureHunt, settings: Settings): Array<AssessmentOpportunity> {
+    return items.filter(item => {
+      let cardItem: OpportunityCardData = this.opportunityCardsService.getAssessmentOpportunityCardData(item, settings, 0, treasureHunt.currentEnergyUsage);
       return this.checkCardItemIncluded(cardItem, sortBy);
     });
   }

--- a/src/app/treasure-hunt/treasure-chest/summary-card/summary-card.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/summary-card/summary-card.component.ts
@@ -101,19 +101,22 @@ export class SummaryCardComponent implements OnInit {
   }
 
 
-  setUtilityTotal(utilityUsed: boolean, baselineCost: number, utilityType: string): UtilityTotal {
+  setUtilityTotal(utilityUsed: boolean, baselineTHCost: number, utilityType: string): UtilityTotal {
     let opportunityCards: Array<OpportunityCardData> = this.opportunityCards;
     opportunityCards = this.sortCardsService.sortCards(opportunityCards, this.sortCardsData);
     if (utilityUsed) {
-      let utilityData: UtilityTotal = this.getSavingsByUtilityType(opportunityCards, utilityType);
+      let treasureHuntCards: Array<OpportunityCardData> = _.filter(opportunityCards, (card) => { 
+          return _.includes(card.utilityType, utilityType);
+      });
+      let utilityTotals: UtilityTotal = this.getCardSavingsByUtilityType(treasureHuntCards, utilityType);
       if (this.currCurrency !== this.settings.currency) {
-        baselineCost = this.convertUnitsService.convertValue(baselineCost, this.currCurrency, this.settings.currency);
+        baselineTHCost = this.convertUnitsService.convertValue(baselineTHCost, this.currCurrency, this.settings.currency);
       }
       return {
-        baselineCost: baselineCost,
-        modificationCost: baselineCost - utilityData.totalCostSavings,
-        totalCostSavings: utilityData.totalCostSavings,
-        totalPercentSavings: utilityData.totalPercentSavings
+        baselineCost: baselineTHCost,
+        modificationCost: baselineTHCost - utilityTotals.totalCostSavings,
+        totalCostSavings: utilityTotals.totalCostSavings,
+        totalPercentSavings: utilityTotals.totalPercentSavings
       }
     } else {
       return {
@@ -126,13 +129,12 @@ export class SummaryCardComponent implements OnInit {
   }
 
 
-  getSavingsByUtilityType(opportunityCards: Array<OpportunityCardData>, utilityType: string): UtilityTotal {
-    let filteredCards: Array<OpportunityCardData> = _.filter(opportunityCards, (data) => { return _.includes(data.utilityType, utilityType) });
+  getCardSavingsByUtilityType(opportunityCards: Array<OpportunityCardData>, utilityType: string): UtilityTotal {
     let totalPercentSavings: number = 0;
     let totalCostSavings: number = 0;
     let baselineCost: number = 0;
     let modificationCost: number = 0;
-    filteredCards.forEach(card => {
+    opportunityCards.forEach(card => {
       if (card.selected == true) {
         let percentSavings = _.find(card.percentSavings, (card) => { return card.label == utilityType });
         if (percentSavings) {
@@ -150,7 +152,6 @@ export class SummaryCardComponent implements OnInit {
     let additionalAnnualSavings: number = 0;
     opportunityCards.forEach(card => {
       if (card.selected && card.opportunitySheet.opportunityCost.additionalAnnualSavings) {
-
         additionalAnnualSavings += card.opportunitySheet.opportunityCost.additionalAnnualSavings.cost;
       }
     });

--- a/src/app/treasure-hunt/treasure-chest/treasure-chest-menu/calculator-type-dropdown/calculator-type-dropdown.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/treasure-chest-menu/calculator-type-dropdown/calculator-type-dropdown.component.ts
@@ -88,6 +88,8 @@ export class CalculatorTypeDropdownComponent implements OnInit {
         return 'Lighting Replacement';
       case Treasure.opportunitySheet:
         return 'Opportunity Sheet';
+      case Treasure.assessmentOpportunity:
+        return 'Assessment Opportunity';
       case Treasure.replaceExisting:
         return 'Replace Existing Motor';
       case Treasure.motorDrive:

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/assessment-opportunity.service.spec.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/assessment-opportunity.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AssessmentOpportunityService } from './assessment-opportunity.service';
+
+describe('AssessmentOpportunityService', () => {
+  let service: AssessmentOpportunityService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AssessmentOpportunityService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/assessment-opportunity.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/assessment-opportunity.service.ts
@@ -1,0 +1,151 @@
+import { Injectable } from '@angular/core';
+import { AssessmentOpportunity, AssessmentOpportunityResult, AssessmentOpportunityResults, EnergyUsage, EnergyUseItem, OpportunityCost, OpportunitySheetResults, OpportunitySummary, Treasure, TreasureHunt } from '../../shared/models/treasure-hunt';
+import { Settings } from '../../shared/models/settings';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AssessmentOpportunityService {
+
+  defaultSheetName: string = 'New Opportunity';
+  assessmentOpportunity: AssessmentOpportunity;
+  constructor() { }
+  
+  initAssessmentOpportunity(): AssessmentOpportunity {
+    return {
+      name: this.defaultSheetName,
+      equipment: 'pump',
+      description: '',
+      originator: '',
+      date: new Date(),
+      owner: '',
+      businessUnits: '',
+      iconString: 'assets/images/app-icon.png',
+      opportunityCost: {
+        engineeringServices: 0,
+        material: 0,
+        otherCosts: [],
+        costDescription: '',
+        labor: 0,
+        additionalSavings: undefined
+      },
+      baselineEnergyUseItems: [{
+        type: 'Electricity',
+        amount: 0
+      }],
+      modificationEnergyUseItems: [],
+      opportunityType: Treasure.assessmentOpportunity,
+      existingIntegrationData: undefined
+    };
+  }
+
+  getResults(assessmentOpportunity: AssessmentOpportunity, settings: Settings): AssessmentOpportunityResults {
+    let baselineElectricityResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'Electricity');
+    let modificationElectricityResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'Electricity');
+    let electricityResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineElectricityResult, modificationElectricityResult);
+
+    let baselineGasResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'Gas');
+    let modificationGasResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'Gas');
+    let gasResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineGasResult, modificationGasResult);
+
+    let baselineCompressedAirResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'Compressed Air');
+    let modificationCompressedAirResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'Compressed Air');
+    let compressedAirResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineCompressedAirResult, modificationCompressedAirResult);
+
+    let baselineOtherFuelResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'Other Fuel');
+    let modificationOtherFuelResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'Other Fuel');
+    let otherFuelResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineOtherFuelResult, modificationOtherFuelResult);
+
+    let baselineSteamResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'Steam');
+    let modificationSteamResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'Steam');
+    let steamResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineSteamResult, modificationSteamResult);
+
+    let baselineWaterResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'Water');
+    let modificationWaterResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'Water');
+    let waterResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineWaterResult, modificationWaterResult);
+
+    let baselineWasterWaterResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.baselineEnergyUseItems, 'WWT');
+    let modificationWasteWaterResult: { energyUse: number, energyCost: number, numItems: number } = this.getEnergyUseData(assessmentOpportunity.modificationEnergyUseItems, 'WWT');
+    let wasteWaterResults: AssessmentOpportunityResult = this.getAssessmentOpportunityResult(baselineWasterWaterResult, modificationWasteWaterResult);
+
+    let totalCostSavings: number = electricityResults.energyCostSavings + gasResults.energyCostSavings + compressedAirResults.energyCostSavings + otherFuelResults.energyCostSavings + steamResults.energyCostSavings + waterResults.energyCostSavings + wasteWaterResults.energyCostSavings;
+    let totalImplementationCost: number = this.getOppSheetImplementationCost(assessmentOpportunity.opportunityCost);
+    
+    return {
+      electricityResults: electricityResults,
+      gasResults: gasResults,
+      compressedAirResults: compressedAirResults,
+      otherFuelResults: otherFuelResults,
+      steamResults: steamResults,
+      waterResults: waterResults,
+      wasteWaterResults: wasteWaterResults,
+      totalEnergySavings: 0,
+      totalCostSavings: totalCostSavings,
+      totalImplementationCost: totalImplementationCost
+    };
+  }
+
+  getEnergyUseData(oppItems: Array<EnergyUseItem>, type: string): { energyUse: number, energyCost: number, numItems: number } {
+    let items: Array<EnergyUseItem> = oppItems.filter(item => { return item.type == type });
+    let energyUse: number = 0;
+    let integratedCost: number = 0;
+    let numItems: number = 0;
+    if (items) {
+      items.forEach(item => {
+        energyUse = energyUse + item.amount;
+        integratedCost = integratedCost + item.integratedEnergyCost? item.integratedEnergyCost : 0;
+      });
+      numItems = items.length;
+    }
+
+    let energyData =  {
+      energyUse: energyUse,
+      energyCost: integratedCost,
+      numItems: numItems
+    }
+    return energyData;
+  }
+
+  getAssessmentOpportunityResult(baseline: { energyUse: number, energyCost: number, numItems: number }, modification: { energyUse: number, energyCost: number, numItems: number }): AssessmentOpportunityResult {
+    return {
+      baselineEnergyUse: baseline.energyUse,
+      baselineEnergyCost: baseline.energyCost,
+      baselineItems: baseline.numItems,
+      modificationEnergyUse: modification.energyUse,
+      modificationEnergyCost: modification.energyCost,
+      modificationItems: modification.numItems,
+      energySavings: baseline.energyUse - modification.energyUse,
+      energyCostSavings: baseline.energyCost - modification.energyCost
+    }
+  }
+
+  getOppSheetImplementationCost(opportunityCost: OpportunityCost): number {
+    let implementationCost: number = 0;
+    if (opportunityCost) {
+      implementationCost = implementationCost + opportunityCost.engineeringServices + opportunityCost.labor + opportunityCost.material;
+      if (opportunityCost.otherCosts) {
+        opportunityCost.otherCosts.forEach(cost => {
+          implementationCost = implementationCost + cost.cost;
+        })
+      }
+      if (opportunityCost.additionalSavings) {
+        implementationCost = implementationCost - opportunityCost.additionalSavings.cost;
+      }
+    }
+    return implementationCost;
+  }
+
+  saveTreasureHuntOpportunity(assessmentOpportunity: AssessmentOpportunity, treasureHunt: TreasureHunt): TreasureHunt {
+    if (!treasureHunt.assessmentOpportunities) {
+      treasureHunt.assessmentOpportunities = new Array();
+    }
+    treasureHunt.assessmentOpportunities.push(assessmentOpportunity);
+    return treasureHunt;
+  }
+ 
+  deleteOpportunity(index: number, treasureHunt: TreasureHunt): TreasureHunt {
+    treasureHunt.assessmentOpportunities.splice(index, 1);
+    return treasureHunt;
+  }
+
+}

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/treasure-hunt-opportunity.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/treasure-hunt-opportunity.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Settings } from '../../shared/models/settings';
-import { AirHeatingTreasureHunt, AirLeakSurveyTreasureHunt, ChillerPerformanceTreasureHunt, ChillerStagingTreasureHunt, CompressedAirPressureReductionTreasureHunt, CompressedAirReductionTreasureHunt, CoolingTowerBasinTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ElectricityReductionTreasureHunt, FlueGasTreasureHunt, HeatCascadingTreasureHunt, LeakageLossTreasureHunt, LightingReplacementTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, OpeningLossTreasureHunt, OpportunitySheet, OpportunitySummary, PipeInsulationReductionTreasureHunt, ReplaceExistingMotorTreasureHunt, SteamReductionTreasureHunt, TankInsulationReductionTreasureHunt, Treasure, TreasureHunt, TreasureHuntOpportunity, WallLossTreasureHunt, WasteHeatTreasureHunt, WaterHeatingTreasureHunt, WaterReductionTreasureHunt } from '../../shared/models/treasure-hunt';
+import { AirHeatingTreasureHunt, AirLeakSurveyTreasureHunt, AssessmentOpportunity, ChillerPerformanceTreasureHunt, ChillerStagingTreasureHunt, CompressedAirPressureReductionTreasureHunt, CompressedAirReductionTreasureHunt, CoolingTowerBasinTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ElectricityReductionTreasureHunt, FlueGasTreasureHunt, HeatCascadingTreasureHunt, LeakageLossTreasureHunt, LightingReplacementTreasureHunt, MotorDriveInputsTreasureHunt, NaturalGasReductionTreasureHunt, OpeningLossTreasureHunt, OpportunitySheet, OpportunitySummary, PipeInsulationReductionTreasureHunt, ReplaceExistingMotorTreasureHunt, SteamReductionTreasureHunt, TankInsulationReductionTreasureHunt, Treasure, TreasureHunt, TreasureHuntOpportunity, WallLossTreasureHunt, WasteHeatTreasureHunt, WaterHeatingTreasureHunt, WaterReductionTreasureHunt } from '../../shared/models/treasure-hunt';
 import { CalculatorsService } from '../calculators/calculators.service';
 import { OpportunityCardData, OpportunityCardsService } from '../treasure-chest/opportunity-cards/opportunity-cards.service';
 import { OpportunitySummaryService } from '../treasure-hunt-report/opportunity-summary.service';
@@ -31,6 +31,7 @@ import { WaterReductionTreasureHuntService } from './water-reduction-treasure-hu
 import { ChillerPerformanceTreasureHuntService } from './chiller-performance-treasure-hunt.service';
 import { CoolingTowerFanTreasureHuntService } from './cooling-tower-fan-treasure-hunt.service';
 import { CoolingTowerBasinTreasureHuntService } from './cooling-tower-basin-treasure-hunt.service';
+import { AssessmentOpportunityService } from './assessment-opportunity.service';
 
 @Injectable()
 export class TreasureHuntOpportunityService {
@@ -38,6 +39,7 @@ export class TreasureHuntOpportunityService {
   constructor(
     private opportunityCardsService: OpportunityCardsService,
     private opportunitySummaryService: OpportunitySummaryService,
+    private assessmentOpportunityService: AssessmentOpportunityService,
     private airLeakTreasureHuntService: AirLeakTreasureHuntService,
     private tankInsulationTreasureHuntService: TankInsulationTreasureHuntService,
     private standaloneOpportunitySheetService: StandaloneOpportunitySheetService,
@@ -68,16 +70,18 @@ export class TreasureHuntOpportunityService {
     private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService
   ) { }
 
-  saveTreasureHuntOpportunity(currentOpportunity: TreasureHuntOpportunity, selectedCalc: string, standaloneOppSheet: OpportunitySheet) {
+  saveTreasureHuntOpportunity(currentOpportunity: TreasureHuntOpportunity, selectedCalc: string, customOpportunity: OpportunitySheet | AssessmentOpportunity) {
     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
+    
     if (selectedCalc === Treasure.airLeak) {
       let airLeakSurveyOpportunity = currentOpportunity as AirLeakSurveyTreasureHunt;
       treasureHunt = this.airLeakTreasureHuntService.saveTreasureHuntOpportunity(airLeakSurveyOpportunity, treasureHunt);
     } else if (selectedCalc === Treasure.tankInsulation) {
       let tankInsulationReductionTreasureHunt = currentOpportunity as TankInsulationReductionTreasureHunt;
       treasureHunt = this.tankInsulationTreasureHuntService.saveTreasureHuntOpportunity(tankInsulationReductionTreasureHunt, treasureHunt);
-    } else if (selectedCalc === Treasure.opportunitySheet && standaloneOppSheet) {
-      treasureHunt = this.standaloneOpportunitySheetService.saveTreasureHuntOpportunity(standaloneOppSheet, treasureHunt);
+    } else if (selectedCalc === Treasure.opportunitySheet && customOpportunity) {
+      let opportunitySheet = customOpportunity as OpportunitySheet;
+      treasureHunt = this.standaloneOpportunitySheetService.saveTreasureHuntOpportunity(opportunitySheet, treasureHunt);
     } else if (selectedCalc === Treasure.lightingReplacement) {
       let lightingReplacementTreasureHunt = currentOpportunity as LightingReplacementTreasureHunt;
       treasureHunt = this.lightingReplacementTreasureHuntService.saveTreasureHuntOpportunity(lightingReplacementTreasureHunt, treasureHunt);
@@ -147,6 +151,9 @@ export class TreasureHuntOpportunityService {
     } else if (selectedCalc === Treasure.coolingTowerBasin) {
       let coolingTowerBasin = currentOpportunity as CoolingTowerBasinTreasureHunt;
       treasureHunt = this.coolingTowerBasinTreasureHuntService.saveTreasureHuntOpportunity(coolingTowerBasin, treasureHunt);
+    } else if (selectedCalc === Treasure.assessmentOpportunity && customOpportunity) {
+      let assessmentOpportunity = customOpportunity as AssessmentOpportunity;
+      treasureHunt = this.assessmentOpportunityService.saveTreasureHuntOpportunity(assessmentOpportunity, treasureHunt);
     }
 
     this.treasureHuntService.treasureHunt.next(treasureHunt);
@@ -207,13 +214,15 @@ export class TreasureHuntOpportunityService {
       this.coolingTowerFanTreasureHuntService.resetCalculatorInputs();
     } else if (selectedCalc === Treasure.coolingTowerBasin) {
       this.coolingTowerBasinTreasureHuntService.resetCalculatorInputs();
+    } else if (selectedCalc === Treasure.assessmentOpportunity) {
+      this.calculatorsService.cancelOpportunitySheet();
     }
 
     this.calculatorsService.itemIndex = undefined;
     this.calculatorsService.selectedCalc.next('none');
   }
 
-  updateTreasureHuntOpportunity(currentOpportunity: TreasureHuntOpportunity, selectedCalc: string, settings: Settings, standaloneOpportunitySheet: OpportunitySheet) {
+  updateTreasureHuntOpportunity(currentOpportunity: TreasureHuntOpportunity, selectedCalc: string, settings: Settings, customOpportunity: OpportunitySheet | AssessmentOpportunity) {
     let treasureHunt: TreasureHunt = this.treasureHuntService.treasureHunt.getValue();
     let updatedCard: OpportunityCardData;
     if (selectedCalc === Treasure.airLeak) {
@@ -228,10 +237,12 @@ export class TreasureHuntOpportunityService {
       let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getIndividualOpportunitySummary(tankInsulationOpportunity, settings);
       updatedCard = this.tankInsulationTreasureHuntService.getTankInsulationReductionCardData(tankInsulationOpportunity, opportunitySummary, settings, this.calculatorsService.itemIndex, treasureHunt.currentEnergyUsage);
     
-    } else if (selectedCalc === Treasure.opportunitySheet && standaloneOpportunitySheet) {
-      treasureHunt.opportunitySheets[this.calculatorsService.itemIndex] = standaloneOpportunitySheet;
-      updatedCard = this.opportunityCardsService.getOpportunitySheetCardData(standaloneOpportunitySheet, settings, this.calculatorsService.itemIndex, treasureHunt.currentEnergyUsage);
-   
+    } else if (selectedCalc === Treasure.opportunitySheet && customOpportunity) {
+      let opportunitySheet = customOpportunity as OpportunitySheet;
+      treasureHunt.opportunitySheets[this.calculatorsService.itemIndex] = opportunitySheet;
+      updatedCard = this.opportunityCardsService.getOpportunitySheetCardData(opportunitySheet, settings, this.calculatorsService.itemIndex, treasureHunt.currentEnergyUsage);
+      updatedCard.opportunityType = Treasure.opportunitySheet;
+      
     } else if (selectedCalc === Treasure.lightingReplacement) {
       let lightingReplacementOpportunity = currentOpportunity as LightingReplacementTreasureHunt;
       treasureHunt.lightingReplacements[this.calculatorsService.itemIndex] = lightingReplacementOpportunity;
@@ -370,6 +381,13 @@ export class TreasureHuntOpportunityService {
       let opportunitySummary: OpportunitySummary = this.opportunitySummaryService.getIndividualOpportunitySummary(coolingTowerBasinOpportunity, settings);
       updatedCard = this.coolingTowerBasinTreasureHuntService.getCoolingTowerBasinCardData(coolingTowerBasinOpportunity, opportunitySummary, this.calculatorsService.itemIndex, treasureHunt.currentEnergyUsage, settings);
     
+    } else if (selectedCalc === Treasure.assessmentOpportunity) {
+      let assessmentOpportunity = customOpportunity as AssessmentOpportunity;
+      treasureHunt.assessmentOpportunities[this.calculatorsService.itemIndex] = assessmentOpportunity;
+      updatedCard = this.opportunityCardsService.getAssessmentOpportunityCardData(assessmentOpportunity, settings, this.calculatorsService.itemIndex, treasureHunt.currentEnergyUsage);
+      updatedCard.opportunitySheet = assessmentOpportunity as OpportunitySheet;
+      updatedCard.assessmentOpportunity = assessmentOpportunity;
+      updatedCard.opportunityType = Treasure.assessmentOpportunity;
     }
     
     this.opportunityCardsService.updatedOpportunityCard.next(updatedCard);

--- a/src/app/treasure-hunt/treasure-hunt-report/opportunity-summary.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/opportunity-summary.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { OpportunitySheetService } from '../calculators/standalone-opportunity-sheet/opportunity-sheet.service';
-import { OpportunityCost, OpportunitySummary, TreasureHunt, ElectricityReductionTreasureHunt, MotorDriveInputsTreasureHunt, ReplaceExistingMotorTreasureHunt, LightingReplacementTreasureHunt, NaturalGasReductionTreasureHunt, OpportunitySheetResults, OpportunitySheet, CompressedAirReductionTreasureHunt, WaterReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, TreasureHuntOpportunity, TreasureHuntResults, OpportunitySheetResult, TreasureHuntOpportunityResults, Treasure, FlueGasTreasureHunt, WallLossTreasureHunt, LeakageLossTreasureHunt, WasteHeatTreasureHunt, OpeningLossTreasureHunt, HeatCascadingTreasureHunt, WaterHeatingTreasureHunt, AirHeatingTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ChillerStagingTreasureHunt, ChillerPerformanceTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerBasinTreasureHunt } from '../../shared/models/treasure-hunt';
+import { OpportunityCost, OpportunitySummary, TreasureHunt, ElectricityReductionTreasureHunt, MotorDriveInputsTreasureHunt, ReplaceExistingMotorTreasureHunt, LightingReplacementTreasureHunt, NaturalGasReductionTreasureHunt, OpportunitySheetResults, OpportunitySheet, CompressedAirReductionTreasureHunt, WaterReductionTreasureHunt, CompressedAirPressureReductionTreasureHunt, SteamReductionTreasureHunt, PipeInsulationReductionTreasureHunt, TankInsulationReductionTreasureHunt, AirLeakSurveyTreasureHunt, TreasureHuntOpportunity, TreasureHuntResults, OpportunitySheetResult, TreasureHuntOpportunityResults, Treasure, FlueGasTreasureHunt, WallLossTreasureHunt, LeakageLossTreasureHunt, WasteHeatTreasureHunt, OpeningLossTreasureHunt, HeatCascadingTreasureHunt, WaterHeatingTreasureHunt, AirHeatingTreasureHunt, CoolingTowerMakeupWaterTreasureHunt, ChillerStagingTreasureHunt, ChillerPerformanceTreasureHunt, CoolingTowerFanTreasureHunt, CoolingTowerBasinTreasureHunt, AssessmentOpportunity } from '../../shared/models/treasure-hunt';
 import { Settings } from '../../shared/models/settings';
 import { processEquipmentOptions } from '../calculators/opportunity-sheet/general-details-form/processEquipmentOptions';
 import { AirLeakTreasureHuntService } from '../treasure-hunt-calculator-services/air-leak-treasure-hunt.service';
@@ -28,6 +28,7 @@ import { ChillerStagingTreasureHuntService } from '../treasure-hunt-calculator-s
 import { ChillerPerformanceTreasureHuntService } from '../treasure-hunt-calculator-services/chiller-performance-treasure-hunt.service';
 import { CoolingTowerFanTreasureHuntService } from '../treasure-hunt-calculator-services/cooling-tower-fan-treasure-hunt.service';
 import { CoolingTowerBasinTreasureHuntService } from '../treasure-hunt-calculator-services/cooling-tower-basin-treasure-hunt.service';
+import { AssessmentOpportunityService } from '../treasure-hunt-calculator-services/assessment-opportunity.service';
 
 @Injectable()
 export class OpportunitySummaryService {
@@ -58,6 +59,7 @@ export class OpportunitySummaryService {
     private chillerPerformanceTreasureHuntService: ChillerPerformanceTreasureHuntService,
     private coolingTowerFanTreasureHuntService: CoolingTowerFanTreasureHuntService,
     private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService,
+    private assessmentOpportunityService: AssessmentOpportunityService
     ) { }
 
   getOpportunitySummaries(treasureHunt: TreasureHunt, settings: Settings): Array<OpportunitySummary> {
@@ -89,6 +91,7 @@ export class OpportunitySummaryService {
     opportunitySummaries = this.getTreasureHuntOpportunitySummaries(treasureHunt.coolingTowerBasinOpportunities, opportunitySummaries, settings);
     //standalone opp sheets
     opportunitySummaries = this.getOpportunitySheetSummaries(treasureHunt.opportunitySheets, opportunitySummaries, settings);
+    opportunitySummaries = this.getAssessmentOpportunitySummaries(treasureHunt.assessmentOpportunities, opportunitySummaries, settings);
 
 
     return opportunitySummaries;
@@ -313,10 +316,125 @@ export class OpportunitySummaryService {
       }
       return opportunitySummaries;
     }
+
+    getAssessmentOpportunitySummaries(assessmentOpportunities: Array<AssessmentOpportunity>, opportunitySummaries: Array<OpportunitySummary>, settings: Settings, getAllResults?: boolean): Array<OpportunitySummary> {
+      if (assessmentOpportunities) {
+        assessmentOpportunities.forEach(assessmentOpp => {
+          if (assessmentOpp.selected || getAllResults) {
+            let oppSummary: OpportunitySummary = this.getAssessmentOpportunitySummary(assessmentOpp, settings);
+            if (oppSummary) {
+              opportunitySummaries.push(oppSummary);
+            }
+          }
+        });
+      }
+      return opportunitySummaries;
+    }
+
+    getAssessmentOpportunitySummary(oppSheet: AssessmentOpportunity, settings: Settings): OpportunitySummary {
+      let mixedIndividualSummaries: Array<OpportunitySummary> = new Array<OpportunitySummary>();
+      let oppSheetResults: OpportunitySheetResults = this.assessmentOpportunityService.getResults(oppSheet, settings);
+      let numEnergyTypes: number = 0;
+      let totalEnergySavings: number = 0;
+      let energyTypeLabel: string;
+      let opportunityMetaData: OpportunityMetaData = {
+        name: oppSheet.name,
+        team: oppSheet.owner,
+        equipment: this.getEquipmentDisplay(oppSheet.equipment),
+        owner: oppSheet.businessUnits,
+        opportunityCost: oppSheet.opportunityCost
+      }
+
+      let treasureHuntOpportunityResults: TreasureHuntOpportunityResults;
+      for (let key in oppSheetResults) {
+        if (oppSheetResults[key].baselineItems != 0 || oppSheetResults[key].modificationItems != 0 && oppSheetResults[key].baselineItems != undefined) {
+          numEnergyTypes = numEnergyTypes + 1;
+        }
+      }
+      //electricity
+      if (oppSheetResults.electricityResults.baselineItems != 0 || oppSheetResults.electricityResults.modificationItems != 0) {
+        energyTypeLabel = 'Electricity';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.electricityResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.electricityResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //compressed air
+      if (oppSheetResults.compressedAirResults.baselineItems != 0 || oppSheetResults.compressedAirResults.modificationItems != 0) {
+        energyTypeLabel = 'Compressed Air';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.compressedAirResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.compressedAirResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //natural gas
+      if (oppSheetResults.gasResults.baselineItems != 0 || oppSheetResults.gasResults.modificationItems != 0) {
+        energyTypeLabel = 'Natural Gas';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.gasResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.gasResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //water
+      if (oppSheetResults.waterResults.baselineItems != 0 || oppSheetResults.waterResults.modificationItems != 0) {
+        energyTypeLabel = 'Water';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.waterResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.waterResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //waste water
+      if (oppSheetResults.wasteWaterResults.baselineItems != 0 || oppSheetResults.wasteWaterResults.modificationItems != 0) {
+        energyTypeLabel = 'Waste Water';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.wasteWaterResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.wasteWaterResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //steam
+      if (oppSheetResults.steamResults.baselineItems != 0 || oppSheetResults.steamResults.modificationItems != 0) {
+        energyTypeLabel = 'Steam';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.steamResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.steamResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      //other fuel
+      if (oppSheetResults.otherFuelResults.baselineItems != 0 || oppSheetResults.otherFuelResults.modificationItems != 0) {
+        energyTypeLabel = 'Other Fuel';
+        totalEnergySavings = totalEnergySavings + oppSheetResults.otherFuelResults.energySavings;
+        treasureHuntOpportunityResults = this.setResultsFromOppSheet(oppSheetResults.otherFuelResults, energyTypeLabel);
+        let oppSummary: OpportunitySummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+        mixedIndividualSummaries.push(oppSummary);
+      }
+      let oppSummary: OpportunitySummary;
+      //if only one energy source in opp sheet
+      if (numEnergyTypes == 1) {
+        oppSummary = mixedIndividualSummaries[0];
+      } else if (numEnergyTypes > 1) {
+        treasureHuntOpportunityResults.utilityType = 'Mixed';
+        treasureHuntOpportunityResults.costSavings = oppSheetResults.totalCostSavings;
+        treasureHuntOpportunityResults.energySavings = oppSheetResults.totalEnergySavings;
+        treasureHuntOpportunityResults.baselineCost = 0;
+        treasureHuntOpportunityResults.modificationCost = 0;
+        oppSummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults, mixedIndividualSummaries);
+      } else {
+        //no energy savings
+        treasureHuntOpportunityResults.utilityType = 'None';
+        treasureHuntOpportunityResults.costSavings = 0;
+        treasureHuntOpportunityResults.energySavings = 0;
+        treasureHuntOpportunityResults.baselineCost = 0;
+        treasureHuntOpportunityResults.modificationCost = 0;
+        opportunityMetaData.opportunityCost = undefined;
+        oppSummary = this.getNewOpportunitySummary(opportunityMetaData, treasureHuntOpportunityResults);
+      }
+      return oppSummary;
+    }
   
-    getOpportunitySheetSummary(oppSheet: OpportunitySheet, settings: Settings): OpportunitySummary {
+    getOpportunitySheetSummary(oppSheet: OpportunitySheet | AssessmentOpportunity, settings: Settings): OpportunitySummary {
       let mixedIndividualSummaries: Array<OpportunitySummary> = new Array<OpportunitySummary>();
       let oppSheetResults: OpportunitySheetResults = this.opportunitySheetService.getResults(oppSheet, settings);
+      
       let numEnergyTypes: number = 0;
       let totalEnergySavings: number = 0;
       let energyTypeLabel: string;
@@ -428,7 +546,6 @@ export class OpportunitySummaryService {
       treasureHuntOpportunityResults.costSavings = sheetResults.energyCostSavings;
       treasureHuntOpportunityResults.energySavings = sheetResults.energySavings;
       treasureHuntOpportunityResults.utilityType = utilityType;
-
       return treasureHuntOpportunityResults;
     }
 

--- a/src/app/treasure-hunt/treasure-hunt-report/treasure-hunt-report.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/treasure-hunt-report.component.ts
@@ -79,8 +79,8 @@ export class TreasureHuntReportComponent implements OnInit {
       this.sortBySub = this.treasureChestMenuService.sortBy.subscribe(val => {
         if (this.assessment.treasureHunt.setupDone == true) {
           let filteredTreasureHunt: TreasureHunt = this.sortCardsService.sortTreasureHunt(this.assessment.treasureHunt, val, this.settings);
-          this.treasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResults(filteredTreasureHunt, this.settings);
           this.opportunityCardsData = this.opportunityCardsService.getOpportunityCardsData(filteredTreasureHunt, this.settings);
+          this.treasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResults(filteredTreasureHunt, this.settings);
           let oppCards = this.opportunityCardsService.opportunityCards.getValue();
           if (oppCards.length != this.opportunityCardsData.length) {
             this.opportunityCardsService.opportunityCards.next(this.opportunityCardsData);
@@ -162,11 +162,11 @@ export class TreasureHuntReportComponent implements OnInit {
 
   updateResults(opportunitySummaries: Array<OpportunitySummary>) {
     if (!this.inRollup) {
-      this.treasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, this.assessment.treasureHunt.currentEnergyUsage, this.settings);
+      this.treasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, this.assessment.treasureHunt, this.settings);
       this.opportunityCardsData = this.opportunityCardsService.getOpportunityCardsData(this.assessment.treasureHunt, this.settings);
       this.opportunitiesPaybackDetails = this.opportunityPaybackService.getOpportunityPaybackDetails(this.treasureHuntResults.opportunitySummaries);
     } else {
-      let treasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, this.assessment.treasureHunt.currentEnergyUsage, this.settings);
+      let treasureHuntResults = this.treasureHuntReportService.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, this.assessment.treasureHunt, this.settings);
       let opportunityCardsData = this.opportunityCardsService.getOpportunityCardsData(this.assessment.treasureHunt, this.settings);
       let opportunitiesPaybackDetails = this.opportunityPaybackService.getOpportunityPaybackDetails(this.treasureHuntResults.opportunitySummaries);
       this.treasureHuntReportRollupService.updateTreasureHuntResults(treasureHuntResults, opportunityCardsData, opportunitiesPaybackDetails, this.assessment.id);

--- a/src/app/treasure-hunt/treasure-hunt-report/treasure-hunt-report.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/treasure-hunt-report.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { TreasureHuntResults, UtilityUsageData, OpportunitySummary, EnergyUsage, TreasureHunt, TreasureHuntCo2EmissionsResults } from '../../shared/models/treasure-hunt';
+import { TreasureHuntResults, UtilityUsageData, OpportunitySummary, EnergyUsage, TreasureHunt, TreasureHuntCo2EmissionsResults, EnergyUseItem, UtilityTypeTreasureHuntEmissions } from '../../shared/models/treasure-hunt';
 import * as _ from 'lodash';
 import { Settings } from '../../shared/models/settings';
 import { OpportunitySummaryService } from './opportunity-summary.service';
@@ -16,12 +16,12 @@ export class TreasureHuntReportService {
 
   calculateTreasureHuntResults(treasureHunt: TreasureHunt, settings: Settings): TreasureHuntResults {
     let opportunitySummaries: Array<OpportunitySummary> = this.opportunitySummaryService.getOpportunitySummaries(treasureHunt, settings);
-    let results: TreasureHuntResults = this.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, treasureHunt.currentEnergyUsage, settings);
+    let results: TreasureHuntResults = this.calculateTreasureHuntResultsFromSummaries(opportunitySummaries, treasureHunt, settings);
     return results;
   }
 
-  calculateTreasureHuntResultsFromSummaries(opportunitySummaries: Array<OpportunitySummary>, currentEnergyUsage: EnergyUsage, settings: Settings): TreasureHuntResults {
-    let totalBaselineCost: number = this.getTotalBaselineCost(currentEnergyUsage);
+  calculateTreasureHuntResultsFromSummaries(opportunitySummaries: Array<OpportunitySummary>, treasureHunt: TreasureHunt, settings: Settings): TreasureHuntResults {
+    let totalBaselineCost: number = this.getTotalBaselineCost(treasureHunt.currentEnergyUsage);
 
     let totalAdditionalSavings: number = _.sumBy(opportunitySummaries, (summary) => {
       if (summary.opportunityCost && summary.opportunityCost.additionalAnnualSavings && summary.opportunityCost.additionalAnnualSavings.cost) {
@@ -36,29 +36,26 @@ export class TreasureHuntReportService {
     let otherUtilityUsage: UtilityUsageData = this.getUtilityUsageData(mixedSummaries, 'Mixed', 0, 0);
     //Electricity
     let electricitySummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Electricity' && summary.selected == true });
-    let electricityUtilityUsage: UtilityUsageData = this.getUtilityUsageData(electricitySummaries, 'Electricity', currentEnergyUsage.electricityUsage, currentEnergyUsage.electricityCosts, mixedSummaries);
+    let electricityUtilityUsage: UtilityUsageData = this.getUtilityUsageData(electricitySummaries, 'Electricity', treasureHunt.currentEnergyUsage.electricityUsage, treasureHunt.currentEnergyUsage.electricityCosts, mixedSummaries);
     //Compresssed Air
     let compressedAirSummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Compressed Air' && summary.selected == true });
-    let compressedAirUtilityUsage: UtilityUsageData = this.getUtilityUsageData(compressedAirSummaries, 'Compressed Air', currentEnergyUsage.compressedAirUsage, currentEnergyUsage.compressedAirCosts, mixedSummaries)
+    let compressedAirUtilityUsage: UtilityUsageData = this.getUtilityUsageData(compressedAirSummaries, 'Compressed Air', treasureHunt.currentEnergyUsage.compressedAirUsage, treasureHunt.currentEnergyUsage.compressedAirCosts, mixedSummaries)
     //Natural Gas
     let naturalGasSummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Natural Gas' && summary.selected == true });
-    let naturalGasUtilityUsage: UtilityUsageData = this.getUtilityUsageData(naturalGasSummaries, 'Natural Gas', currentEnergyUsage.naturalGasUsage, currentEnergyUsage.naturalGasCosts, mixedSummaries)
+    let naturalGasUtilityUsage: UtilityUsageData = this.getUtilityUsageData(naturalGasSummaries, 'Natural Gas', treasureHunt.currentEnergyUsage.naturalGasUsage, treasureHunt.currentEnergyUsage.naturalGasCosts, mixedSummaries)
     //Water
     let waterSummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Water' && summary.selected == true });
-    let waterUtilityUsage: UtilityUsageData = this.getUtilityUsageData(waterSummaries, 'Water', currentEnergyUsage.waterUsage, currentEnergyUsage.waterCosts, mixedSummaries)
+    let waterUtilityUsage: UtilityUsageData = this.getUtilityUsageData(waterSummaries, 'Water', treasureHunt.currentEnergyUsage.waterUsage, treasureHunt.currentEnergyUsage.waterCosts, mixedSummaries)
     //Waste Water
     let wasteWaterSummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Waste Water' && summary.selected == true });
-    let wasteWaterUtilityUsage: UtilityUsageData = this.getUtilityUsageData(wasteWaterSummaries, 'Waste Water', currentEnergyUsage.wasteWaterUsage, currentEnergyUsage.wasteWaterCosts, mixedSummaries)
+    let wasteWaterUtilityUsage: UtilityUsageData = this.getUtilityUsageData(wasteWaterSummaries, 'Waste Water', treasureHunt.currentEnergyUsage.wasteWaterUsage, treasureHunt.currentEnergyUsage.wasteWaterCosts, mixedSummaries)
     //Steam
     let steamSummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Steam' && summary.selected == true });
-    let steamUtilityUsage: UtilityUsageData = this.getUtilityUsageData(steamSummaries, 'Steam', currentEnergyUsage.steamUsage, currentEnergyUsage.steamCosts, mixedSummaries)
+    let steamUtilityUsage: UtilityUsageData = this.getUtilityUsageData(steamSummaries, 'Steam', treasureHunt.currentEnergyUsage.steamUsage, treasureHunt.currentEnergyUsage.steamCosts, mixedSummaries)
 
     //Other Fuel
     let otherFuelSummaries: Array<OpportunitySummary> = opportunitySummaries.filter(summary => { return summary.utilityType == 'Other Fuel' && summary.selected == true });
-    let otherFuelUtilityUsage: UtilityUsageData = this.getUtilityUsageData(otherFuelSummaries, 'Other Fuel', currentEnergyUsage.otherFuelUsage, currentEnergyUsage.otherFuelCosts, mixedSummaries)
-
-
-
+    let otherFuelUtilityUsage: UtilityUsageData = this.getUtilityUsageData(otherFuelSummaries, 'Other Fuel', treasureHunt.currentEnergyUsage.otherFuelUsage, treasureHunt.currentEnergyUsage.otherFuelCosts, mixedSummaries)
 
     let utilityArr: Array<UtilityUsageData> = [electricityUtilityUsage, compressedAirUtilityUsage, naturalGasUtilityUsage, waterUtilityUsage, wasteWaterUtilityUsage, steamUtilityUsage, otherFuelUtilityUsage];
     let totalImplementationCost: number = _.sumBy(utilityArr, (usage: UtilityUsageData) => { return usage.implementationCost }) + otherUtilityUsage.implementationCost;
@@ -125,7 +122,7 @@ export class TreasureHuntReportService {
         element.modificationCost = this.convertUnitsService.value(element.modificationCost).from("$").to(settings.currency);
       });
     }
-    thuntResults.co2EmissionsResults = this.getCO2EmissionsResults(currentEnergyUsage, thuntResults, settings);
+    thuntResults.co2EmissionsResults = this.getCO2EmissionsResults(treasureHunt, thuntResults, settings);
     return thuntResults;
   }
 
@@ -199,37 +196,40 @@ export class TreasureHuntReportService {
     return additionalCostSavings;
   }
 
-  getCO2EmissionsResults(energyUsage: EnergyUsage, treasureHuntResults: TreasureHuntResults, settings: Settings): TreasureHuntCo2EmissionsResults {
+  getCO2EmissionsResults(treasureHunt: TreasureHunt, treasureHuntResults: TreasureHuntResults, settings: Settings): TreasureHuntCo2EmissionsResults {
     let carbonResults: TreasureHuntCo2EmissionsResults;
-    carbonResults = this.calculateCO2Results(energyUsage, treasureHuntResults, settings);
-    carbonResults.totalCO2CurrentUse = this.calculateTotalCurrentCarbonEmissions(energyUsage, carbonResults);
-    carbonResults.totalCO2ProjectedUse = this.calculateTotalProjectedCarbonEmissions(energyUsage, carbonResults);
+    carbonResults = this.calculateCO2Results(treasureHunt, treasureHuntResults, settings);
+
+    carbonResults.totalCO2CurrentUse = this.calculateTotalCurrentCarbonEmissions(treasureHunt.currentEnergyUsage, carbonResults);
+    carbonResults.totalCO2ProjectedUse = this.calculateTotalProjectedCarbonEmissions(treasureHunt.currentEnergyUsage, carbonResults);
     carbonResults.totalCO2Savings = carbonResults.totalCO2CurrentUse - carbonResults.totalCO2ProjectedUse;
+
     return carbonResults;
   }
 
-  calculateCO2Results(energyUsage: EnergyUsage, treasureHuntResults: TreasureHuntResults, settings: Settings): TreasureHuntCo2EmissionsResults  {
-    let electricityCO2CurrentUse: number =  this.getCo2EmissionsResultFromObj(energyUsage.electricityCO2SavingsData, treasureHuntResults.electricity.baselineEnergyUsage, settings);
-    let electricityCO2ProjectedUse: number = this.getCo2EmissionsResultFromObj(energyUsage.electricityCO2SavingsData, treasureHuntResults.electricity.modifiedEnergyUsage, settings);
-    let naturalGasCO2CurrentUse: number = this.getCo2EmissionsResultFromObj(energyUsage.naturalGasCO2SavingsData, treasureHuntResults.naturalGas.baselineEnergyUsage, settings);
-    let naturalGasCO2ProjectedUse: number = this.getCo2EmissionsResultFromObj(energyUsage.naturalGasCO2SavingsData, treasureHuntResults.naturalGas.modifiedEnergyUsage, settings);
-    let otherFuelCO2CurrentUse: number = this.getCo2EmissionsResultFromObj(energyUsage.otherFuelCO2SavingsData, treasureHuntResults.otherFuel.baselineEnergyUsage, settings);
-    let otherFuelCO2ProjectedUse: number = this.getCo2EmissionsResultFromObj(energyUsage.otherFuelCO2SavingsData, treasureHuntResults.otherFuel.modifiedEnergyUsage, settings);
-    let waterCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.waterCO2OutputRate, treasureHuntResults.water.baselineEnergyUsage);
-    let waterCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.waterCO2OutputRate, treasureHuntResults.water.modifiedEnergyUsage);
-    let wasteWaterCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.wasteWaterCO2OutputRate, treasureHuntResults.wasteWater.baselineEnergyUsage);
-    let wasteWaterCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.wasteWaterCO2OutputRate, treasureHuntResults.wasteWater.modifiedEnergyUsage);
-    let compressedAirCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.compressedAirCO2OutputRate, treasureHuntResults.compressedAir.baselineEnergyUsage);
-    let compressedAirCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.compressedAirCO2OutputRate, treasureHuntResults.compressedAir.modifiedEnergyUsage);
-    let steamCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.steamCO2OutputRate, treasureHuntResults.steam.baselineEnergyUsage);
-    let steamCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(energyUsage.steamCO2OutputRate, treasureHuntResults.steam.modifiedEnergyUsage);
+  calculateCO2Results(treasureHunt: TreasureHunt, treasureHuntResults: TreasureHuntResults, settings: Settings): TreasureHuntCo2EmissionsResults  {
+    let electricityCO2CurrentUse: number =  this.getCo2EmissionsResultFromObj(treasureHunt.currentEnergyUsage.electricityCO2SavingsData, treasureHuntResults.electricity.baselineEnergyUsage, settings);
+    let electricityCO2ProjectedUse: number = this.getCo2EmissionsResultFromObj(treasureHunt.currentEnergyUsage.electricityCO2SavingsData, treasureHuntResults.electricity.modifiedEnergyUsage, settings);
+    let naturalGasCO2CurrentUse: number = this.getCo2EmissionsResultFromObj(treasureHunt.currentEnergyUsage.naturalGasCO2SavingsData, treasureHuntResults.naturalGas.baselineEnergyUsage, settings);
+    let naturalGasCO2ProjectedUse: number = this.getCo2EmissionsResultFromObj(treasureHunt.currentEnergyUsage.naturalGasCO2SavingsData, treasureHuntResults.naturalGas.modifiedEnergyUsage, settings);
+    let otherFuelCO2CurrentUse: number = this.getCo2EmissionsResultFromObj(treasureHunt.currentEnergyUsage.otherFuelCO2SavingsData, treasureHuntResults.otherFuel.baselineEnergyUsage, settings);
+    let otherFuelCO2ProjectedUse: number = this.getCo2EmissionsResultFromObj(treasureHunt.currentEnergyUsage.otherFuelCO2SavingsData, treasureHuntResults.otherFuel.modifiedEnergyUsage, settings);
+    let waterCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.waterCO2OutputRate, treasureHuntResults.water.baselineEnergyUsage);
+    let waterCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.waterCO2OutputRate, treasureHuntResults.water.modifiedEnergyUsage);
+    let wasteWaterCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.wasteWaterCO2OutputRate, treasureHuntResults.wasteWater.baselineEnergyUsage);
+    let wasteWaterCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.wasteWaterCO2OutputRate, treasureHuntResults.wasteWater.modifiedEnergyUsage);
+    let compressedAirCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.compressedAirCO2OutputRate, treasureHuntResults.compressedAir.baselineEnergyUsage);
+    let compressedAirCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.compressedAirCO2OutputRate, treasureHuntResults.compressedAir.modifiedEnergyUsage);
+    let steamCO2CurrentUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.steamCO2OutputRate, treasureHuntResults.steam.baselineEnergyUsage);
+    let steamCO2ProjectedUse: number = this.getCo2EmissionsResultFromNumber(treasureHunt.currentEnergyUsage.steamCO2OutputRate, treasureHuntResults.steam.modifiedEnergyUsage);
+
     let carbonResults: TreasureHuntCo2EmissionsResults = {
       electricityCO2CurrentUse: electricityCO2CurrentUse,
       electricityCO2ProjectedUse: electricityCO2ProjectedUse,
       electricityCO2Savings: electricityCO2CurrentUse - electricityCO2ProjectedUse,
       naturalGasCO2CurrentUse: naturalGasCO2CurrentUse,
       naturalGasCO2ProjectedUse: naturalGasCO2ProjectedUse,
-      naturalGasCO2Savings: naturalGasCO2CurrentUse - naturalGasCO2ProjectedUse,
+      naturalGasCO2Savings: naturalGasCO2CurrentUse - naturalGasCO2ProjectedUse, 
       otherFuelCO2CurrentUse: otherFuelCO2CurrentUse,
       otherFuelCO2ProjectedUse: otherFuelCO2ProjectedUse,
       otherFuelCO2Savings: otherFuelCO2CurrentUse - otherFuelCO2ProjectedUse,
@@ -246,7 +246,79 @@ export class TreasureHuntReportService {
       steamCO2ProjectedUse: steamCO2ProjectedUse,
       steamCO2Savings: steamCO2CurrentUse - steamCO2ProjectedUse
     }
+
+    if (treasureHunt.assessmentOpportunities) { 
+      this.setAssessmentOpportunitesCO2(treasureHunt, carbonResults);
+    }
+
     return carbonResults;
+  }
+
+  setAssessmentOpportunitesCO2(treasureHunt: TreasureHunt, carbonResults: TreasureHuntCo2EmissionsResults) {
+    treasureHunt.assessmentOpportunities.forEach(opp => {
+      let baselineEmissions: UtilityTypeTreasureHuntEmissions = this.setIntegratedEnergyUseItemEmissions(opp.baselineEnergyUseItems);
+      let modificationEmissions: UtilityTypeTreasureHuntEmissions = this.setIntegratedEnergyUseItemEmissions(opp.modificationEnergyUseItems);
+
+      carbonResults.electricityCO2CurrentUse += baselineEmissions.electricityEmissions,
+      carbonResults.electricityCO2ProjectedUse += modificationEmissions.electricityEmissions,
+      carbonResults.electricityCO2Savings += baselineEmissions.electricityEmissions - modificationEmissions.electricityEmissions,
+      carbonResults.naturalGasCO2CurrentUse += baselineEmissions.naturalGasEmissions;
+      carbonResults.naturalGasCO2ProjectedUse += modificationEmissions.naturalGasEmissions;
+      carbonResults.naturalGasCO2Savings += baselineEmissions.naturalGasEmissions - modificationEmissions.naturalGasEmissions; 
+      carbonResults.otherFuelCO2CurrentUse += baselineEmissions.otherFuelEmissions;
+      carbonResults.otherFuelCO2ProjectedUse += modificationEmissions.otherFuelEmissions;
+      carbonResults.otherFuelCO2Savings += baselineEmissions.otherFuelEmissions - modificationEmissions.otherFuelEmissions;
+      carbonResults.waterCO2CurrentUse += baselineEmissions.waterEmissions;
+      carbonResults.waterCO2ProjectedUse += modificationEmissions.waterEmissions;
+      carbonResults.waterCO2Savings += baselineEmissions.waterEmissions - modificationEmissions.waterEmissions;
+      carbonResults.wasteWaterCO2CurrentUse += baselineEmissions.wasteWaterEmissions;
+      carbonResults.wasteWaterCO2ProjectedUse += modificationEmissions.wasteWaterEmissions;
+      carbonResults.wasteWaterCO2Savings += baselineEmissions.wasteWaterEmissions - modificationEmissions.wasteWaterEmissions;
+      carbonResults.compressedAirCO2CurrentUse += baselineEmissions.compressedAirEmissions;
+      carbonResults.compressedAirCO2ProjectedUse += modificationEmissions.compressedAirEmissions;      
+      carbonResults.compressedAirCO2Savings += baselineEmissions.compressedAirEmissions - modificationEmissions.compressedAirEmissions;
+      carbonResults.steamCO2CurrentUse += baselineEmissions.steamEmissions;
+      carbonResults.steamCO2ProjectedUse += modificationEmissions.steamEmissions;
+      carbonResults.steamCO2Savings += baselineEmissions.steamEmissions - modificationEmissions.steamEmissions;
+    });
+
+  }
+
+  setIntegratedEnergyUseItemEmissions(energyUseItems: EnergyUseItem[]): UtilityTypeTreasureHuntEmissions {
+    let treasureHuntEmissions: UtilityTypeTreasureHuntEmissions = {
+      electricityEmissions: 0,
+      naturalGasEmissions: 0,
+      otherFuelEmissions: 0,
+      waterEmissions: 0,
+      wasteWaterEmissions: 0,
+      compressedAirEmissions: 0,
+      steamEmissions: 0,
+    }
+    energyUseItems.forEach(item => {
+      let integratedEmissions: number = item.integratedEmissionRate !== undefined? item.integratedEmissionRate : 0;
+      if (item.type === 'Electricity') {
+        treasureHuntEmissions.electricityEmissions += integratedEmissions;
+      } else if (item.type === 'Gas') {
+        treasureHuntEmissions.naturalGasEmissions += integratedEmissions;
+        
+      } else if (item.type === 'Other Fuel') {
+        treasureHuntEmissions.otherFuelEmissions += integratedEmissions;
+        
+      } else if (item.type === 'Steam') {
+        treasureHuntEmissions.steamEmissions += integratedEmissions;
+      
+      } else if (item.type === 'Compressed Air') {
+        treasureHuntEmissions.compressedAirEmissions += integratedEmissions;
+     
+      } else if (item.type === 'Water') {
+        treasureHuntEmissions.waterEmissions += integratedEmissions;
+
+      } else if (item.type === 'Waste Water') {
+        treasureHuntEmissions.wasteWaterEmissions += integratedEmissions;
+      }
+    });
+
+    return treasureHuntEmissions;
   }
 
   getCo2EmissionsResultFromObj(data: Co2SavingsData, electricityUsed: number, settings: Settings): number {

--- a/src/app/treasure-hunt/treasure-hunt.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt.component.ts
@@ -103,7 +103,7 @@ export class TreasureHuntComponent implements OnInit {
           }
         }
         this.getSettings();
-        let tmpTab = this.assessmentService.getTab();
+        let tmpTab = this.assessmentService.getStartingTab();
         if (tmpTab) {
           this.treasureHuntService.mainTab.next(tmpTab);
         }

--- a/src/app/treasure-hunt/treasure-hunt.module.ts
+++ b/src/app/treasure-hunt/treasure-hunt.module.ts
@@ -60,6 +60,7 @@ import { ChillerPerformanceTreasureHuntService } from './treasure-hunt-calculato
 import { CoolingTowerFanTreasureHuntService } from './treasure-hunt-calculator-services/cooling-tower-fan-treasure-hunt.service';
 import { CoolingTowerBasinTreasureHuntService } from './treasure-hunt-calculator-services/cooling-tower-basin-treasure-hunt.service';
 import { ImportExportModule } from '../shared/import-export/import-export.module';
+import { AssessmentIntegrationModule } from '../shared/assessment-integration/assessment-integration.module';
 
 @NgModule({
   imports: [
@@ -77,8 +78,8 @@ import { ImportExportModule } from '../shared/import-export/import-export.module
     UpdateUnitsModalModule,
     AssessmentCo2SavingsModule,
     MixedCo2EmissionsModule,
-    Co2HelpTextModule,    
-    ImportExportModule
+    ImportExportModule,
+    Co2HelpTextModule,
   ],
   declarations: [
     TreasureHuntComponent, 

--- a/src/app/waste-water/waste-water.component.ts
+++ b/src/app/waste-water/waste-water.component.ts
@@ -90,8 +90,8 @@ export class WasteWaterComponent implements OnInit {
           this.settings = settings;
           this.wasteWaterService.settings.next(settings);
         }
-        if (this.assessmentService.tab) {
-          this.wasteWaterService.mainTab.next(this.assessmentService.tab);
+        if (this.assessmentService.startingTab) {
+          this.wasteWaterService.mainTab.next(this.assessmentService.startingTab);
         }
       }
     });

--- a/src/assets/styles/two-panel.css
+++ b/src/assets/styles/two-panel.css
@@ -547,6 +547,7 @@
 
 .log-tool-container  
 .btn-primary:hover:enabled,
+.log-tool-container  
 .btn-primary:focus:enabled {
     color: white;
     background: #447f73 !important;


### PR DESCRIPTION
#6453 

slack if you want assessments for test.

- adds modification id's to psat, fsat, phast
- assessment opps are very similar to standalone opportunity sheets. Tried to combine logic for these where it made sense ("custom opportunities"), and just duplicated code blocks with slight changes when necessary.
- bunch of small stray changes in unrelated files from bugs needing to be fixed to nav between assessment/th
- made issues to finish other assessment modules integration, as well as add modificationIds