### PR TITLE
Updated web.yml - add legacy-peer-deps flag for dependency resolution

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,7 +23,7 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: Build
         run: npm run build-prod-web
       - name: Upload artifact


### PR DESCRIPTION
Missed change. `--legacy-peer-deps` flag must be used with `npm install` to resolve dependencies.