### PR TITLE
Separate workflow for qa water-assessment, requiring child-project install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  qa-water:
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'water-assessment'
+    uses: ./.github/workflows/release_qa_water.yml
+  
   qa:
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/release_qa.yml
+    if: github.event_name == 'workflow_dispatch' && github.ref_name != 'water-assessment'
+    uses: ./.github/workflows/release_qa.yml  
 
   web:
     if: github.ref_name == 'develop' || github.ref_name == 'master'

--- a/.github/workflows/release_qa_water.yml
+++ b/.github/workflows/release_qa_water.yml
@@ -1,0 +1,23 @@
+name: "Release: QA Water"
+
+on:
+  workflow_call:
+
+jobs:
+  call_install_diagram:
+    uses: ./.github/workflows/template_install_diagram.yml
+
+  call_build_measur:
+    needs: [call_install_diagram]
+    uses: ./.github/workflows/template_build.yml
+    with:
+      artifact-name: dist
+      artifact-path: dist
+
+  call_deploy-qa-water:
+    needs: [call_install_diagram, call_build_measur]
+    uses: ./.github/workflows/template_deploy.yml
+    with:
+      app-dir: qa.measur
+      artifact-name: dist
+      deploy-dir: /var/www/

--- a/.github/workflows/template_install_diagram.yml
+++ b/.github/workflows/template_install_diagram.yml
@@ -1,0 +1,26 @@
+name: "Template: Install Diagram"
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Get Node version
+        run: echo "BUILD_NODE_VER=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' ./process-flow-diagram-component/package.json)" >> $GITHUB_ENV
+      - name: Node setup
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.BUILD_NODE_VER }}
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('./process-flow-diagram-component/package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        working-directory: ./process-flow-diagram-component
+        run: npm ci


### PR DESCRIPTION
Please review:
- Note lack of conditional branch names in the qa_water workflow (not needed if main entry point has it?)
- Removed artifact name inputs (dist will be copied into measur dist by measur build
- not sure if cached deps is necessary