### PR TITLE
Issue 7258 - Fix: percent cost savings equals savings divided by total baseline cost

### DIFF
--- a/src/app/compressed-air-assessment/compressed-air-assessment-results.service.ts
+++ b/src/app/compressed-air-assessment/compressed-air-assessment-results.service.ts
@@ -460,7 +460,7 @@ export class CompressedAirAssessmentResultsService {
     if (dayTypeModificationResult.allSavingsResults.paybackPeriod < 0) {
       dayTypeModificationResult.allSavingsResults.paybackPeriod = 0;
     }
-    dayTypeModificationResult.allSavingsResults.savings.percentSavings = ((baselineResults.total.totalAnnualOperatingCost - dayTypeModificationResult.totalAnnualOperatingCost) / dayTypeModificationResult.totalAnnualOperatingCost) * 100
+    dayTypeModificationResult.allSavingsResults.savings.percentSavings = ((baselineResults.total.totalAnnualOperatingCost - dayTypeModificationResult.totalAnnualOperatingCost) / baselineResults.total.totalAnnualOperatingCost) * 100
 
     return dayTypeModificationResult;
   }


### PR DESCRIPTION
#7258 