### PR TITLE
Remove updater download timeout

### DIFF
--- a/src/app/update-toast/update-toast.component.ts
+++ b/src/app/update-toast/update-toast.component.ts
@@ -108,9 +108,6 @@ export class UpdateToastComponent implements OnInit {
     this.downloadingUpdate = true;
     this.cd.detectChanges();
     this.electronService.sendUpdateSignal();
-    setTimeout(() => {
-      this.error = true;
-    }, 120000)
   }
 
   async quitAndInstall() {


### PR DESCRIPTION
#6856 

This is causing the ghost error to display - I don't believe this is needed. Errors should be caught by the error sub defined on init...