### PR TITLE
Issue-6949 fix binding translation for mediumPressureCondensateFlashTank

### DIFF
--- a/src/app/ssmt/ssmt-diagram/flash-tank-diagram/flash-tank-diagram.component.ts
+++ b/src/app/ssmt/ssmt-diagram/flash-tank-diagram/flash-tank-diagram.component.ts
@@ -17,7 +17,7 @@ export class FlashTankDiagramComponent implements OnInit {
   @Output('emitSelectEquipment')
   emitSelectEquipment = new EventEmitter<string>();
   @Input()
-  flashTankType: string;
+  flashTankType: 'highPressure' | 'mediumPressure';
   @Input()
   settings: Settings;
 

--- a/src/app/tools-suite-api/steam-suite-api.service.ts
+++ b/src/app/tools-suite-api/steam-suite-api.service.ts
@@ -609,6 +609,17 @@ export class SteamSuiteApiService {
         lowPressureCondensate.delete();
       }
 
+      let lowPressureFlashedSteamIntoHeaderCalculatorDomain = lowPressureHeaderCalculationsDomain.lowPressureFlashedSteamIntoHeaderCalculatorDomain;
+      if (lowPressureFlashedSteamIntoHeaderCalculatorDomain) {
+        let mediumPressureCondensateFlashTank = lowPressureFlashedSteamIntoHeaderCalculatorDomain.mediumPressureCondensateFlashTank;
+        ssmtOutput.mediumPressureCondensateFlashTank = this.getFlashTankOutput(mediumPressureCondensateFlashTank);
+        if (mediumPressureCondensateFlashTank) {
+          mediumPressureCondensateFlashTank.delete();
+        }
+  
+        lowPressureFlashedSteamIntoHeaderCalculatorDomain.delete();
+      }
+
       lowPressureHeaderCalculationsDomain.delete();
     }
 
@@ -653,16 +664,7 @@ export class SteamSuiteApiService {
       mediumPressureHeaderCalculationsDomain.delete();
     }
 
-    let LowPressureFlashedSteamIntoHeaderCalculatorDomain = wasmOutput.LowPressureFlashedSteamIntoHeaderCalculatorDomain;
-    if (LowPressureFlashedSteamIntoHeaderCalculatorDomain) {
-      let mediumPressureCondensateFlashTank = LowPressureFlashedSteamIntoHeaderCalculatorDomain.mediumPressureCondensateFlashTank;
-      ssmtOutput.mediumPressureCondensateFlashTank = this.getFlashTankOutput(mediumPressureCondensateFlashTank);
-      if (mediumPressureCondensateFlashTank) {
-        mediumPressureCondensateFlashTank.delete();
-      }
 
-      LowPressureFlashedSteamIntoHeaderCalculatorDomain.delete();
-    }
 
     let operationsOutput: SSMTOperationsOutput;
 


### PR DESCRIPTION
connects #6949 

The translation of the WASM binding was pointing one level too high for mediumPressureCondensateFlashTank. 

Fixed.