### PR TITLE
bugfix/7067-sed-find-and-replace-of hashes

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -50,7 +50,7 @@ jobs:
               $EXE_PATH &&
             (OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ../output/latest.yml) &
             NEW_HASH=$(node ~/gen_hash.js -f $EXE_PATH)) &&
-            sed -i.bk "s|$OLD_HASH|$NEW_HASH|g" ../output/latest.yml) &
+            fndrep $OLD_HASH $NEW_HASH ../output/latest.yml) &
           node ./node_modules/.bin/electron-builder --linux --x64 --publish never
       - name: Prepare output
         id: output


### PR DESCRIPTION
Updated electron workflow find and replacement of hash post-signing to handle replacement with different method due to sed changes presenting the previously reported bug.