### PR TITLE
Issue 7573 - Fix broken DTA on large datasets

### DIFF
--- a/src/app/log-tool/log-tool-data.service.ts
+++ b/src/app/log-tool/log-tool-data.service.ts
@@ -6,6 +6,7 @@ import { LogToolDay, LogToolField, IndividualDataFromCsv, ExplorerData, Explorer
 import { BehaviorSubject } from 'rxjs';
 import { CsvImportData, CsvToJsonService } from '../shared/helper-services/csv-to-json.service';
 import { MeasurMessageData } from '../shared/models/utilities';
+import { copyObject } from '../shared/helperFunctions';
 
 @Injectable()
 export class LogToolDataService {
@@ -69,7 +70,14 @@ export class LogToolDataService {
   }
 
   setLogToolDays() {
-    let explorerDatasets: Array<ExplorerDataSet> = JSON.parse(JSON.stringify(this.logToolService.individualDataFromCsv));
+    // this.logToolService.individualDataFromCsv.forEach((dataset: ExplorerDataSet) => {
+    //   let stringData = JSON.stringify(dataset);
+    //   let dataStr = 'data:text/json;charset=utf-8,' + encodeURIComponent(stringData);
+    //   const dataMB = dataStr.length / 1024 / 1024; 
+    //   console.log(dataStr.length, dataMB);
+    // });
+    
+    let explorerDatasets: Array<ExplorerDataSet> = copyObject(this.logToolService.individualDataFromCsv);
     this.logToolDays = new Array();
     explorerDatasets.forEach((dataset: ExplorerDataSet) => {
       let dataForDays: Array<{ date: Date, data: Array<any> }> = this.divideDataIntoDays(dataset.csvImportData.data, dataset.dateField.fieldName);

--- a/src/app/log-tool/visualize/visualize-sidebar/visualize-sidebar.service.ts
+++ b/src/app/log-tool/visualize/visualize-sidebar/visualize-sidebar.service.ts
@@ -502,13 +502,26 @@ export class VisualizeSidebarService {
     }
     selectedGraphObj.bins = new Array();
     let maxValue = Number(_.max(selectedGraphObj.selectedXAxisDataOption.data));
+
+    // todo 7573 Bug ' bin size out of range' - cannot reproduce, adding logging below 
+    console.log('maxValue', maxValue);
+    console.log('binlength', selectedGraphObj.bins.length);
+    console.log('binSize', selectedGraphObj.binSize);
+    console.log('starting maxValue, lowerbound', maxValue, lowerBound);
+
     if (selectedGraphObj.binningMethod == 'binSize') {
-      for (lowerBound; lowerBound <= maxValue; lowerBound += selectedGraphObj.binSize) {
-        selectedGraphObj.bins.push({
-          min: Math.floor(lowerBound),
-          max: Math.floor(lowerBound + selectedGraphObj.binSize)
-        })
-      };
+      try {
+        for (lowerBound; lowerBound <= maxValue; lowerBound += selectedGraphObj.binSize) {
+          selectedGraphObj.bins.push({
+            min: Math.floor(lowerBound),
+            max: Math.floor(lowerBound + selectedGraphObj.binSize)
+          })
+        };
+      } catch (e) {
+        console.error(e);
+        console.log('error maxValue, lowerbound', maxValue, lowerBound);
+        console.log('error binlength', selectedGraphObj.bins.length);
+      }
       selectedGraphObj.numberOfBins = selectedGraphObj.bins.length;
     } else {
       for (let binNum = 0; binNum < selectedGraphObj.numberOfBins; binNum++) {


### PR DESCRIPTION
#7573 
Use copyObject in place of stringify for large datasets in DE DTA d logging