### PR TITLE
Updated web.yml - use dynamic node version setting for build job

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -10,10 +10,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Get Node version
+        run: echo "BUILD_NODE_VER=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> $GITHUB_ENV
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: ${{ env.BUILD_NODE_VER }}
       - name: Cache dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Piggybacking change: 

Update node setup step to dynamically set the node version based on the engine version of Node in `package.json`