### PR TITLE
Issue 6969

### DIFF
--- a/src/app/compressed-air-assessment/compressed-air-data-management.service.ts
+++ b/src/app/compressed-air-assessment/compressed-air-data-management.service.ts
@@ -219,7 +219,8 @@ export class CompressedAirDataManagementService {
       }
     });
     //TODO: Recalculate other control types??
-    if (recalculateOrdering && compressedAirAssessment.systemInformation.multiCompressorSystemControls == 'cascading') {
+    //issue 6969 updated to include baseTrim
+    if (recalculateOrdering && (compressedAirAssessment.systemInformation.multiCompressorSystemControls == 'cascading' || compressedAirAssessment.systemInformation.multiCompressorSystemControls == 'baseTrim')) {
       let numberOfHourIntervals: number = compressedAirAssessment.systemProfile.systemProfileSetup.numberOfHours / compressedAirAssessment.systemProfile.systemProfileSetup.dataInterval;
       compressedAirAssessment.compressedAirDayTypes.forEach(dayType => {
         compressedAirAssessment.systemProfile.profileSummary = this.systemProfileService.updateCompressorOrderingCascading(compressedAirAssessment.systemProfile.profileSummary, dayType, numberOfHourIntervals);
@@ -230,7 +231,6 @@ export class CompressedAirDataManagementService {
       compressedAirAssessment.compressedAirDayTypes.forEach(dayType => {
         compressedAirAssessment.systemProfile.profileSummary = this.systemProfileService.updateCompressorOrderingIsentropicEfficiency(compressedAirAssessment.systemProfile.profileSummary, dayType, numberOfHourIntervals, compressedAirAssessment.compressorInventoryItems, settings, compressedAirAssessment.systemInformation);
       })
-
     }
     //update assessment
     this.compressedAirAssessmentService.updateCompressedAir(compressedAirAssessment, true);

--- a/src/app/compressed-air-assessment/system-profile-graphs/system-profile-graphs.component.ts
+++ b/src/app/compressed-air-assessment/system-profile-graphs/system-profile-graphs.component.ts
@@ -519,7 +519,7 @@ export class SystemProfileGraphsComponent implements OnInit {
   getCompressorName(compressorId: string): string {
     let compressor: CompressorInventoryItem = this.inventoryItems.find(item => { return item.itemId == compressorId });
 
-    if (compressor) {
+    if (compressor && this.selectedDayType) {
       if (this.compressedAirAssessment.systemInformation.multiCompressorSystemControls == 'baseTrim') {
         let selection = this.compressedAirAssessment.systemInformation.trimSelections.find(selection => { return selection.dayTypeId == this.selectedDayType.dayTypeId && selection.compressorId == compressorId });
         if (selection != undefined) {


### PR DESCRIPTION
- Fix bug when navigating away from system profile graphs in CA assessment
- Update system profile when control type is 'baseTrim'

connects #6969 

TODO: we need to update the logic for basetrim ordering to have the selected trim compressor be last. This isn't easily done given the current setup of the profile. Further work to come on this.