### PR TITLE
Issue 7678 - Remove Process Heating Wall SQL lite dependency

### DIFF
--- a/src/app/calculator/furnaces/wall/wall-form/wall-form.component.html
+++ b/src/app/calculator/furnaces/wall/wall-form/wall-form.component.html
@@ -183,7 +183,7 @@
             New Surface</a>
         </label>
         <select name="{{'surfaceShape'+idString}}" class="form-control" id="{{'surfaceShape'+idString}}"
-          formControlName="surfaceShape" (change)="setProperties()" (focus)="focusField('surfaceShape')">
+          formControlName="surfaceShape" (change)="setConditionFactor()" (focus)="focusField('surfaceShape')">
           <option *ngFor="let option of surfaceOptions" [ngValue]="option.id">{{option.surface}}</option>
         </select>
       </div>

--- a/src/app/core/core.component.ts
+++ b/src/app/core/core.component.ts
@@ -217,6 +217,7 @@ export class CoreComponent implements OnInit {
         await this.coreService.setNewApplicationInstanceData();
         await this.coreService.createDefaultDirectories();
         await this.coreService.createExamples();
+        await this.coreService.createDefaultProcessHeatingMaterials();
         await this.coreService.createDirectorySettings();
       } catch (e) {
         this.appErrorService.handleAppError(e, 'Error creating MEASUR database');

--- a/src/app/core/core.service.ts
+++ b/src/app/core/core.service.ts
@@ -24,6 +24,7 @@ import { DiagramIdbService } from '../indexedDb/diagram-idb.service';
 import { MockWaterdiagram } from '../examples/mockWaterDiagram';
 import { Diagram } from '../shared/models/diagram';
 import { ApplicationInstanceDbService, ApplicationInstanceData } from '../indexedDb/application-instance-db.service';
+import { WallLossesSurfaceDbService } from '../indexedDb/wall-losses-surface-db.service';
 @Injectable()
 export class CoreService {
 
@@ -50,6 +51,7 @@ export class CoreService {
     private electronService: ElectronService,
     private diagramIdbService: DiagramIdbService,
     private applicationDataService: ApplicationInstanceDbService,
+    private wallLossesSurfaceDbService: WallLossesSurfaceDbService,
     private directoryDbService: DirectoryDbService) {
       this.showShareDataModal = new BehaviorSubject<boolean>(false);
   }
@@ -174,6 +176,12 @@ export class CoreService {
 
     MockFsatCalculator.assessmentId = this.exampleFsatId;
     await firstValueFrom(this.calculatorDbService.addWithObservable(MockFsatCalculator));
+  }
+
+    async createDefaultProcessHeatingMaterials(): Promise<void> {
+      let updatedIds = await firstValueFrom(this.wallLossesSurfaceDbService.insertDefaultMaterials());
+
+      return Promise.resolve();
   }
 
   async createDirectorySettings() {

--- a/src/app/indexedDb/wall-losses-surface-db.service.ts
+++ b/src/app/indexedDb/wall-losses-surface-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, map, Observable } from 'rxjs';
 import { WallLossesSurface } from '../shared/models/materials';
 import { WallLossesSurfaceStoreMeta } from './dbConfig';
 
@@ -13,6 +13,30 @@ export class WallLossesSurfaceDbService {
   constructor(private dbService: NgxIndexedDBService) {
     this.dbWallLossesSurfaceMaterials = new BehaviorSubject<Array<WallLossesSurface>>([]);
 
+  }
+
+  insertDefaultMaterials(): Observable<number[]> {
+    // todo will get from MEASUR-Tool-suite defaultProcessHeatingMaterialsApi
+    let defaultMaterials: WallLossesSurface[] = [
+      { surface: "Horizontal cylinders", conditionFactor: 1.016 },
+      { surface: "Longer vertical cylinders", conditionFactor: 1.235 },
+      { surface: "Vertical plates", conditionFactor: 1.394 },
+      { surface: "Horizontal plate facing up, warmer than air", conditionFactor: 1.79 },
+      { surface: "Horizontal plate facing down, warmer than air", conditionFactor: 0.89 },
+      { surface: "Horizontal plate facing up, cooler than air", conditionFactor: 0.89 },
+      { surface: "Horizontal plate facing down, cooler than air", conditionFactor: 1.79 },
+    ];
+
+    defaultMaterials = defaultMaterials.map(material => {
+      return { ...material, isDefault: true };
+    });
+    return this.dbService.bulkAdd(this.storeName, defaultMaterials);
+  }
+
+  getAllCustomMaterials(): Observable<Array<WallLossesSurface>> {
+    return this.dbService.getAll(this.storeName).pipe(
+      map((materials: WallLossesSurface[]) => materials.filter((material: WallLossesSurface) => !material.isDefault))
+    );
   }
 
   getAllWithObservable(): Observable<Array<WallLossesSurface>> {

--- a/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.html
+++ b/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.html
@@ -5,7 +5,7 @@
       edit the custom material, please use the Custom Materials database or click 'Restore Surface Material'.
     </div>
     <div class="d-flex justify-content-around">
-      <a class="click-link" (click)="showMaterialModal(true)">Restore Surface Material</a>
+      <a class="click-link" (click)="showMaterialModal()">Restore Surface Material</a>
       <a class="click-link" (click)="dismissMessage()">Dismiss Material</a>
     </div>
   </div>
@@ -68,11 +68,11 @@
 
     <div class="form-group">
       <label class="small" for="{{'surfaceShape'+idString}}">Surface Shape / Orientation
-        <a id="materialHelp" class="form-text small click-link" (click)="showMaterialModal(false)" [ngClass]="{'disabled-link': !baselineSelected}">Add
+        <a id="materialHelp" class="form-text small click-link" (click)="showMaterialModal(true)" [ngClass]="{'disabled-link': !baselineSelected}">Add
           New Surface</a>
       </label>
       <select name="{{'surfaceShape'+lossIndex}}" class="form-control" id="{{'surfaceShape'+idString}}"
-        formControlName="surfaceShape" (change)="setProperties()" (focus)="focusField('surfaceShape')" 
+        formControlName="surfaceShape" (change)="setConditionFactor()" (focus)="focusField('surfaceShape')" 
         [ngClass]="{'indicate-different': compareSurfaceShape(), 'invalid': wallLossesForm.controls.surfaceShape.invalid}">
         <option *ngFor="let option of surfaceOptions" [ngValue]="option.id">{{option.surface}}</option>
       </select>
@@ -149,7 +149,7 @@
     <div class="modal-content">
       <div>
         <app-wall-losses-surface *ngIf="showModal" (closeModal)="hideMaterialModal($event)" (hideModal)="hideMaterialModal($event)"
-          [settings]="settings" [editExistingMaterial]="editExistingMaterial" [existingMaterial]="existingMaterial"></app-wall-losses-surface>
+          [settings]="settings" [existingMaterial]="existingMaterial"></app-wall-losses-surface>
       </div>
     </div>
   </div>

--- a/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.ts
+++ b/src/app/phast/losses/wall-losses/wall-losses-form/wall-losses-form.component.ts
@@ -6,101 +6,92 @@ import { LossesService } from '../../losses.service';
 import { Settings } from '../../../../shared/models/settings';
 import { UntypedFormGroup } from '@angular/forms';
 import { WallFormService } from '../../../../calculator/furnaces/wall/wall-form.service';
-import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
 import { firstValueFrom } from 'rxjs';
 import { WallLossesSurfaceDbService } from '../../../../indexedDb/wall-losses-surface-db.service';
+import { roundVal } from '../../../../shared/helperFunctions';
 
 @Component({
-    selector: 'app-wall-losses-form',
-    templateUrl: './wall-losses-form.component.html',
-    styleUrls: ['./wall-losses-form.component.css'],
-    standalone: false
+  selector: 'app-wall-losses-form',
+  templateUrl: './wall-losses-form.component.html',
+  styleUrls: ['./wall-losses-form.component.css'],
+  standalone: false
 })
 export class WallLossesFormComponent implements OnInit {
-  @Input()
-  wallLossesForm: UntypedFormGroup;
   @Output('calculate')
   calculate = new EventEmitter<boolean>();
-  @Input()
-  baselineSelected: boolean;
   @Output('changeField')
   changeField = new EventEmitter<string>();
   @Output('saveEmit')
   saveEmit = new EventEmitter<boolean>();
+
   @Input()
-  lossIndex: number;
+  wallLossesForm: UntypedFormGroup;
   @Input()
   settings: Settings;
   @Input()
   inSetup: boolean;
   @Input()
-  isBaseline: boolean;
+  lossIndex: number;
 
+  private _baselineSelected: boolean;
+  @Input()
+  set baselineSelected(isSelected: boolean) {
+    this._baselineSelected = isSelected;
+    if (this.wallLossesForm && !isSelected) {
+      this.wallLossesForm.controls.surfaceShape.disable();
+    } else {
+      this.setWallSurfaceOptions();
+      this.wallLossesForm.controls.surfaceShape.enable();
+    }
+  }
+  get baselineSelected(): boolean {
+    return this._baselineSelected;
+  }
+
+  private _isBaseline: boolean;
+  @Input()
+  set isBaseline(val: boolean) {
+    this._isBaseline = val;
+    this.idString = this._isBaseline ? '_baseline_' + this.lossIndex : '_modification_' + this.lossIndex;
+  }
+  get isBaseline(): boolean {
+    return this._isBaseline;
+  }
 
   @ViewChild('materialModal', { static: false }) public materialModal: ModalDirective;
-
   hasDeletedCustomMaterial: boolean = false;
-  editExistingMaterial: boolean;
   existingMaterial: WallLossesSurface;
   surfaceOptions: Array<WallLossesSurface>;
   showModal: boolean = false;
   idString: string;
-  constructor(private wallLossCompareService: WallLossCompareService, private sqlDbApiService: SqlDbApiService, private wallFormService: WallFormService, private lossesService: LossesService, private wallLossesSurfaceDbService: WallLossesSurfaceDbService) { }
+  constructor(private wallLossCompareService: WallLossCompareService,
+    private wallFormService: WallFormService,
+    private lossesService: LossesService,
+    private wallLossesSurfaceDbService: WallLossesSurfaceDbService) { }
 
   ngOnInit() {
-    if (!this.isBaseline) {
-      this.idString = '_modification_' + this.lossIndex;
-    }
-    else {
-      this.idString = '_baseline_' + this.lossIndex;
-    }
-    this.surfaceOptions = this.sqlDbApiService.selectWallLossesSurface();
+    this.initForm();
+  }
+
+  async initForm() {
+    await this.setWallSurfaceOptions();
     if (this.surfaceOptions) {
       if (this.wallLossesForm.controls.surfaceShape.value && this.wallLossesForm.controls.surfaceShape.value !== '') {
         if (this.wallLossesForm.controls.conditionFactor.value === '') {
-          this.setProperties();
+          this.setConditionFactor();
         } else {
           this.checkForDeletedMaterial();
         }
       }
     }
-    //init warnings
-    if (!this.baselineSelected) {
-      this.disableForm();
-    }
   }
 
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.baselineSelected) {
-      if (!changes.baselineSelected.firstChange) {
-        //on changes to baseline selected enable/disable form
-        if (!this.baselineSelected) {
-          this.disableForm();
-        } else {
-          this.surfaceOptions = this.sqlDbApiService.selectWallLossesSurface();
-          this.enableForm();
-        }
-      }
-    }
+  async setWallSurfaceOptions() {
+    this.surfaceOptions = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
   }
 
-  //disable select input fields
-  disableForm() {
-    this.wallLossesForm.controls.surfaceShape.disable();
-  }
-  //enable select input fields
-  enableForm() {
-    this.wallLossesForm.controls.surfaceShape.enable();
-  }
-
-  //emits to wall-losses.component the focused field changed
   focusField(str: string) {
     this.changeField.emit(str);
-  }
-  //emits to default help on blur of input elements
-  focusOut() {
-    this.changeField.emit('default');
   }
 
   save() {
@@ -109,8 +100,8 @@ export class WallLossesFormComponent implements OnInit {
     this.saveEmit.emit(true);
   }
 
-  checkForDeletedMaterial() {
-    let selectedMaterial: WallLossesSurface = this.sqlDbApiService.selectWallLossesSurfaceById(this.wallLossesForm.controls.surfaceShape.value);
+  async checkForDeletedMaterial() {
+    let selectedMaterial: WallLossesSurface = await firstValueFrom(this.wallLossesSurfaceDbService.getByIdWithObservable(this.wallLossesForm.controls.surfaceShape.value));
     if (!selectedMaterial) {
       this.hasDeletedCustomMaterial = true;
       this.restoreMaterial();
@@ -119,66 +110,51 @@ export class WallLossesFormComponent implements OnInit {
   }
 
   async restoreMaterial() {
-    let customMaterial: WallLossesSurface = {
+    this.existingMaterial = {
       conditionFactor: this.wallLossesForm.controls.conditionFactor.value,
       surface: "Custom Material"
     };
-    let suiteDbResult = this.sqlDbApiService.insertWallLossesSurface(customMaterial);
-    if (suiteDbResult === true) {
-      await firstValueFrom(this.wallLossesSurfaceDbService.addWithObservable(customMaterial));
-    }
-    this.surfaceOptions = this.sqlDbApiService.selectWallLossesSurface();
-    let newMaterial: WallLossesSurface = this.surfaceOptions.find(material => { return material.surface === customMaterial.surface; });
+    let addedMaterial = await firstValueFrom(this.wallLossesSurfaceDbService.addWithObservable(this.existingMaterial));
+    this.surfaceOptions = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
     this.wallLossesForm.patchValue({
-      surfaceShape: newMaterial.id
+      surfaceShape: addedMaterial.id
     });
+    this.existingMaterial.id = addedMaterial.id;
   }
 
 
-  setProperties() {
-    let tmpFactor: WallLossesSurface = this.sqlDbApiService.selectWallLossesSurfaceById(this.wallLossesForm.controls.surfaceShape.value);
-    if (tmpFactor) {
+  setConditionFactor() {
+    const wallSurface: WallLossesSurface = this.surfaceOptions.find(material => material.id === this.wallLossesForm.controls.surfaceShape.value);
+    if (wallSurface) {
       this.wallLossesForm.patchValue({
-        conditionFactor: this.roundVal(tmpFactor.conditionFactor, 4)
+        conditionFactor: roundVal(wallSurface.conditionFactor, 4)
       });
-      this.calculate.emit(true);
     }
     this.save();
   }
-  roundVal(val: number, digits: number) {
-    let test = Number(val.toFixed(digits));
-    return test;
-  }
 
-  showMaterialModal(editExistingMaterial: boolean) {
-    this.editExistingMaterial = editExistingMaterial;
-    if(editExistingMaterial === true) {
-      this.existingMaterial = {
-        conditionFactor: this.wallLossesForm.controls.conditionFactor.value,
-        surface: "Custom Material"
-      };
-    }
+  showMaterialModal(isNewMaterial: boolean = false) {
+    this.existingMaterial = isNewMaterial ? undefined : this.existingMaterial;
     this.showModal = true;
     this.lossesService.modalOpen.next(this.showModal);
     this.materialModal.show();
   }
 
-  hideMaterialModal(event?: any) {
-    if (event) {
-      this.surfaceOptions = this.sqlDbApiService.selectWallLossesSurface();
-      let newMaterial: WallLossesSurface = this.surfaceOptions.find(material => { return material.surface === event.surface; });
-      if (newMaterial) {
-        this.wallLossesForm.patchValue({
-          surfaceShape: newMaterial.id
-        });
-        this.setProperties();
-      }
+  async hideMaterialModal(materialEvent?: WallLossesSurface) {
+    if (materialEvent && materialEvent.id) {
+      await this.setWallSurfaceOptions();
+      this.wallLossesForm.patchValue({
+        surfaceShape: materialEvent.id,
+        conditionFactor: roundVal(materialEvent.conditionFactor, 4)
+      });
+      this.save();
     }
     this.materialModal.hide();
     this.showModal = false;
     this.dismissMessage();
     this.lossesService.modalOpen.next(this.showModal);
   }
+
   canCompare() {
     if (this.wallLossCompareService.baselineWallLosses && this.wallLossCompareService.modifiedWallLosses && !this.inSetup) {
       return true;

--- a/src/app/phast/phast-report/phast-input-summary/wall-summary/wall-summary.component.ts
+++ b/src/app/phast/phast-report/phast-input-summary/wall-summary/wall-summary.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, Input, ChangeDetectorRef, ViewChild, ElementRef } fr
 import { PHAST } from '../../../../shared/models/phast/phast';
 import { Settings } from '../../../../shared/models/settings';
 import { WallLossesSurface } from '../../../../shared/models/materials';
-import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
+import { WallLossesSurfaceDbService } from '../../../../indexedDb/wall-losses-surface-db.service';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
     selector: 'app-wall-summary',
@@ -40,7 +41,7 @@ export class WallSummaryComponent implements OnInit {
   copyTableString: any;
 
   constructor(
-    private sqlDbApiService: SqlDbApiService,
+    private wallDbService: WallLossesSurfaceDbService,
     private cd: ChangeDetectorRef) { }
 
   ngOnInit() {
@@ -53,7 +54,7 @@ export class WallSummaryComponent implements OnInit {
     this.conditionFactorDiff = new Array();
     this.emissivityDiff = new Array();
     //get substances
-    this.surfaceOrientationOptions = this.sqlDbApiService.selectWallLossesSurface();
+    this.setWallSurfaces();
     //init array
     this.lossData = new Array();
     if (this.phast.losses) {
@@ -99,6 +100,11 @@ export class WallSummaryComponent implements OnInit {
         });
       }
     }
+  }
+
+  async setWallSurfaces() {
+    this.surfaceOrientationOptions = await firstValueFrom(this.wallDbService.getAllWithObservable());
+
   }
 
 

--- a/src/app/shared/import-backup.service.ts
+++ b/src/app/shared/import-backup.service.ts
@@ -233,10 +233,7 @@ export class ImportBackupService {
     for await (let material of measurBackupFile.wallLossesSurfaces) {
       material.selected = false;
       delete material.id;
-      let isAdded = this.sqlDbApiService.insertWallLossesSurface(material);
-      if (isAdded) {
-        await firstValueFrom(this.wallLossesSurfaceDbService.addWithObservable(material));
-      }
+      await firstValueFrom(this.wallLossesSurfaceDbService.addWithObservable(material));
     };
 
     for await (let material of measurBackupFile.flueGasMaterials) {

--- a/src/app/shared/models/materials.ts
+++ b/src/app/shared/models/materials.ts
@@ -71,6 +71,7 @@ export interface AtmosphereSpecificHeat {
 export interface WallLossesSurface {
     conditionFactor: number;
     id?: number;
+    isDefault?: boolean;
     selected?: boolean;
     surface: string;
 }

--- a/src/app/suiteDb/custom-materials/custom-wall-losses-sufaces/custom-wall-losses-surfaces.component.html
+++ b/src/app/suiteDb/custom-materials/custom-wall-losses-sufaces/custom-wall-losses-surfaces.component.html
@@ -33,7 +33,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content tab-content">
       <app-wall-losses-surface *ngIf="showModal" (closeModal)="hideMaterialModal($event)" (hideModal)="hideMaterialModal($event)"
-        [settings]="settings" [editExistingMaterial]="editExistingMaterial" [existingMaterial]="existingMaterial" [deletingMaterial]="deletingMaterial"></app-wall-losses-surface>
+        [settings]="settings" [existingMaterial]="existingMaterial" [deletingMaterial]="deletingMaterial"></app-wall-losses-surface>
     </div>
   </div>
 </div>

--- a/src/app/suiteDb/custom-materials/custom-wall-losses-sufaces/custom-wall-losses-surfaces.component.ts
+++ b/src/app/suiteDb/custom-materials/custom-wall-losses-sufaces/custom-wall-losses-surfaces.component.ts
@@ -3,7 +3,6 @@ import { Settings } from '../../../shared/models/settings';
 import { WallLossesSurface } from '../../../shared/models/materials';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { CustomMaterialsService } from '../custom-materials.service';
-import * as _ from 'lodash';
 import { firstValueFrom, Subscription } from 'rxjs';
 import { WallLossesSurfaceDbService } from '../../../indexedDb/wall-losses-surface-db.service';
 
@@ -66,24 +65,21 @@ export class CustomWallLossesSurfacesComponent implements OnInit {
   }
   
   async getCustomMaterials() {
-    this.wallLossesSurfaces = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
+    this.wallLossesSurfaces = await firstValueFrom(this.wallLossesSurfaceDbService.getAllCustomMaterials());
     this.emitNumMaterials.emit(this.wallLossesSurfaces.length);
   }
 
-  async editMaterial(id: number) {
-    this.existingMaterial = await firstValueFrom(this.wallLossesSurfaceDbService.getByIdWithObservable(id));
-    this.editExistingMaterial = true;
-    this.showMaterialModal();
+  editMaterial(id: number) {
+    this.showMaterialModal(id);
   }
 
-  async deleteMaterial(id: number) {
-    this.existingMaterial = await firstValueFrom(this.wallLossesSurfaceDbService.getByIdWithObservable(id));
-    this.editExistingMaterial = true;
+  deleteMaterial(id: number) {
     this.deletingMaterial = true;
-    this.showMaterialModal();
+    this.showMaterialModal(id);
   }
 
-  showMaterialModal() {
+  async showMaterialModal(id?: number) {
+    this.existingMaterial = id ? await firstValueFrom(this.wallLossesSurfaceDbService.getByIdWithObservable(id)) : undefined;
     this.showModal = true;
     this.materialModal.show();
   }
@@ -97,7 +93,7 @@ export class CustomWallLossesSurfacesComponent implements OnInit {
   }
 
   getSelected() {
-    let selected: Array<WallLossesSurface> = _.filter(this.wallLossesSurfaces, (material) => { return material.selected === true; });
+    let selected: Array<WallLossesSurface> = this.wallLossesSurfaces.filter((material) => { return material.selected === true; });
     this.customMaterialService.selectedWall = selected;
   }
 

--- a/src/app/suiteDb/wall-losses-surface/wall-losses-surface.component.html
+++ b/src/app/suiteDb/wall-losses-surface/wall-losses-surface.component.html
@@ -5,42 +5,37 @@
         <div class="row phast align-items-top">
           <div class="col-12">
             <div class="header card-header">
-              <h3 *ngIf="!editExistingMaterial">Create Surface Material</h3>
-              <h3 *ngIf="editExistingMaterial">Edit Surface Material</h3>
+              <h3 *ngIf="!existingMaterial">Create Surface Material</h3>
+              <h3 *ngIf="existingMaterial">Edit Surface Material</h3>
             </div>
           </div>
         </div>
         <form>
-          <div class="form-section" *ngIf="!editExistingMaterial">
+          <div class="form-section" *ngIf="!existingMaterial">
             <div class="form-group">
-              <label class="small" for="selectedMaterial">Start with existing surface</label>
-              <select name="selectedMaterial" class="form-control" id="selectedMaterial" (change)="setExisting()" [(ngModel)]="selectedMaterial"
+              <label class="small" for="originalMaterial">Start with existing surface</label>
+              <select name="originalMaterial" class="form-control" id="originalMaterial" (change)="setActiveMaterial()" [(ngModel)]="originalMaterial"
                 (focus)="focusField('selectedMaterial')">
                 <option *ngFor="let material of allMaterials" [ngValue]="material">{{material.surface}}</option>
-                <option [ngValue]="null"></option>
               </select>
             </div>
           </div>
           <div class="form-section">
             <label>
-              <h6 *ngIf="!editExistingMaterial">New Surface:</h6>
-              <h6 *ngIf="editExistingMaterial">Edit Surface:</h6>
+              <h6 *ngIf="!existingMaterial">New Surface:</h6>
+              <h6 *ngIf="existingMaterial">Edit Surface:</h6>
             </label>
             <div class="form-group">
               <label class="small" for="surface">Surface Name</label>
-              <div class="input-group" *ngIf="!editExistingMaterial">
-                <input type="text" id="surface" name="surface" class="form-control" [(ngModel)]="newMaterial.surface" (input)="checkMaterialName()"
+              <div class="input-group">
+                <input type="text" id="surface" name="surface" class="form-control" [(ngModel)]="activeMaterial.surface" (input)="setMaterialNameError()"
                   (focus)="focusField('substance')" />
               </div>
-              <div class="input-group" *ngIf="editExistingMaterial">
-                <input type="text" id="surface" name="surface" class="form-control" [(ngModel)]="newMaterial.surface" (input)="checkEditMaterialName()"
-                />
-              </div>
-              <span class="alert-warning pull-right small" *ngIf="nameError !== null">{{nameError}}</span>
+              <span class="alert-danger pull-right small" *ngIf="nameError">{{nameError}}</span>
             </div>
             <div class="form-group" *ngIf="settings">
               <label class="small" for="conditionFactor">Surface Shape / Orientation Factor</label>
-              <input type="number" id="conditionFactor" name="conditionFactor" class="form-control" [(ngModel)]="newMaterial.conditionFactor"
+              <input type="number" id="conditionFactor" name="conditionFactor" class="form-control" [(ngModel)]="activeMaterial.conditionFactor"
                 (focus)="focusField('conditionFactor')" />
             </div>
           </div>
@@ -65,7 +60,7 @@
           <div class="delete-warning-container">
             <div class="row">
               <div class="col-12">
-                Material Name: {{newMaterial.substance}}
+                Material Name: {{activeMaterial.surface}}
               </div>
             </div>
             <div class="row">
@@ -84,11 +79,12 @@
     </div>
     <div class="modal-btn-container">
       <button type="button" class="btn btn-secondary btn-sm modal-btn" (click)="hideMaterialModal()">Cancel</button>
-      <button *ngIf="!editExistingMaterial && !deletingMaterial" type="button" class="btn btn-primary btn-sm modal-btn" (click)="addMaterial()"
-        [disabled]="!isValidMaterialName">Submit</button>
-      <button *ngIf="editExistingMaterial && !deletingMaterial" type="button" class="btn btn-primary btn-sm modal-btn" (click)="updateMaterial()"
-        [disabled]="!isValidMaterialName">Submit</button>
-      <button *ngIf="deletingMaterial" type="button" class="btn btn-danger btn-sm modal-btn" (click)="deleteMaterial()">Delete</button>
+      @if (!deletingMaterial) {
+        <button type="button" class="btn btn-primary btn-sm modal-btn" (click)="saveMaterial()"
+          [disabled]="nameError">Submit</button>
+      } @else {
+        <button type="button" class="btn btn-danger btn-sm modal-btn" (click)="deleteMaterial()">Delete</button>
+      }
     </div>
   </div>
 </div>

--- a/src/app/suiteDb/wall-losses-surface/wall-losses-surface.component.ts
+++ b/src/app/suiteDb/wall-losses-surface/wall-losses-surface.component.ts
@@ -1,17 +1,16 @@
 import { Component, OnInit, EventEmitter, Output, Input } from '@angular/core';
 import { WallLossesSurface } from '../../shared/models/materials';
-import * as _ from 'lodash';
-import { SqlDbApiService } from '../../tools-suite-api/sql-db-api.service';
 import { Settings } from '../../shared/models/settings';
 import { SettingsDbService } from '../../indexedDb/settings-db.service';
 import { firstValueFrom } from 'rxjs';
 import { WallLossesSurfaceDbService } from '../../indexedDb/wall-losses-surface-db.service';
+import { CustomMaterialsService } from '../custom-materials/custom-materials.service';
 
 @Component({
-    selector: 'app-wall-losses-surface',
-    templateUrl: './wall-losses-surface.component.html',
-    styleUrls: ['./wall-losses-surface.component.css'],
-    standalone: false
+  selector: 'app-wall-losses-surface',
+  templateUrl: './wall-losses-surface.component.html',
+  styleUrls: ['./wall-losses-surface.component.css'],
+  standalone: false
 })
 export class WallLossesSurfaceComponent implements OnInit {
   @Output('closeModal')
@@ -19,140 +18,79 @@ export class WallLossesSurfaceComponent implements OnInit {
   @Input()
   settings: Settings;
   @Input()
-  editExistingMaterial: boolean;
-  @Input()
   existingMaterial: WallLossesSurface;
   @Input()
   deletingMaterial: boolean;
   @Output('hideModal')
   hideModal = new EventEmitter();
 
-  newMaterial: WallLossesSurface = {
+  activeMaterial: WallLossesSurface = {
     surface: 'New Surface',
     conditionFactor: 0
   };
-  selectedMaterial: WallLossesSurface;
+  originalMaterial: WallLossesSurface;
   allMaterials: Array<WallLossesSurface>;
-  allCustomMaterials: Array<WallLossesSurface>;
-  isValidMaterialName: boolean = true;
   nameError: string = null;
-  canAdd: boolean;
   currentField: string = 'selectedMaterial';
   idbEditMaterialId: number;
-  sdbEditMaterialId: number;
-  constructor(
-    private sqlDbApiService: SqlDbApiService, private settingsDbService: SettingsDbService, private wallLossesSurfaceDbService: WallLossesSurfaceDbService) { }
+  constructor(private settingsDbService: SettingsDbService,
+    private customMaterialsService: CustomMaterialsService,
+    private wallLossesSurfaceDbService: WallLossesSurfaceDbService) { }
 
   ngOnInit() {
     if (!this.settings) {
       this.settings = this.settingsDbService.getByDirectoryId(1);
     }
+    this.initMaterials();
+  }
 
-    if (this.editExistingMaterial) {
-      this.allMaterials = this.sqlDbApiService.selectWallLossesSurface();
-      this.getAllMaterials();
-    }
-    else {
-      this.canAdd = true;
-      this.allMaterials = this.sqlDbApiService.selectWallLossesSurface();
-      this.checkMaterialName();
+  async initMaterials() {
+    this.allMaterials = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
+    this.originalMaterial = this.allMaterials[0];
+    if (this.existingMaterial) {
+      this.setActiveMaterial();
     }
   }
 
-  async getAllMaterials() {
-    this.allCustomMaterials = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
-    this.sdbEditMaterialId = _.find(this.allMaterials, (material) => { return this.existingMaterial.surface === material.surface; }).id;
-    this.idbEditMaterialId = _.find(this.allCustomMaterials, (material) => { return this.existingMaterial.surface === material.surface; }).id;
-    this.setExisting();
-  }
-
-  async addMaterial() {
-    if (this.canAdd) {
-      this.canAdd = false;
-      let suiteDbResult = this.sqlDbApiService.insertWallLossesSurface(this.newMaterial);
-      if (suiteDbResult === true) {
-        await firstValueFrom(this.wallLossesSurfaceDbService.addWithObservable(this.newMaterial));
-        let materials: WallLossesSurface[] = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
-        this.wallLossesSurfaceDbService.dbWallLossesSurfaceMaterials.next(materials);
-        this.closeModal.emit(this.newMaterial);
-
-      }
+  async saveMaterial() {
+    if (this.existingMaterial) {
+      await firstValueFrom(this.wallLossesSurfaceDbService.updateWithObservable(this.activeMaterial));
+    } else {
+      let newMaterial = await firstValueFrom(this.wallLossesSurfaceDbService.addWithObservable(this.activeMaterial));
+      this.activeMaterial.id = newMaterial.id;
     }
-  }
-
- async updateMaterial() {
-    this.newMaterial.id = this.sdbEditMaterialId;
-    let suiteDbResult = this.sqlDbApiService.updateWallLossesSurface(this.newMaterial);
-    if (suiteDbResult === true) {
-      //need to set id for idb to put updates
-      this.newMaterial.id = this.idbEditMaterialId;
-      await firstValueFrom(this.wallLossesSurfaceDbService.updateWithObservable(this.newMaterial));
-      let materials: WallLossesSurface[] = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
-      this.wallLossesSurfaceDbService.dbWallLossesSurfaceMaterials.next(materials);
-      this.closeModal.emit(this.newMaterial);
-    }
+    this.updateMaterialsAndClose();
   }
 
   async deleteMaterial() {
-    if (this.deletingMaterial && this.existingMaterial) {
-      let suiteDbResult = this.sqlDbApiService.deleteWallLossesSurface(this.sdbEditMaterialId);
-      if (suiteDbResult === true) {
-        await firstValueFrom(this.wallLossesSurfaceDbService.deleteByIdWithObservable(this.idbEditMaterialId));
-        let materials: WallLossesSurface[] = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
-        this.wallLossesSurfaceDbService.dbWallLossesSurfaceMaterials.next(materials);
-        this.closeModal.emit(this.newMaterial);
-      }
-    }
+    await firstValueFrom(this.wallLossesSurfaceDbService.deleteByIdWithObservable(this.activeMaterial.id));
+    this.updateMaterialsAndClose();
   }
 
-  setExisting() {
-    if (this.editExistingMaterial && this.existingMaterial) {
-      this.newMaterial = {
+  async updateMaterialsAndClose() {
+    let materials: WallLossesSurface[] = await firstValueFrom(this.wallLossesSurfaceDbService.getAllWithObservable());
+    this.wallLossesSurfaceDbService.dbWallLossesSurfaceMaterials.next(materials);
+    this.closeModal.emit(this.activeMaterial);
+  }
+
+  setActiveMaterial() {
+    this.nameError = undefined;
+    if (this.existingMaterial) {
+      this.activeMaterial = {
         id: this.existingMaterial.id,
         surface: this.existingMaterial.surface,
         conditionFactor: this.existingMaterial.conditionFactor
       };
-    }
-    else if (this.selectedMaterial) {
-      this.newMaterial = {
-        surface: this.selectedMaterial.surface + ' (mod)',
-        conditionFactor: this.selectedMaterial.conditionFactor
+    } else if (this.originalMaterial) {
+      this.activeMaterial = {
+        surface: this.originalMaterial.surface + ' (Custom)',
+        conditionFactor: this.originalMaterial.conditionFactor
       };
-      this.checkMaterialName();
     }
   }
 
-  checkEditMaterialName() {
-    let test = _.filter(this.allMaterials, (material) => {
-      if (material.id !== this.sdbEditMaterialId) {
-        return material.surface.toLowerCase().trim() === this.newMaterial.surface.toLowerCase().trim();
-      }
-    });
-
-    if (test.length > 0) {
-      this.nameError = 'This name is in use by another material';
-      this.isValidMaterialName = false;
-    }
-    else if (this.newMaterial.surface.toLowerCase().trim() === '') {
-      this.nameError = 'The material must have a name';
-      this.isValidMaterialName = false;
-    }
-    else {
-      this.isValidMaterialName = true;
-      this.nameError = null;
-    }
-  }
-
-
-  checkMaterialName() {
-    let test = _.filter(this.allMaterials, (material) => { return material.surface.toLowerCase().trim() === this.newMaterial.surface.toLowerCase().trim(); });
-    if (test.length > 0) {
-      this.nameError = 'Cannot have same name as existing surface';
-      this.isValidMaterialName = false;
-    } else {
-      this.isValidMaterialName = true;
-      this.nameError = null;
-    }
+  setMaterialNameError() {
+    this.nameError = this.customMaterialsService.getMaterialNameError(this.allMaterials, this.idbEditMaterialId, this.activeMaterial.surface, 'surface');
   }
 
   focusField(str: string) {


### PR DESCRIPTION
#7678 
Adding more detail than usual here as we'll base future removals off this.

Priority:
- Remove all SQLDb references and calls for the given material
- Add material method for inserting default materials on startup
- Replace with calls to _WhateverMaterial_DbService in PHAST, and calculator, SuiteDb, Custom materisl

Tech debt upgrades - SuiteDb component (Wall Losses Surface):
- Add new method on customMaterialsService to setMaterialNameError, Remove method definition for check material name in component 
- Remove lodash in transformation/filters and replace with js native methods
- Use initMaterials() and set a default selected material
- remove canAdd
- remove isValidMaterialName
- Change name to ‘Custom’ over ‘mod’
- group updateMaterialsAndclose logic into method
- Overall reduce template complexity, remove Input + change name to original material