### PR TITLE
Issue 6538, 6526, 6536

### DIFF
--- a/src/app/phast/losses/energy-input-exhaust-gas-losses/energy-input-exhaust-gas-form/energy-input-exhaust-gas-form.component.html
+++ b/src/app/phast/losses/energy-input-exhaust-gas-losses/energy-input-exhaust-gas-form/energy-input-exhaust-gas-form.component.html
@@ -1,29 +1,51 @@
 <form [formGroup]="exhaustGasForm">
+  <div class="form-group">
+    <label class="small" for="{{'electricalHeaterEfficiency'+idString}}">
+      <span>
+        Electrical Heater Efficiency
+      </span>
+    </label>
+    <div class="input-group">
+      <input [readonly]="!baselineSelected" name="{{'electricalHeaterEfficiency'+idString}}" type="number" step="any"
+        min="0" class="form-control" formControlName="electricalHeaterEfficiency"
+        id="{{'electricalHeaterEfficiency'+idString}}" onfocus="this.select();" (input)="save()"
+        (focus)="focusField('electricalHeaterEfficiency')">
+      <span class="input-group-addon units">%</span>
+    </div>
+    <span class="alert-danger pull-right small"
+      *ngIf="exhaustGasForm.controls.electricalHeaterEfficiency.invalid && !exhaustGasForm.controls.electricalHeaterEfficiency.pristine">
+      <span *ngIf="exhaustGasForm.controls.electricalHeaterEfficiency.errors.required">Value Required</span>
+      <span *ngIf="exhaustGasForm.controls.electricalHeaterEfficiency.errors.greaterThan == 0">Value must be greater
+        than than
+        0.</span>
+      <span *ngIf="exhaustGasForm.controls.electricalHeaterEfficiency.errors.max">Value can't be greater than
+        100%.</span>
+    </span>
+  </div>
+
   <div class="form-section">
     <div class="form-group">
-      <label class="small" for="{{'totalHeatInput_'+idString}}">Total Heat Input for Burners</label>
-      <div class="input-group" [ngClass]="{'indicate-different': compareTotalHeatInput(), 'invalid': exhaustGasForm.controls.totalHeatInput.invalid}">
+      <label class="small" for="{{'totalHeatInput_'+idString}}">Total Additional Fuel Heat</label>
+      <div class="input-group"
+        [ngClass]="{'indicate-different': compareTotalHeatInput(), 'invalid': exhaustGasForm.controls.totalHeatInput.invalid}">
         <input [readonly]="!baselineSelected" name="{{'totalHeatInput_'+lossIndex}}" type="number" step="100" min="0"
-          class="form-control" formControlName="totalHeatInput" id="{{'totalHeatInput_'+idString}}" onfocus="this.select();"
-          (input)="save()" (focus)="focusField('totalHeatInput')" >
+          class="form-control" formControlName="totalHeatInput" id="{{'totalHeatInput_'+idString}}"
+          onfocus="this.select();" (input)="save()" (focus)="focusField('totalHeatInput')">
         <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="input-group-addon units">MMBtu/hr</span>
         <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="input-group-addon units">GJ/hr</span>
       </div>
     </div>
-  </div>
-  <div class="form-section">
-    <div class="form-group">
+    <div *ngIf="exhaustGasForm.controls.totalHeatInput.value > 0" class="form-group">
       <label class="small" for="{{'availableHeat'+idString}}">
         <span>
-          Fuel Heater Efficiency
+          Available Heat of Fuel
         </span>
-        <a id="materialHelp"
-          class="form-text small click-link" (click)="initFlueGasModal()">Calculate</a>
+        <a id="materialHelp" class="form-text small click-link" (click)="initFlueGasModal()">Calculate</a>
       </label>
       <div class="input-group">
-        <input [readonly]="!baselineSelected" name="{{'availableHeat'+idString}}" type="number" step="any" min="0" class="form-control"
-          formControlName="availableHeat" id="{{'availableHeat'+idString}}" onfocus="this.select();"
-          (input)="save()" (focus)="focusField('availableHeat')">
+        <input [readonly]="!baselineSelected" name="{{'availableHeat'+idString}}" type="number" step="any" min="0"
+          class="form-control" formControlName="availableHeat" id="{{'availableHeat'+idString}}"
+          onfocus="this.select();" (input)="save()" (focus)="focusField('availableHeat')">
         <span class="input-group-addon units">%</span>
       </div>
       <span class="alert-danger pull-right small"
@@ -35,6 +57,7 @@
       </span>
     </div>
   </div>
+
 </form>
 
 <div bsModal #flueGasModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="flueGasModalLabel"

--- a/src/app/phast/losses/energy-input-exhaust-gas-losses/energy-input-exhaust-gas-losses.component.html
+++ b/src/app/phast/losses/energy-input-exhaust-gas-losses/energy-input-exhaust-gas-losses.component.html
@@ -33,31 +33,31 @@
   <div class="d-flex flex-column loss-total" [ngClass]="{'input-error': showError == true}">
     <div class="form-group">
       <label class="bold">Fuel Heat Delivered</label>
-      <div *ngIf="loss.heatLoss" class="text-center bold">
-        {{loss.heatLoss | sigFigs:'5'}}
+      <div *ngIf="energyExhaustGasOutput.fuelHeatDelivered" class="text-center bold">
+        {{energyExhaustGasOutput.fuelHeatDelivered | sigFigs:'5'}}
         <span>{{resultsUnit}}</span>
       </div>
-      <div *ngIf="!loss.heatLoss" class="text-center bold">
+      <div *ngIf="!energyExhaustGasOutput.fuelHeatDelivered" class="text-center bold">
         &mdash; &mdash;
       </div>
     </div>
     <div class="form-group">
       <label class="bold">Exhaust Gas Losses</label>
-      <div *ngIf="loss.exhaustGas" class="text-center bold">
-        {{loss.exhaustGas | sigFigs:'6'}}
+      <div *ngIf="energyExhaustGasOutput.exhaustGasLosses" class="text-center bold">
+        {{energyExhaustGasOutput.exhaustGasLosses | sigFigs:'6'}}
         <span>{{resultsUnit}}</span>
       </div>
-      <div *ngIf="!loss.exhaustGas" class="text-center bold">
+      <div *ngIf="!energyExhaustGasOutput.exhaustGasLosses" class="text-center bold">
         &mdash; &mdash;
       </div>
     </div>
     <div class="form-group">
       <label class="bold">Electrical Heat Delivered</label>
-      <div *ngIf="electricalHeatDelivered > 0" class="text-center bold">
-        {{electricalHeatDelivered | sigFigs:'6'}}
+      <div *ngIf="energyExhaustGasOutput.phastElectricalHeatDelivered > 0" class="text-center bold">
+        {{energyExhaustGasOutput.phastElectricalHeatDelivered | sigFigs:'6'}}
         <span>{{resultsUnit}}</span>
       </div>
-      <div *ngIf="!electricalHeatDelivered || electricalHeatDelivered <= 0" class="text-center bold">
+      <div *ngIf="!energyExhaustGasOutput.phastElectricalHeatDelivered || energyExhaustGasOutput.phastElectricalHeatDelivered <= 0" class="text-center bold">
         &mdash; &mdash;
       </div>
      <div *ngIf="warnings.energyInputHeatDelivered !== null" class="text-alert alert-warning">
@@ -65,13 +65,25 @@
       </div>
     </div>
 
+     <div class="form-group">
+      <label class="bold">Electrical Heater losses</label>
+      <div *ngIf="energyExhaustGasOutput.electricalHeaterLosses > 0" class="text-center bold">
+        {{energyExhaustGasOutput.electricalHeaterLosses | sigFigs:'6'}}
+        <span>{{resultsUnit}}</span>
+        
+      </div>
+      <div *ngIf="!energyExhaustGasOutput.electricalHeaterLosses || energyExhaustGasOutput.electricalHeaterLosses <= 0" class="text-center bold">
+        &mdash; &mdash;
+      </div>
+    </div>
+
     <div class="form-group">
       <label class="bold">Energy Input Total</label>
-      <div *ngIf="energyInputTotal" class="text-center bold">
-        {{energyInputTotal | sigFigs:'6'}}
+      <div *ngIf="energyExhaustGasOutput.phastEnergyInputTotal" class="text-center bold">
+        {{energyExhaustGasOutput.phastEnergyInputTotal | sigFigs:'6'}}
         <span>{{resultsUnit}}</span>
       </div>
-      <div *ngIf="!energyInputTotal" class="text-center bold">
+      <div *ngIf="!energyExhaustGasOutput.phastEnergyInputTotal" class="text-center bold">
         &mdash; &mdash;
       </div>
     </div>

--- a/src/app/phast/losses/energy-input-exhaust-gas-losses/energy-input-exhaust-gas.service.ts
+++ b/src/app/phast/losses/energy-input-exhaust-gas-losses/energy-input-exhaust-gas.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { EnergyInputExhaustGasLoss } from '../../../shared/models/phast/losses/energyInputExhaustGasLosses';
-import { UntypedFormBuilder, Validators, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormBuilder, Validators, UntypedFormGroup, FormGroup } from '@angular/forms';
 import { GreaterThanValidator } from '../../../shared/validators/greater-than';
 @Injectable()
 export class EnergyInputExhaustGasService {
@@ -9,20 +9,37 @@ export class EnergyInputExhaustGasService {
   }
 
   initForm(lossNum: number): UntypedFormGroup {
-    return this.formBuilder.group({
+    let form: FormGroup = this.formBuilder.group({
       'totalHeatInput': [0, Validators.required],
       'name': ['Loss #' + lossNum],
-      'availableHeat': [100, [Validators.required,  GreaterThanValidator.greaterThan(0), Validators.max(100)]]
+      'availableHeat': [100, [Validators.required,  GreaterThanValidator.greaterThan(0), Validators.max(100)]],
+      'electricalHeaterEfficiency': [100, [Validators.required,  GreaterThanValidator.greaterThan(0), Validators.max(100)]]
     });
+
+    for (let key in form.controls) {
+      if (form.controls[key]) {
+        form.controls[key].markAsDirty();
+      }
+    }
+
+    return form;
   }
 
   getFormFromLoss(energyInputExhaustGas: EnergyInputExhaustGasLoss): UntypedFormGroup {
-    let tmpGroup = this.formBuilder.group({
+    let form: FormGroup = this.formBuilder.group({
       'totalHeatInput': [energyInputExhaustGas.totalHeatInput, Validators.required],
       'name': [energyInputExhaustGas.name],
-      'availableHeat': [energyInputExhaustGas.availableHeat, [Validators.required,  GreaterThanValidator.greaterThan(0), Validators.max(100)]]
+      'availableHeat': [energyInputExhaustGas.availableHeat, [Validators.required,  GreaterThanValidator.greaterThan(0), Validators.max(100)]],
+      'electricalHeaterEfficiency': [energyInputExhaustGas.electricalHeaterEfficiency, [Validators.required,  GreaterThanValidator.greaterThan(0), Validators.max(100)]]
     });
-    return tmpGroup;
+
+    for (let key in form.controls) {
+      if (form.controls[key]) {
+        form.controls[key].markAsDirty();
+      }
+    }
+
+    return form;
   }
 
   getLossFromForm(form: UntypedFormGroup): EnergyInputExhaustGasLoss {
@@ -30,7 +47,8 @@ export class EnergyInputExhaustGasService {
       totalHeatInput: form.controls.totalHeatInput.value,
       otherLosses: 0.0,
       name: form.controls.name.value,
-      availableHeat: form.controls.availableHeat.value
+      availableHeat: form.controls.availableHeat.value,
+      electricalHeaterEfficiency: form.controls.electricalHeaterEfficiency.value,
     };
     return tmpExhaustGas;
   }

--- a/src/app/phast/losses/losses-help/energy-input-exhaust-gas-losses-help/energy-input-exhaust-gas-losses-help.component.html
+++ b/src/app/phast/losses/losses-help/energy-input-exhaust-gas-losses-help/energy-input-exhaust-gas-losses-help.component.html
@@ -36,14 +36,38 @@
   <!-- All -->
   <div class="my-2" *ngIf="currentField == 'totalHeatInput'">
     <h6>
-      Total Heat Input
+      Total Additional Fuel Heat
       <br>
       <small class="text-muted">
-        Give value of total heat input to the heating system (furnace/oven) from all sources of heat supplied.
+        Additional heat supplied per hour by fuel burners. This value is zero for most electrotechnologies. This can be calculated from the fuel's higher heating value and volumetric flow rate.
         <hr>
       </small>
     </h6>
   </div>
+
+
+  <div class="my-2" *ngIf="currentField == 'availableHeat'">
+    <h6>
+      Available Heat of Fuel
+      <br>
+      <small class="text-muted">
+        Fraction of heating value of the fuel available for use. This can be calculated from estimating the flue gas losses with the "Calculate" button.
+        <hr>
+      </small>
+    </h6>
+  </div>
+
+  <div class="my-2" *ngIf="currentField == 'electricalHeaterEfficiency'">
+    <h6>
+      Electrical Heater Efficiency
+      <br>
+      <small class="text-muted">
+        Efficiency of the conversion of electrical energy into heat, this is often close to 100%.
+        <hr>
+      </small>
+    </h6>
+  </div>
+
 
   <div class="my-2" *ngIf="currentField == 'excessAir'">
     <h6>

--- a/src/app/phast/losses/losses-help/exhaust-gas-help/exhaust-gas-help.component.html
+++ b/src/app/phast/losses/losses-help/exhaust-gas-help/exhaust-gas-help.component.html
@@ -4,7 +4,7 @@
     <br>
     <small class="text-muted">
       Enter measured data to calculate your system's annual savings potential. This loss is optional. If no data,
-      exhaust gas losses will be calculated from the difference between Gross Heat Input and Total Net Heat Required
+      exhaust gas losses will be calculated from the difference between Gross Heat Input and Total Available Heat Required
     </small>
   </h5>
   <label class="p-1" (click)="toggleSuggestions()">

--- a/src/app/phast/losses/operations/co2-savings-phast/co2-savings-phast.service.ts
+++ b/src/app/phast/losses/operations/co2-savings-phast/co2-savings-phast.service.ts
@@ -194,8 +194,6 @@ export class Co2SavingsPhastService {
     };
 
     if (settings.energySourceType == 'Electricity') { 
-      phastCopy.co2SavingsData.electricityUse = resultsCopy.electricalHeatDelivered;
-      let hourlyElectricityEmissionOutput = this.getCo2EmissionsResult(phastCopy.co2SavingsData, settings);
       if (settings.furnaceType == 'Electric Arc Furnace (EAF)') { 
         if (settings.unitsOfMeasure != 'Imperial') {
           co2EmissionsOutput.fuelEmissionOutput = this.convertUnitsService.value(co2EmissionsOutput.fuelEmissionOutput).from('GJ').to('MMBtu');
@@ -203,7 +201,7 @@ export class Co2SavingsPhastService {
         }
 
         // 1tonne / 1000kW * 1Mw/1000kW
-        hourlyElectricityEmissionOutput = phastCopy.co2SavingsData.totalEmissionOutputRate * 1/1000 * resultsCopy.hourlyEAFResults.electricEnergyUsed * 1/1000;
+        let hourlyElectricityEmissionOutput: number = phastCopy.co2SavingsData.totalEmissionOutputRate * 1/1000 * resultsCopy.hourlyEAFResults.electricEnergyUsed * 1/1000;
         // 1tonne / 1000kW or 1tonne / 1000kg
         let hourlyFuelEmissionOutput = resultsCopy.hourlyEAFResults.naturalGasUsed * phastCopy.co2SavingsData.totalNaturalGasEmissionOutputRate * 1/1000;
         let hourlyElectrodeUse: number = resultsCopy.hourlyEAFResults.electrodeUse;
@@ -230,6 +228,10 @@ export class Co2SavingsPhastService {
             fuelHeatInputTotal += exGas.totalHeatInput;
           });
         }
+
+        phastCopy.co2SavingsData.electricityUse = resultsCopy.electricalHeatDelivered + resultsCopy.electricalHeaterLosses;
+        let hourlyElectricityEmissionOutput: number = this.getCo2EmissionsResult(phastCopy.co2SavingsData, settings);
+
         let hourlyFuelEmissionOutput = fuelHeatInputTotal * phastCopy.co2SavingsData.totalFuelEmissionOutputRate;
         co2EmissionsOutput.hourlyTotalEmissionOutput = hourlyElectricityEmissionOutput + hourlyFuelEmissionOutput;
         // 1tonne / 1000kW or 1tonne / 1000kg

--- a/src/app/phast/phast-report/phast-input-summary/energy-input-exhaust-gas-summary/energy-input-exhaust-gas-summary.component.html
+++ b/src/app/phast/phast-report/phast-input-summary/energy-input-exhaust-gas-summary/energy-input-exhaust-gas-summary.component.html
@@ -35,7 +35,7 @@
                 {{data.baseline.name}}
               </th>
               <th [ngStyle]="{'width.%': 100 /(numMods+2)}" *ngFor="let mod of data.modifications">
-                <div class="alert-danger" *ngIf="!mod.phast.valid.inputExhaustValid && lossData.length == 1">
+                <div class="alert-danger" *ngIf="!mod.phast.valid && !mod.phast.valid.inputExhaustValid && lossData.length == 1">
                   Invalid Modification<br>
                   <span>Errors found in Energy Input Exhaust Gas<br></span>
                 </div>
@@ -46,7 +46,18 @@
           <tbody>
             <tr>
               <td>
-                Total Heat Input for Burners
+                Electrical Heater Efficiency
+              </td>
+              <td>
+                {{data.baseline.electricalHeaterEfficiency}}
+              </td>
+              <td *ngFor="let mod of data.modifications">
+                {{mod.electricalHeaterEfficiency}}
+              </td>
+            </tr> 
+            <tr>
+              <td>
+                Total Additional Fuel Heat
               </td>
               <td>
                 {{data.baseline.totalHeatInput}}
@@ -57,7 +68,7 @@
             </tr>          
             <tr>
               <td>
-                Fuel Heater Efficiency
+                Available Heat of Fuel
               </td>
               <td>
                 {{data.baseline.availableHeat}}

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -225,8 +225,8 @@
           <span *ngIf="!mod.exothermicHeat">&mdash; &mdash;</span>
         </td>
       </tr>
-      <tr *ngIf="showResultsCats.showEnInput2">
-        <td>Energy Input Available Heat</td>
+      <tr *ngIf="showResultsCats.showEnInput2" class="tr-border">
+        <td>Fuel Input Available Heat</td>
         <td *ngIf="baseLineResults.availableHeatPercent"
           [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
           {{baseLineResults.availableHeatPercent | number:'1.0-0'}}%</td>

--- a/src/app/phast/phast-report/results-data/results-data.component.html
+++ b/src/app/phast/phast-report/results-data/results-data.component.html
@@ -175,7 +175,7 @@
         </td>
       </tr>
       <tr>
-        <td>Total Net Heat Required</td>
+        <td>Total Available Heat Required</td>
         <td *ngIf="baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
           {{baseLineResults.totalInput | number: decimalCount}}</td>
         <td *ngIf="!baseLineResults.totalInput" [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
@@ -290,7 +290,6 @@
           <span *ngIf="!mod.totalSystemLosses">&mdash; &mdash;</span>
         </td>
       </tr>
-
       <tr *ngIf="showResultsCats.showHeatDelivered">
         <td>Fuel Heat Delivered</td>
         <td *ngIf="baseLineResults.energyInputHeatDelivered"
@@ -304,19 +303,20 @@
           <span *ngIf="!mod.energyInputHeatDelivered">&mdash; &mdash;</span>
         </td>
       </tr>
-      <tr *ngIf="showResultsCats.showElectricalDelivered && settings.furnaceType !== 'Electric Arc Furnace (EAF)'">
-        <td>Electrical Heat Delivered</td>
-        <td *ngIf="baseLineResults.electricalHeatDelivered"
+      <tr *ngIf="showResultsCats.showEnInput2">
+        <td>Total Additional Fuel Heat</td>
+        <td *ngIf="baseLineResults.totalAdditionalFuelHeat"
           [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-          {{baseLineResults.electricalHeatDelivered | number: decimalCount}}</td>
-        <td *ngIf="!baseLineResults.electricalHeatDelivered"
+          {{baseLineResults.totalAdditionalFuelHeat | number: decimalCount}}</td>
+        <td *ngIf="!baseLineResults.totalAdditionalFuelHeat"
           [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
         <td *ngFor="let mod of modificationResults; let index = index;"
           [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-          <span *ngIf="mod.electricalHeatDelivered">{{mod.electricalHeatDelivered | number: decimalCount}}</span>
-          <span *ngIf="!mod.electricalHeatDelivered">&mdash; &mdash;</span>
+          <span *ngIf="mod.totalAdditionalFuelHeat">{{mod.totalAdditionalFuelHeat | number: decimalCount}}</span>
+          <span *ngIf="!mod.totalAdditionalFuelHeat">&mdash; &mdash;</span>
         </td>
       </tr>
+
       <tr *ngIf="showResultsCats.showElectricalDelivered && settings.furnaceType === 'Electric Arc Furnace (EAF)'">
         <td>Electrical Heat Delivered</td>
         <td *ngIf="baseLineResults.energyInputHeatDelivered"
@@ -343,6 +343,52 @@
           <span *ngIf="!mod.energyInputTotalChemEnergy">&mdash; &mdash;</span>
         </td>
       </tr>
+
+      <tr class="tr-border" *ngIf="showResultsCats.showElectricalDelivered && settings.furnaceType !== 'Electric Arc Furnace (EAF)'">
+        <td>Electrical Heat Delivered</td>
+        <td *ngIf="baseLineResults.electricalHeatDelivered"
+          [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+          {{baseLineResults.electricalHeatDelivered | number: decimalCount}}</td>
+        <td *ngIf="!baseLineResults.electricalHeatDelivered"
+          [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
+        <td *ngFor="let mod of modificationResults; let index = index;"
+          [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+          <span *ngIf="mod.electricalHeatDelivered">{{mod.electricalHeatDelivered | number: decimalCount}}</span>
+          <span *ngIf="!mod.electricalHeatDelivered">&mdash; &mdash;</span>
+        </td>
+      </tr>
+
+      <ng-container *ngIf="showResultsCats.showEnInput2">
+        <tr>
+          <td>Electrical Heater Losses</td>
+          <td *ngIf="baseLineResults.electricalHeaterLosses"
+            [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baseLineResults.electricalHeaterLosses | number: decimalCount}}</td>
+          <td *ngIf="!baseLineResults.electricalHeaterLosses"
+            [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
+          <td *ngFor="let mod of modificationResults; let index = index;"
+            [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+            <span *ngIf="mod.electricalHeaterLosses">{{mod.electricalHeaterLosses | number: decimalCount}}</span>
+            <span *ngIf="!mod.electricalHeaterLosses">&mdash; &mdash;</span>
+          </td>
+        </tr>
+        <tr>
+          <td>Total Provided Electrical Heat</td>
+          <td *ngIf="baseLineResults.totalProvidedElectricalHeat"
+            [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baseLineResults.totalProvidedElectricalHeat | number: decimalCount}}</td>
+          <td *ngIf="!baseLineResults.totalProvidedElectricalHeat"
+            [ngClass]="{'selected-modification': selectedModificationIndex == -1}">&mdash; &mdash;</td>
+          <td *ngFor="let mod of modificationResults; let index = index;"
+            [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+            <span *ngIf="mod.totalProvidedElectricalHeat">{{mod.totalProvidedElectricalHeat | number:
+              decimalCount}}</span>
+            <span *ngIf="!mod.totalProvidedElectricalHeat">&mdash; &mdash;</span>
+          </td>
+        </tr>
+      </ng-container>
+
+
       <tr class="tr-border">
         <td style="font-weight: bold;">Gross Heat Input</td>
         <td *ngIf="baseLineResults.grossHeatInput" style="font-weight: bold;"
@@ -439,63 +485,69 @@
       </thead>
 
       <tbody>
-        <tr >
+        <tr>
           <td>Electrical </td>
           <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
             {{baseLineResults.annualEAFResults.electricEnergyUsed
             | number:'1.0-0'}}</td>
           <td *ngFor="let mod of modificationResults; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-            <span *ngIf="mod.annualEAFResults.electricEnergyUsed">{{mod.annualEAFResults.electricEnergyUsed | number:'1.0-0'}}</span>
+            <span *ngIf="mod.annualEAFResults.electricEnergyUsed">{{mod.annualEAFResults.electricEnergyUsed |
+              number:'1.0-0'}}</span>
             <span *ngIf="!mod.annualEAFResults.electricEnergyUsed">&mdash; &mdash;</span>
           </td>
         </tr>
         <tr>
           <td>Natural Gas </td>
-          <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">{{baseLineResults.annualEAFResults.naturalGasUsed
+          <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baseLineResults.annualEAFResults.naturalGasUsed
             |
             sigFigs:'3'}}</td>
           <td *ngFor="let mod of modificationResults; let index = index;"
             [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-            <span *ngIf="mod.annualEAFResults.naturalGasUsed">{{mod.annualEAFResults.naturalGasUsed | number:'1.0-0'}}</span>
+            <span *ngIf="mod.annualEAFResults.naturalGasUsed">{{mod.annualEAFResults.naturalGasUsed |
+              number:'1.0-0'}}</span>
             <span *ngIf="!mod.annualEAFResults.naturalGasUsed">&mdash; &mdash;</span>
           </td>
         </tr>
-          <tr>
-            <td>Coal Carbon  </td>
-            <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-              {{baseLineResults.annualEAFResults.coalCarbonUsed |
-              sigFigs:'3'}}</td>
-            <td *ngFor="let mod of modificationResults; let index = index;"
-              [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.annualEAFResults.coalCarbonUsed">{{mod.annualEAFResults.coalCarbonUsed | number:'1.0-0'}}</span>
-              <span *ngIf="!mod.annualEAFResults.coalCarbonUsed">&mdash; &mdash;</span>
-            </td>
-          </tr>
+        <tr>
+          <td>Coal Carbon </td>
+          <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baseLineResults.annualEAFResults.coalCarbonUsed |
+            sigFigs:'3'}}</td>
+          <td *ngFor="let mod of modificationResults; let index = index;"
+            [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+            <span *ngIf="mod.annualEAFResults.coalCarbonUsed">{{mod.annualEAFResults.coalCarbonUsed |
+              number:'1.0-0'}}</span>
+            <span *ngIf="!mod.annualEAFResults.coalCarbonUsed">&mdash; &mdash;</span>
+          </td>
+        </tr>
 
-          <tr>
-            <td>Electrode  </td>
-            <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-              {{baseLineResults.annualEAFResults.electrodeEnergyUsed |
-              sigFigs:'3'}}</td>
-            <td *ngFor="let mod of modificationResults; let index = index;"
-              [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.annualEAFResults.electrodeEnergyUsed">{{mod.annualEAFResults.electrodeEnergyUsed | number:'1.0-0'}}</span>
-              <span *ngIf="!mod.annualEAFResults.electrodeEnergyUsed">&mdash; &mdash;</span>
-            </td>
-          </tr>
+        <tr>
+          <td>Electrode </td>
+          <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baseLineResults.annualEAFResults.electrodeEnergyUsed |
+            sigFigs:'3'}}</td>
+          <td *ngFor="let mod of modificationResults; let index = index;"
+            [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+            <span *ngIf="mod.annualEAFResults.electrodeEnergyUsed">{{mod.annualEAFResults.electrodeEnergyUsed |
+              number:'1.0-0'}}</span>
+            <span *ngIf="!mod.annualEAFResults.electrodeEnergyUsed">&mdash; &mdash;</span>
+          </td>
+        </tr>
 
-          <tr>
-            <td>Other Fuel  </td>
-            <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
-              {{baseLineResults.annualEAFResults.otherFuelUsed |
-              sigFigs:'3'}}</td>
-            <td *ngFor="let mod of modificationResults; let index = index;"
-              [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.annualEAFResults.otherFuelUsed">{{mod.annualEAFResults.otherFuelUsed | number:'1.0-0'}}</span>
-              <span *ngIf="!mod.annualEAFResults.otherFuelUsed">&mdash; &mdash;</span>
-            </td>
-          </tr>
+        <tr>
+          <td>Other Fuel </td>
+          <td [ngClass]="{'selected-modification': selectedModificationIndex == -1}">
+            {{baseLineResults.annualEAFResults.otherFuelUsed |
+            sigFigs:'3'}}</td>
+          <td *ngFor="let mod of modificationResults; let index = index;"
+            [ngClass]="{'selected-modification': index == selectedModificationIndex}">
+            <span *ngIf="mod.annualEAFResults.otherFuelUsed">{{mod.annualEAFResults.otherFuelUsed |
+              number:'1.0-0'}}</span>
+            <span *ngIf="!mod.annualEAFResults.otherFuelUsed">&mdash; &mdash;</span>
+          </td>
+        </tr>
 
       </tbody>
     </ng-container>
@@ -565,7 +617,7 @@
           </td>
         </tr>
 
-      
+
         <ng-container *ngIf="settings.furnaceType === 'Electric Arc Furnace (EAF)'">
           <tr>
             <td> Coal Carbon CO<sub>2</sub> Emissions </td>
@@ -602,7 +654,9 @@
               number:'1.0-2'}}</td>
             <td *ngFor="let mod of modificationResults; let index = index;"
               [ngClass]="{'selected-modification': index == selectedModificationIndex}">
-              <span *ngIf="mod.co2EmissionsOutput.otherFuelEmissionsOutput">{{mod.co2EmissionsOutput.otherFuelEmissionsOutput | number:'1.0-2'}}</span>
+              <span
+                *ngIf="mod.co2EmissionsOutput.otherFuelEmissionsOutput">{{mod.co2EmissionsOutput.otherFuelEmissionsOutput
+                | number:'1.0-2'}}</span>
               <span *ngIf="!mod.co2EmissionsOutput.otherFuelEmissionsOutput">&mdash; &mdash;</span>
             </td>
           </tr>

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -13,6 +13,7 @@ import { FlueGasByVolumeSuiteResults, MaterialInputProperties } from '../shared/
 import { SqlDbApiService } from '../tools-suite-api/sql-db-api.service';
 import { FlueGasMaterial, SolidLiquidFlueGasMaterial } from '../shared/models/materials';
 
+import { EnergyExhaustGasOutput } from '../tools-suite-api/process-heating-api.service';
 
 
 @Injectable()
@@ -56,6 +57,7 @@ export class PhastResultsService {
       totalEnergyInputEAF: 0,
       totalEnergyInput: 0,
       totalExhaustGas: 0,
+      electricalHeaterLosses: 0,
       totalExhaustGasEAF: 0,
       totalSystemLosses: 0,
       exothermicHeat: 0,
@@ -109,7 +111,6 @@ export class PhastResultsService {
     let results: PhastResults = this.initResults();
     results.exothermicHeat = 0 - Math.abs(this.phastService.sumChargeMaterialExothermic(phast.losses.chargeMaterials, settings));
     results.totalInput = this.phastService.sumHeatInput(phast.losses, settings);
-    results.grossHeatInput = results.totalInput;
     if (this.checkLoss(phast.losses.wallLosses)) {
       results.totalWallLoss = this.phastService.sumWallLosses(phast.losses.wallLosses, settings);
     }
@@ -167,12 +168,15 @@ export class PhastResultsService {
     if (resultCats.showEnInput2 && this.checkLoss(phast.losses.energyInputExhaustGasLoss)) {
       let tmpForm = this.energyInputExhaustGasService.getFormFromLoss(phast.losses.energyInputExhaustGasLoss[0]);
       if (tmpForm.status === 'VALID') {
-        let tmpResults = this.phastService.energyInputExhaustGasLosses(phast.losses.energyInputExhaustGasLoss[0], settings);
-        results.energyInputHeatDelivered = tmpResults.heatDelivered;
-        results.totalExhaustGas = tmpResults.exhaustGasLosses;
-        results.grossHeatInput = results.totalInput - Math.abs(results.exothermicHeat) + tmpResults.exhaustGasLosses;
-        results.availableHeatPercent = tmpResults.availableHeat;
-        results.electricalHeatDelivered = results.grossHeatInput - results.energyInputHeatDelivered - results.totalExhaustGas;
+        let energyInputResults: EnergyExhaustGasOutput = this.phastService.energyInputExhaustGasLosses(phast.losses.energyInputExhaustGasLoss[0], settings);
+        results.energyInputHeatDelivered = energyInputResults.fuelHeatDelivered;
+        results.totalExhaustGas = energyInputResults.exhaustGasLosses;
+        results.availableHeatPercent = energyInputResults.availableHeat;
+        results.electricalHeatDelivered = results.totalInput - energyInputResults.fuelHeatDelivered;
+        results.electricalHeaterLosses = results.electricalHeatDelivered * ((1 / energyInputResults.electricalEfficiency) - 1);
+        results.totalAdditionalFuelHeat = phast.losses.energyInputExhaustGasLoss[0].totalHeatInput;
+        results.totalProvidedElectricalHeat = results.electricalHeatDelivered + results.electricalHeaterLosses;
+        results.grossHeatInput = results.totalInput - Math.abs(results.exothermicHeat) + energyInputResults.exhaustGasLosses + results.electricalHeaterLosses;
       }
     }
 
@@ -180,7 +184,6 @@ export class PhastResultsService {
       results.heatingSystemEfficiency = phast.systemEfficiency;
       let grossHeatInput = (results.totalInput / (phast.systemEfficiency / 100));
       results.totalSystemLosses = grossHeatInput * (1 - (phast.systemEfficiency / 100));
-
       results.grossHeatInput = results.totalInput + results.totalSystemLosses - Math.abs(results.exothermicHeat);
     }
 

--- a/src/app/phast/phast-results.service.ts
+++ b/src/app/phast/phast-results.service.ts
@@ -174,7 +174,15 @@ export class PhastResultsService {
         results.availableHeatPercent = energyInputResults.availableHeat;
         results.electricalHeatDelivered = results.totalInput - energyInputResults.fuelHeatDelivered;
         results.electricalHeaterLosses = results.electricalHeatDelivered * ((1 / energyInputResults.electricalEfficiency) - 1);
-        results.totalAdditionalFuelHeat = phast.losses.energyInputExhaustGasLoss[0].totalHeatInput;
+
+        let kWTotalAdditionalFuelHeat: number;
+        if (settings.unitsOfMeasure == 'Imperial') {
+          kWTotalAdditionalFuelHeat = this.convertUnitsService.value(phast.losses.energyInputExhaustGasLoss[0].totalHeatInput).from('MMBtu').to(settings.energyResultUnit);
+        } else {
+          kWTotalAdditionalFuelHeat = this.convertUnitsService.value(phast.losses.energyInputExhaustGasLoss[0].totalHeatInput).from('GJ').to(settings.energyResultUnit);
+        }
+        
+        results.totalAdditionalFuelHeat = kWTotalAdditionalFuelHeat;
         results.totalProvidedElectricalHeat = results.electricalHeatDelivered + results.electricalHeaterLosses;
         results.grossHeatInput = results.totalInput - Math.abs(results.exothermicHeat) + energyInputResults.exhaustGasLosses + results.electricalHeaterLosses;
       }

--- a/src/app/phast/phast.component.html
+++ b/src/app/phast/phast.component.html
@@ -71,7 +71,7 @@
         [containerHeight]="containerHeight"></app-phast-report>
   </div>
   <!--Sankey-->
-  <div *ngIf="mainTab == 'sankey'" class="mx-auto d-flex flex-column scroll-item"
+  <div *ngIf="mainTab == 'sankey'" class="d-flex flex-column scroll-item"
     [ngStyle]="{'height.px': containerHeight}">
     <nav class="navbar phast">
       <div *ngIf="showSankeyLabelOptions" class="d-flex justify-content-start align-items-center w-100 flex-wrap">

--- a/src/app/shared/models/phast/losses/energyInputExhaustGasLosses.ts
+++ b/src/app/shared/models/phast/losses/energyInputExhaustGasLosses.ts
@@ -5,5 +5,6 @@ export interface EnergyInputExhaustGasLoss {
     totalHeatInput?: number;
     otherLosses?: number;
     availableHeat?: number;
+    electricalHeaterEfficiency?: number;
     name?: string;
 }

--- a/src/app/shared/models/phast/phast.ts
+++ b/src/app/shared/models/phast/phast.ts
@@ -140,6 +140,9 @@ export interface PhastResults {
   calculatedFlueGasO2: number;
   availableHeatPercent: number;
   electricalHeatDelivered?: number;
+  electricalHeaterLosses?: number;
+  totalAdditionalFuelHeat?: number;
+  totalProvidedElectricalHeat?: number;
   co2EmissionsOutput?: PhastCo2EmissionsOutput
 }
 

--- a/src/app/tools-suite-api/process-heating-api.service.ts
+++ b/src/app/tools-suite-api/process-heating-api.service.ts
@@ -931,9 +931,13 @@ export interface EnergyEAFOutput {
 }
 
 export interface EnergyExhaustGasOutput {
-  heatDelivered: number,
+  fuelHeatDelivered: number,
   exhaustGasLosses: number,
-  availableHeat: number
+  availableHeat: number,
+  electricalEfficiency: number,
+  electricalHeaterLosses?: number,
+  phastElectricalHeatDelivered?: number,
+  phastEnergyInputTotal?: number
 }
 
 export interface HeatingValueByVolumeOutput {


### PR DESCRIPTION
#6538 #6536 #6526

Add electrical efficiency input, electrical heater losses result
remove/cleanup redundant form call to results
remove mx-auto causing sankey width problem
Change field names and help text
Stopped adding exhaust gas losses to "gross heat input"
Stop setting named result "input total" to "gross heat input" as a default value
Add results totalProvidedElectricalHeat, totalAdditionalFuelHeat

+ various name changes from 6536 and 6526