### PR TITLE
Update mac build targets to universal architecture to support x86_64 and arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,17 @@
     },
     "mac": {
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": [
+            "universal"
+          ]
+        },{
+          "target": "zip",
+          "arch": [
+            "universal"
+          ]
+        }
       ],
       "icon": "src/assets/icons/mac/icon.icns",
       "hardenedRuntime": true,


### PR DESCRIPTION
Resolves #6835. 

Set build target architectures for both dmg and zip targets for MacOS to universal. The zip was set to universal due to otherwise providing only a zip of the architecture the build has been done on.