### PR TITLE
bugfix/7067-sed-find-and-replace-of-hashes

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -51,7 +51,7 @@ jobs:
               $EXE_PATH &&
             (OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ../output/latest.yml) &
             NEW_HASH=$(node ~/gen_hash.js -f $EXE_PATH)) &&
-            sed -i '' 's|'$OLD_HASH'|'$NEW_HASH'|g' ../output/latest.yml) &
+            sed -i.bk "s|$OLD_HASH|$NEW_HASH|g" ../output/latest.yml) &
           node ./node_modules/.bin/electron-builder --linux --x64 --publish never
       - name: Prepare output
         id: output

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -35,7 +35,6 @@ jobs:
           cp "$PROV_PROF_PATH" ./embedded.provisionprofile
           npm ci --legacy-peer-deps &&
           security -v unlock-keychain -p "${{ secrets.KC_SECRET }}" ~/Library/Keychains/login.keychain-db
-          rm -rf ../output/*
       - name: Build
         run: npm run build-prod-desktop-ci
       - name: Package
@@ -82,6 +81,9 @@ jobs:
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
+      - name: Cleanup
+        run: |
+          rm -rf ../output/*
     outputs:
       BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 


### PR DESCRIPTION
Resolves #7067. 

- Added in-place suffix for sed find and replace for `latest.yml` 
- Piggybacked relocating cleanup to end of build job.