### PR TITLE
Automate Windows build signing

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Dependency setup
         run: |
           PROV_PROF_PATH=$RUNNER_TEMP/embedded.provisionprofile
+          WIN_CERT_PATH=$RUNNER_TEMP/wincert.pem
+          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $WIN_CERT_PATH &&
+          cp "$WIN_CERT_PATH" ./wincert.pem
           echo -n "${{ secrets.APPLE_PROV_PROF_BASE64 }}" | base64 --decode -o $PROV_PROF_PATH &&
           cp "$PROV_PROF_PATH" ./embedded.provisionprofile
           npm ci --legacy-peer-deps &&
@@ -37,12 +40,22 @@ jobs:
       - name: Package
         run: |
           (node ./node_modules/.bin/electron-builder --mac --universal --publish never &&
-          xcrun notarytool submit --wait \
-            --apple-id "${{ secrets.APPLE_ID }}" \
-            --password "${{ secrets.APPLE_APP_SECRET }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            $(find ../output -name "MEASUR-*.*.*.dmg")) &
-          node ./node_modules/.bin/electron-builder --win --x64 --publish never &
+            xcrun notarytool submit --wait \
+              --apple-id "${{ secrets.APPLE_ID }}" \
+              --password "${{ secrets.APPLE_APP_SECRET }}" \
+              --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+              $(find ../output -name "MEASUR-*.*.*.dmg")) &
+          (node ./node_modules/.bin/electron-builder --win --x64 --publish never &&
+            EXE_PATH=$(find ../output -name "MEASUR-Setup-*.*.*.exe") &&
+            java -jar ~/jsign.jar \
+              --storetype "${{ secrets.WIN_STORE_TYPE }}" \
+              --storepass "${{ secrets.WIN_STORE_SECRET }}" \
+              --tsaurl "http://timestamp.sectigo.com"
+              --certfile ./wincert.pem \
+              $EXE_PATH &&
+            (OLD_HASH=$(grep -o -P -m 1 '(?<=sha512:\s).*' ../output/latest.yml) &
+            NEW_HASH=$(node ~/gen_hash.js -f $EXE_PATH)) &&
+            sed 's|'$OLD_HASH'|'$NEW_HASH'|g' ../output/latest.yml) &
           node ./node_modules/.bin/electron-builder --linux --x64 --publish never
       - name: Prepare output
         id: output
@@ -51,7 +64,6 @@ jobs:
           echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           OUTPUTS_DIR=$(cd ../output/ && pwd)
           echo "RUNNER_OUTDIR=$OUTPUTS_DIR" >> "$GITHUB_ENV"
-          ls -lah
       - name: Upload notarization artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -97,7 +109,7 @@ jobs:
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-22.04
-    needs: [notarization]
+    needs: [build,notarization]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Node setup
         run: source ~/load_nvm.sh && nvm install ${{ env.BUILD_NODE_VER }}
       - name: Cache setup
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -65,17 +65,17 @@ jobs:
           OUTPUTS_DIR=$(cd ../output/ && pwd)
           echo "RUNNER_OUTDIR=$OUTPUTS_DIR" >> "$GITHUB_ENV"
       - name: Upload notarization artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: d-output
+          name: init-mac-output
           path: |
             ${{ env.RUNNER_OUTDIR }}/*.dmg
           if-no-files-found: error
-          retention-days: 3
+          retention-days: 1
       - name: Upload remaining artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: o-output
+          name: final-winux-output
           path: |
             ${{ env.RUNNER_OUTDIR }}/*
             !${{ env.RUNNER_OUTDIR }}/*-unpacked
@@ -93,15 +93,15 @@ jobs:
     needs: [build]
     steps:
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: d-output
+          name: init-mac-output
       - name: Notarize
         run: xcrun stapler staple $(find ./ -name "MEASUR-*.*.*.dmg")
       - name: Upload notarized artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: d-output
+          name: final-mac-output
           path: ./*.dmg
           if-no-files-found: error
           retention-days: 3
@@ -114,7 +114,9 @@ jobs:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          pattern: final-*
       - name: Release
         uses: softprops/action-gh-release@v1
         # if: startsWith(github.ref, 'refs/tags/') # Uncomment if enabling tag gating
@@ -124,5 +126,5 @@ jobs:
           draft: true # Comment out if enabling tag gating and publishing via action
           generate_release_notes: false
           files: |
-            d-output/*
-            o-output/*
+            final-mac-output/*
+            final-winux-output/*

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -70,6 +70,7 @@ jobs:
           name: init-mac-output
           path: |
             ${{ env.RUNNER_OUTDIR }}/*.dmg
+          compression-level: 1
           if-no-files-found: error
           retention-days: 1
       - name: Upload remaining artifacts
@@ -82,8 +83,9 @@ jobs:
             !${{ env.RUNNER_OUTDIR }}/*-universal
             !${{ env.RUNNER_OUTDIR }}/*.dmg
             !${{ env.RUNNER_OUTDIR }}/builder-debug.yml
+          compression-level: 1
           if-no-files-found: error
-          retention-days: 3
+          retention-days: 1
     outputs:
       BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
@@ -103,8 +105,9 @@ jobs:
         with:
           name: final-mac-output
           path: ./*.dmg
+          compression-level: 1
           if-no-files-found: error
-          retention-days: 3
+          retention-days: 1
 
   release:
     if: github.ref_name == 'master'

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -32,10 +32,12 @@ jobs:
       - name: Build
         run: npm run build-prod-web
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./dist
+          if-no-files-found: error
+          retention-days: 3
 
   deploy-dev:
     if: github.ref_name == 'develop'
@@ -46,7 +48,7 @@ jobs:
       BACKUP_DIR: /opt/actions-runner/backups
     steps:
       - name: Get artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
       - name: Deploy
@@ -55,7 +57,7 @@ jobs:
           rm -rf $APACHE_DIR/measur/*
           chgrp -R apache ./
           mv -v ./* $APACHE_DIR/measur/
-  
+
   deploy-prod:
     if: github.ref_name == 'master'
     runs-on: [self-hosted, prod]
@@ -65,7 +67,7 @@ jobs:
       BACKUP_DIR: /opt/actions-runner/backups
     steps:
       - name: Get artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
       - name: Deploy


### PR DESCRIPTION
Implements automation for signing Windows builds via Jsign. 

Additional changes: 
- Upgraded to usage of `upload-artifact@v4` and `download-artifact@v4` which implement artifact immutability
  - Applies to both web and desktop pipelines
- Reduced compression for uploading build artifacts for desktop releases given the artifact contents
- Reduced artifact retention rules given artifacts are ultimately uploaded to releases