### PR TITLE
hotfix/automate-windows-build-signing - Resolve jsign syntax during windows build

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -51,7 +51,7 @@ jobs:
             java -jar ~/jsign.jar \
               --storetype "${{ secrets.WIN_STORE_TYPE }}" \
               --storepass "${{ secrets.WIN_STORE_SECRET }}" \
-              --tsaurl "http://timestamp.sectigo.com"
+              --tsaurl "http://timestamp.sectigo.com" \
               --certfile ./wincert.pem \
               $EXE_PATH &&
             (OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ../output/latest.yml) &

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -40,12 +40,7 @@ jobs:
         run: npm run build-prod-desktop-ci
       - name: Package
         run: |
-          (node ./node_modules/.bin/electron-builder --mac --universal --publish never &&
-            xcrun notarytool submit --wait \
-              --apple-id "${{ secrets.APPLE_ID }}" \
-              --password "${{ secrets.APPLE_APP_SECRET }}" \
-              --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-              $(find ../output -name "MEASUR-*.*.*.dmg")) &
+          node ./node_modules/.bin/electron-builder --mac --universal --publish never &
           (node ./node_modules/.bin/electron-builder --win --x64 --publish never &&
             EXE_PATH=$(find ../output -name "MEASUR-Setup-*.*.*.exe") &&
             java -jar ~/jsign.jar \
@@ -100,7 +95,10 @@ jobs:
         with:
           name: init-mac-output
       - name: Notarize
-        run: xcrun stapler staple $(find ./ -name "MEASUR-*.*.*.dmg")
+        run: |
+          xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $(find ./ -name "MEASUR-*.*.*.dmg") &&
+          sleep 60 &&
+          xcrun stapler staple $(find ./ -name "MEASUR-*.*.*.dmg")
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Resolve jsign not receiving file during building and signing process of Windows .exe.

Additionally relocated MacOS notarization submission to notarization step instead of doing so during building and added an additional period of sleep prior to stapling.