### PR TITLE
Issue 6984 - use new measur_app_open_v2

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,7 +32,10 @@ export class AppComponent {
     if (environment.production) {
       // analytics handled through gatg() automatically manages sessions, visits, clicks, etc
       gtag('config', 'G-EEHE8GEBH4');
-      this.analyticsService.sendEvent('measur_app_open_v2');
+
+      if (!this.electronService.isElectron) {
+        this.analyticsService.sendEvent('measur_app_open_v2');
+      }
       this.router.events.subscribe(event => {
         if (event instanceof NavigationEnd) {
           let path: string = environment.production ? event.urlAfterRedirects : 'testing-web';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,7 +32,7 @@ export class AppComponent {
     if (environment.production) {
       // analytics handled through gatg() automatically manages sessions, visits, clicks, etc
       gtag('config', 'G-EEHE8GEBH4');
-      this.analyticsService.sendEvent('measur_app_open');
+      this.analyticsService.sendEvent('measur_app_open_v2');
       this.router.events.subscribe(event => {
         if (event instanceof NavigationEnd) {
           let path: string = environment.production ? event.urlAfterRedirects : 'testing-web';

--- a/src/app/shared/analytics/analytics.service.ts
+++ b/src/app/shared/analytics/analytics.service.ts
@@ -42,7 +42,7 @@ export class AnalyticsService {
   async initAnalyticsSession(path: string) {
     await this.setClientAnalyticsId();
     let measurOpenEvent: GAEvent = {
-      name: 'measur_app_open',
+      name: 'measur_app_open_v2',
       params: {
         measur_platform: 'measur-desktop',
         measur_version: environment.version,

--- a/src/app/shared/analytics/analytics.service.ts
+++ b/src/app/shared/analytics/analytics.service.ts
@@ -39,7 +39,7 @@ export class AnalyticsService {
     this.setClientId(clientId);
   }
 
-  async initAnalyticsSession(path: string) {
+  async initAnalyticsSession(path?: string) {
     await this.setClientAnalyticsId();
     let measurOpenEvent: GAEvent = {
       name: 'measur_app_open_v2',
@@ -54,14 +54,6 @@ export class AnalyticsService {
     };
     this.postEventToMeasurementProtocol(measurOpenEvent);
     if (path) {
-      this.sendAnalyticsPageView(path);
-    }
-  }
-
-  async sendAnalyticsPageView(path: string) {
-    if (!this.clientId) {
-      await this.initAnalyticsSession(path);
-    } else {
       let pageViewEvent: GAEvent = {
         name: 'page_view',
         params: {
@@ -71,13 +63,13 @@ export class AnalyticsService {
           session_id: this.analyticsSessionId
         }
       }
-      this.postEventToMeasurementProtocol(pageViewEvent)
+      this.sendAnalyticsEvent(pageViewEvent.name, pageViewEvent.params);
     }
   }
 
   async sendAnalyticsEvent(eventName: AnalyticsEventString, eventParams: EventParameters) {
     if (!this.clientId) {
-      await this.initAnalyticsSession(undefined);
+      await this.initAnalyticsSession();
     } else {
       eventParams.session_id = this.analyticsSessionId;
       let pageViewEvent: GAEvent = {
@@ -152,8 +144,6 @@ export class AnalyticsService {
           session_id: undefined
         }
         gtag('event', eventName, eventParams);
-      } else if (path) {
-        this.sendAnalyticsPageView(path)
       } else {
         let eventParams: EventParameters = {
           page_path: path,

--- a/src/app/shared/analytics/analyticsEventTypes.ts
+++ b/src/app/shared/analytics/analyticsEventTypes.ts
@@ -1,6 +1,6 @@
 
 export type AnalyticsEventString = 'page_view' |
-    'measur_app_open' |
+    'measur_app_open_v2' |
     'create-assessment' |
     'view-pump-assessment' |
     'view-process-heating-assessment' |


### PR DESCRIPTION
#6984 

- Change to new event name (fix bunk data in GA)
- Prevent measur_app_open_v2 being called twice in electron. Logic got a little circular when we built this up - I have a note on some improvements to be made hwen we look at this closer.
- Removed redundant method 