### PR TITLE
Issue 7714: Remove SQLite suite calls for Solid Charge Materials

### DIFF
--- a/src/app/calculator/furnaces/atmosphere/atmosphere-form/atmosphere-form.component.ts
+++ b/src/app/calculator/furnaces/atmosphere/atmosphere-form/atmosphere-form.component.ts
@@ -179,26 +179,6 @@ export class AtmosphereFormComponent implements OnInit {
     this.atmosphereService.removeLoss(this.index);
   }
 
-  async checkSpecificHeat() {
-    if (this.atmosphereLossForm.controls.atmosphereGas.value) {
-      let material: AtmosphereSpecificHeat = await firstValueFrom(this.atmosphereDbService.getByIdWithObservable(this.atmosphereLossForm.controls.atmosphereGas.value));
-      if (material) {
-        let val = material.specificHeat;
-        if (this.settings.unitsOfMeasure === 'Metric') {
-          val = this.convertUnitsService.value(val).from('btuScfF').to('kJm3C');
-        }
-        material.specificHeat = roundVal(val, 4);
-        if (material.specificHeat !== this.atmosphereLossForm.controls.specificHeat.value) {
-          return true;
-        } else {
-          return false;
-        }
-      }
-    } else {
-      return false;
-    }
-  }
-
   setEnergySource(energySourceType: string) {
     this.atmosphereLossForm.patchValue({
       energySourceType: energySourceType

--- a/src/app/calculator/furnaces/charge-material/solid-material-form/solid-material-form.component.ts
+++ b/src/app/calculator/furnaces/charge-material/solid-material-form/solid-material-form.component.ts
@@ -162,19 +162,23 @@ export class SolidMaterialFormComponent implements OnInit {
   }
 
   async setProperties() {
-    let selectedMaterial: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(this.chargeMaterialForm.controls.materialId.value));
+    let selectedMaterial: SolidLoadChargeMaterial = this.materialTypes.find(material => { return material.id === this.chargeMaterialForm.controls.materialId.value; });
     if (selectedMaterial) {
+      let latentHeat: number = selectedMaterial.latentHeat;
+      let meltingPoint: number = selectedMaterial.meltingPoint;
+      let specificHeatLiquid: number = selectedMaterial.specificHeatLiquid;
+      let specificHeatSolid: number = selectedMaterial.specificHeatSolid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        selectedMaterial.latentHeat = this.convertUnitsService.value(selectedMaterial.latentHeat).from('btuLb').to('kJkg');
-        selectedMaterial.meltingPoint = this.convertUnitsService.value(selectedMaterial.meltingPoint).from('F').to('C');
-        selectedMaterial.specificHeatLiquid = this.convertUnitsService.value(selectedMaterial.specificHeatLiquid).from('btulbF').to('kJkgC');
-        selectedMaterial.specificHeatSolid = this.convertUnitsService.value(selectedMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
+        latentHeat = this.convertUnitsService.value(latentHeat).from('btuLb').to('kJkg');
+        meltingPoint = this.convertUnitsService.value(meltingPoint).from('F').to('C');
+        specificHeatLiquid = this.convertUnitsService.value(specificHeatLiquid).from('btulbF').to('kJkgC');
+        specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
       }
       this.chargeMaterialForm.patchValue({
-        materialLatentHeatOfFusion: roundVal(selectedMaterial.latentHeat, 4),
-        materialMeltingPoint: roundVal(selectedMaterial.meltingPoint, 4),
-        materialHeatOfLiquid: roundVal(selectedMaterial.specificHeatLiquid, 4),
-        materialSpecificHeatOfSolidMaterial: roundVal(selectedMaterial.specificHeatSolid, 4)
+        materialLatentHeatOfFusion: roundVal(latentHeat, 4),
+        materialMeltingPoint: roundVal(meltingPoint, 4),
+        materialHeatOfLiquid: roundVal(specificHeatLiquid, 4),
+        materialSpecificHeatOfSolidMaterial: roundVal(specificHeatSolid, 4)
       });
     }
     this.calculate();

--- a/src/app/calculator/furnaces/charge-material/solid-material-form/solid-material-form.component.ts
+++ b/src/app/calculator/furnaces/charge-material/solid-material-form/solid-material-form.component.ts
@@ -1,20 +1,21 @@
-import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap/modal';
-import { Subscription } from 'rxjs';
+import { firstValueFrom, Subscription } from 'rxjs';
 import { ConvertUnitsService } from '../../../../shared/convert-units/convert-units.service';
 import { SolidLoadChargeMaterial } from '../../../../shared/models/materials';
 import { ChargeMaterial, ChargeMaterialOutput, ChargeMaterialResult, SolidChargeMaterial } from '../../../../shared/models/phast/losses/chargeMaterial';
 import { Settings } from '../../../../shared/models/settings';
-import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
 import { ChargeMaterialService } from '../charge-material.service';
 import { SolidMaterialFormService, SolidMaterialWarnings } from './solid-material-form.service';
+import { SolidLoadMaterialDbService } from '../../../../indexedDb/solid-load-material-db.service';
+import { roundVal } from '../../../../shared/helperFunctions';
 
 @Component({
-    selector: 'app-solid-material-form',
-    templateUrl: './solid-material-form.component.html',
-    styleUrls: ['./solid-material-form.component.css'],
-    standalone: false
+  selector: 'app-solid-material-form',
+  templateUrl: './solid-material-form.component.html',
+  styleUrls: ['./solid-material-form.component.css'],
+  standalone: false
 })
 export class SolidMaterialFormComponent implements OnInit {
   @Input()
@@ -46,10 +47,10 @@ export class SolidMaterialFormComponent implements OnInit {
   collapseMaterialSub: Subscription;
 
   constructor(
-    private sqlDbApiService: SqlDbApiService, 
     private chargeMaterialService: ChargeMaterialService,
     private convertUnitsService: ConvertUnitsService,
     private solidMaterialFormService: SolidMaterialFormService,
+    private solidLoadMaterialDbService: SolidLoadMaterialDbService
   ) { }
 
   ngOnInit() {
@@ -62,7 +63,7 @@ export class SolidMaterialFormComponent implements OnInit {
       let baselineData: Array<ChargeMaterial> = this.chargeMaterialService.baselineData.getValue();
       this.chargeMaterialType = baselineData[this.index].chargeMaterialType;
     }
-    this.materialTypes = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+    this.setMaterials();
     if (this.chargeMaterialForm) {
       if (this.chargeMaterialForm.controls.materialId.value && this.chargeMaterialForm.controls.materialId.value !== '') {
         if (this.chargeMaterialForm.controls.materialLatentHeatOfFusion.value === '') {
@@ -80,6 +81,10 @@ export class SolidMaterialFormComponent implements OnInit {
       let output: ChargeMaterialOutput = this.chargeMaterialService.output.getValue();
       this.setLossResult(output);
     }
+  }
+
+  async setMaterials() {
+    this.materialTypes = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable())
   }
 
   toggleMaterialProperties() {
@@ -143,11 +148,11 @@ export class SolidMaterialFormComponent implements OnInit {
     }
   }
 
-  setFormState() {
+  async setFormState() {
     if (this.selected == false) {
       this.chargeMaterialForm.disable();
     } else {
-      this.materialTypes = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+      await this.setMaterials();
       this.chargeMaterialForm.enable();
     }
   }
@@ -156,8 +161,8 @@ export class SolidMaterialFormComponent implements OnInit {
     this.chargeMaterialService.currentField.next(str);
   }
 
-  setProperties() {
-    let selectedMaterial: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.chargeMaterialForm.controls.materialId.value);
+  async setProperties() {
+    let selectedMaterial: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(this.chargeMaterialForm.controls.materialId.value));
     if (selectedMaterial) {
       if (this.settings.unitsOfMeasure === 'Metric') {
         selectedMaterial.latentHeat = this.convertUnitsService.value(selectedMaterial.latentHeat).from('btuLb').to('kJkg');
@@ -166,18 +171,13 @@ export class SolidMaterialFormComponent implements OnInit {
         selectedMaterial.specificHeatSolid = this.convertUnitsService.value(selectedMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
       }
       this.chargeMaterialForm.patchValue({
-        materialLatentHeatOfFusion: this.roundVal(selectedMaterial.latentHeat, 4),
-        materialMeltingPoint: this.roundVal(selectedMaterial.meltingPoint, 4),
-        materialHeatOfLiquid: this.roundVal(selectedMaterial.specificHeatLiquid, 4),
-        materialSpecificHeatOfSolidMaterial: this.roundVal(selectedMaterial.specificHeatSolid, 4)
+        materialLatentHeatOfFusion: roundVal(selectedMaterial.latentHeat, 4),
+        materialMeltingPoint: roundVal(selectedMaterial.meltingPoint, 4),
+        materialHeatOfLiquid: roundVal(selectedMaterial.specificHeatLiquid, 4),
+        materialSpecificHeatOfSolidMaterial: roundVal(selectedMaterial.specificHeatSolid, 4)
       });
     }
     this.calculate();
-  }
-
-  roundVal(val: number, digits: number) {
-    let test = Number(val.toFixed(digits));
-    return test;
   }
 
   checkWarnings() {
@@ -193,72 +193,15 @@ export class SolidMaterialFormComponent implements OnInit {
 
   }
 
-  checkSpecificHeatOfSolid() {
-    let material: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.chargeMaterialForm.controls.materialId.value);
-    if (material) {
-      if (this.settings.unitsOfMeasure === 'Metric') {
-        material.specificHeatSolid = this.convertUnitsService.value(material.specificHeatSolid).from('btulbF').to('kJkgC');
-      }
-      material.specificHeatSolid = this.roundVal(material.specificHeatSolid, 4);
-      if (material.specificHeatSolid !== this.chargeMaterialForm.controls.materialSpecificHeatOfSolidMaterial.value) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }
-  checkLatentHeatOfFusion() {
-    let material: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.chargeMaterialForm.controls.materialId.value);
-    if (material) {
-      if (this.settings.unitsOfMeasure === 'Metric') {
-        let val = this.convertUnitsService.value(material.latentHeat).from('btuLb').to('kJkg');
-        material.latentHeat = this.roundVal(val, 4);
-      }
-      if (material.latentHeat !== this.chargeMaterialForm.controls.materialLatentHeatOfFusion.value) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }
-  checkHeatOfLiquid() {
-    let material: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.chargeMaterialForm.controls.materialId.value);
-    if (material) {
-      if (this.settings.unitsOfMeasure === 'Metric') {
-        let val = this.convertUnitsService.value(material.specificHeatLiquid).from('btulbF').to('kJkgC');
-        material.specificHeatLiquid = this.roundVal(val, 4);
-      }
-      if (material.specificHeatLiquid !== this.chargeMaterialForm.controls.materialHeatOfLiquid.value) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }
-  checkMeltingPoint() {
-    let material: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.chargeMaterialForm.controls.materialId.value);
-    if (material) {
-      if (this.settings.unitsOfMeasure === 'Metric') {
-        let val = this.convertUnitsService.value(material.meltingPoint).from('F').to('C');
-        material.meltingPoint = this.roundVal(val, 4);
-      }
-      if (material.meltingPoint !== this.chargeMaterialForm.controls.materialMeltingPoint.value) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }
-
   showMaterialModal() {
     this.showModal = true;
     this.chargeMaterialService.modalOpen.next(true);
     this.materialModal.show();
   }
 
-  hideMaterialModal(event?: any) {
+  async hideMaterialModal(event?: any) {
     if (event) {
-      this.materialTypes = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+      await this.setMaterials();
       let newMaterial: SolidLoadChargeMaterial = this.materialTypes.find(material => { return material.substance === event.substance; });
       if (newMaterial) {
         this.chargeMaterialForm.patchValue({

--- a/src/app/calculator/furnaces/fixture/fixture-form/fixture-form.component.ts
+++ b/src/app/calculator/furnaces/fixture/fixture-form/fixture-form.component.ts
@@ -11,6 +11,7 @@ import { Settings } from '../../../../shared/models/settings';
 import { FixtureFormService } from '../fixture-form.service';
 import { FixtureService } from '../fixture.service';
 import { SolidLoadMaterialDbService } from '../../../../indexedDb/solid-load-material-db.service';
+import { roundVal } from '../../../../shared/helperFunctions';
 
 @Component({
   selector: 'app-fixture-form',
@@ -100,7 +101,7 @@ export class FixtureFormComponent implements OnInit {
       this.energySourceTypeSub.unsubscribe();
     }
   }
-  
+
   async setMaterials() {
     this.materialTypes = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable())
   }
@@ -153,28 +154,30 @@ export class FixtureFormComponent implements OnInit {
     }
   }
 
-  async setSpecificHeat() {
-    let tmpMaterial: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(this.fixtureForm.controls.materialName.value));
-    if (tmpMaterial) {
+  setSpecificHeat() {
+    let selectedMaterial: SolidLoadChargeMaterial = this.materialTypes.find(material => { return material.id === this.fixtureForm.controls.materialName.value; });
+    if (selectedMaterial) {
+      let specificHeatSolid: number = selectedMaterial.specificHeatSolid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        tmpMaterial.specificHeatSolid = this.convertUnitsService.value(tmpMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
+        specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
       }
       this.fixtureForm.patchValue({
-        specificHeat: this.roundVal(tmpMaterial.specificHeatSolid, 3)
+        specificHeat: roundVal(specificHeatSolid, 3)
       });
     }
     this.calculate();
   }
 
-  async setProperties() {
-    let selectedMaterial: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(this.fixtureForm.controls.materialName.value));
+  setProperties() {
+    let selectedMaterial: SolidLoadChargeMaterial = this.materialTypes.find(material => { return material.id === this.fixtureForm.controls.materialName.value; });
     if (selectedMaterial) {
+      let specificHeatSolid: number = selectedMaterial.specificHeatSolid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        selectedMaterial.specificHeatSolid = this.convertUnitsService.value(selectedMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
+        specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
       }
 
       this.fixtureForm.patchValue({
-        specificHeat: this.roundVal(selectedMaterial.specificHeatSolid, 4)
+        specificHeat: roundVal(specificHeatSolid, 4)
       });
     }
     this.calculate();
@@ -261,12 +264,6 @@ export class FixtureFormComponent implements OnInit {
     this.fixtureService.modalOpen.next(this.showMaterialModal);
   }
 
-
-  roundVal(val: number, digits: number) {
-    let rounded = Number(val.toFixed(digits));
-    return rounded;
-  }
-
   initFlueGasModal() {
     this.showFlueGasModal = true;
     this.fixtureService.modalOpen.next(this.showFlueGasModal);
@@ -275,7 +272,7 @@ export class FixtureFormComponent implements OnInit {
 
   hideFlueGasModal(flueGasModalData?: FlueGasModalData) {
     if (flueGasModalData) {
-      flueGasModalData.calculatedAvailableHeat = this.roundVal(flueGasModalData.calculatedAvailableHeat, 1);
+      flueGasModalData.calculatedAvailableHeat = roundVal(flueGasModalData.calculatedAvailableHeat, 1);
       this.fixtureForm.patchValue({
         availableHeat: flueGasModalData.calculatedAvailableHeat
       });

--- a/src/app/calculator/furnaces/fixture/fixture-form/fixture-form.component.ts
+++ b/src/app/calculator/furnaces/fixture/fixture-form/fixture-form.component.ts
@@ -1,22 +1,22 @@
 import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap/modal';
-import { Subscription } from 'rxjs';
+import { firstValueFrom, Subscription } from 'rxjs';
 import { ConvertUnitsService } from '../../../../shared/convert-units/convert-units.service';
 import { SolidLoadChargeMaterial } from '../../../../shared/models/materials';
 import { OperatingHours } from '../../../../shared/models/operations';
 import { FlueGasModalData } from '../../../../shared/models/phast/heatCascading';
 import { FixtureLoss, FixtureLossOutput, FixtureLossResults } from '../../../../shared/models/phast/losses/fixtureLoss';
 import { Settings } from '../../../../shared/models/settings';
-import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
 import { FixtureFormService } from '../fixture-form.service';
 import { FixtureService } from '../fixture.service';
+import { SolidLoadMaterialDbService } from '../../../../indexedDb/solid-load-material-db.service';
 
 @Component({
-    selector: 'app-fixture-form',
-    templateUrl: './fixture-form.component.html',
-    styleUrls: ['./fixture-form.component.css'],
-    standalone: false
+  selector: 'app-fixture-form',
+  templateUrl: './fixture-form.component.html',
+  styleUrls: ['./fixture-form.component.css'],
+  standalone: false
 })
 export class FixtureFormComponent implements OnInit {
   @Input()
@@ -33,7 +33,7 @@ export class FixtureFormComponent implements OnInit {
   @ViewChild('flueGasModal', { static: false }) public flueGasModal: ModalDirective;
   @ViewChild('formElement', { static: false }) formElement: ElementRef;
   @ViewChild('materialModal', { static: false }) public materialModal: ModalDirective;
-  
+
   materialTypes: Array<SolidLoadChargeMaterial>;
   showMaterialModal: boolean = false;
 
@@ -55,7 +55,7 @@ export class FixtureFormComponent implements OnInit {
   outputSubscription: Subscription;
 
   constructor(private fixtureFormService: FixtureFormService,
-    private sqlDbApiService: SqlDbApiService, 
+    private solidLoadMaterialDbService: SolidLoadMaterialDbService,
     private convertUnitsService: ConvertUnitsService,
     private cd: ChangeDetectorRef,
     private fixtureService: FixtureService) { }
@@ -69,7 +69,7 @@ export class FixtureFormComponent implements OnInit {
     }
     this.trackingEnergySource = this.index > 0 || !this.isBaseline;
 
-    this.materialTypes = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+    this.setMaterials();
     this.initSubscriptions();
     this.energyUnit = this.fixtureService.getAnnualEnergyUnit(this.fixtureForm.controls.energySourceType.value, this.settings);
     if (this.isBaseline) {
@@ -99,6 +99,10 @@ export class FixtureFormComponent implements OnInit {
     if (this.trackingEnergySource) {
       this.energySourceTypeSub.unsubscribe();
     }
+  }
+  
+  async setMaterials() {
+    this.materialTypes = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable())
   }
 
   checkEnergySourceSub() {
@@ -140,17 +144,17 @@ export class FixtureFormComponent implements OnInit {
     }
   }
 
-  setFormState() {
+  async setFormState() {
     if (this.selected == false) {
       this.fixtureForm.disable();
     } else {
-      this.materialTypes = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+      this.setMaterials();
       this.fixtureForm.enable();
     }
   }
 
-  setSpecificHeat() {
-    let tmpMaterial: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.fixtureForm.controls.materialName.value);
+  async setSpecificHeat() {
+    let tmpMaterial: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(this.fixtureForm.controls.materialName.value));
     if (tmpMaterial) {
       if (this.settings.unitsOfMeasure === 'Metric') {
         tmpMaterial.specificHeatSolid = this.convertUnitsService.value(tmpMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
@@ -162,28 +166,8 @@ export class FixtureFormComponent implements OnInit {
     this.calculate();
   }
 
-  checkSpecificHeat() {
-    if (this.fixtureForm.controls.materialName.value) {
-      let material: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.fixtureForm.controls.materialName.value);
-      if (material) {
-        let val = material.specificHeatSolid;
-        if (this.settings.unitsOfMeasure === 'Metric') {
-          val = this.convertUnitsService.value(val).from('btulbF').to('kJkgC');
-        }
-        material.specificHeatSolid = this.roundVal(val, 3);
-        if (material.specificHeatSolid !== this.fixtureForm.controls.specificHeat.value) {
-          return true;
-        } else {
-          return false;
-        }
-      }
-    } else {
-      return false;
-    }
-  }
-
-  setProperties() {
-    let selectedMaterial: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(this.fixtureForm.controls.materialName.value);
+  async setProperties() {
+    let selectedMaterial: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(this.fixtureForm.controls.materialName.value));
     if (selectedMaterial) {
       if (this.settings.unitsOfMeasure === 'Metric') {
         selectedMaterial.specificHeatSolid = this.convertUnitsService.value(selectedMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
@@ -261,9 +245,9 @@ export class FixtureFormComponent implements OnInit {
     this.materialModal.show();
   }
 
-  hideMaterialModal(event?: any) {
+  async hideMaterialModal(event?: any) {
     if (event) {
-      this.materialTypes = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+      await this.setMaterials();
       let newMaterial: SolidLoadChargeMaterial = this.materialTypes.find(material => { return material.substance === event.substance; });
       if (newMaterial) {
         this.fixtureForm.patchValue({

--- a/src/app/core/core.service.ts
+++ b/src/app/core/core.service.ts
@@ -26,6 +26,7 @@ import { Diagram } from '../shared/models/diagram';
 import { ApplicationInstanceDbService, ApplicationInstanceData } from '../indexedDb/application-instance-db.service';
 import { WallLossesSurfaceDbService } from '../indexedDb/wall-losses-surface-db.service';
 import { AtmosphereDbService } from '../indexedDb/atmosphere-db.service';
+import { SolidLoadMaterialDbService } from '../indexedDb/solid-load-material-db.service';
 @Injectable()
 export class CoreService {
 
@@ -54,7 +55,8 @@ export class CoreService {
     private applicationDataService: ApplicationInstanceDbService,
     private wallLossesSurfaceDbService: WallLossesSurfaceDbService,
     private directoryDbService: DirectoryDbService,
-    private atmosphereDbService: AtmosphereDbService) {
+    private atmosphereDbService: AtmosphereDbService,
+    private solidLoadMaterialDbService: SolidLoadMaterialDbService) {
     this.showShareDataModal = new BehaviorSubject<boolean>(false);
   }
 
@@ -183,7 +185,7 @@ export class CoreService {
   async createDefaultProcessHeatingMaterials(): Promise<void> {
     await firstValueFrom(this.wallLossesSurfaceDbService.insertDefaultMaterials());
     await firstValueFrom(this.atmosphereDbService.insertDefaultMaterials());
-
+    await firstValueFrom(this.solidLoadMaterialDbService.insertDefaultMaterials())
     return Promise.resolve();
   }
 

--- a/src/app/indexedDb/solid-load-material-db.service.ts
+++ b/src/app/indexedDb/solid-load-material-db.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, map, Observable } from 'rxjs';
 import { SolidLoadChargeMaterial } from '../shared/models/materials';
 import { SolidLoadMaterialStoreMeta } from './dbConfig';
+declare var Module: any;
 
 @Injectable()
 export class SolidLoadMaterialDbService {
@@ -12,6 +13,34 @@ export class SolidLoadMaterialDbService {
   constructor(private dbService: NgxIndexedDBService) {
     this.dbSolidLoadChargeMaterials = new BehaviorSubject<Array<SolidLoadChargeMaterial>>([]);
 
+  }
+
+  insertDefaultMaterials(): Observable<number[]> {
+    let DefaultData = new Module.DefaultData();
+    let suiteDefaultMaterials = DefaultData.getSolidLoadChargeMaterials();
+
+    let defaultMaterials: Array<SolidLoadChargeMaterial> = [];
+    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+      let wasmClass = suiteDefaultMaterials.get(i);
+      defaultMaterials.push({
+        latentHeat: wasmClass.getLatentHeat(),
+        meltingPoint: wasmClass.getMeltingPoint(),
+        specificHeatLiquid: wasmClass.getSpecificHeatLiquid(),
+        specificHeatSolid: wasmClass.getSpecificHeatSolid(),
+        substance: wasmClass.getSubstance(),
+        isDefault: true
+      });
+      wasmClass.delete();
+    }
+    DefaultData.delete();
+    suiteDefaultMaterials.delete();
+    return this.dbService.bulkAdd(this.storeName, defaultMaterials);
+  }
+
+  getAllCustomMaterials(): Observable<Array<SolidLoadChargeMaterial>> {
+    return this.dbService.getAll(this.storeName).pipe(
+      map((materials: SolidLoadChargeMaterial[]) => materials.filter((material: SolidLoadChargeMaterial) => !material.isDefault))
+    );
   }
 
   getAllWithObservable(): Observable<Array<SolidLoadChargeMaterial>> {

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-fixtures-form/explore-fixtures-form.component.ts
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-fixtures-form/explore-fixtures-form.component.ts
@@ -6,9 +6,9 @@ import { SolidLoadChargeMaterial } from '../../../../shared/models/materials';
 import { FixtureLoss } from '../../../../shared/models/phast/losses/fixtureLoss';
 import { ConvertUnitsService } from '../../../../shared/convert-units/convert-units.service';
 import { FixtureFormService } from '../../../../calculator/furnaces/fixture/fixture-form.service';
-import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
 import { firstValueFrom } from 'rxjs';
 import { SolidLoadMaterialDbService } from '../../../../indexedDb/solid-load-material-db.service';
+import { roundVal } from '../../../../shared/helperFunctions';
 
 @Component({
   selector: 'app-explore-fixtures-form',
@@ -187,10 +187,12 @@ export class ExploreFixturesFormComponent implements OnInit {
   async setSpecificHeat(loss: FixtureLoss) {
     let material: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(loss.materialName));
     if (material) {
+      let specificHeatSolid: number = material.specificHeatSolid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        material.specificHeatSolid = this.convertUnitsService.value(material.specificHeatSolid).from('btulbF').to('kJkgC');
+        specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
       }
-      loss.specificHeat = Number(material.specificHeatSolid.toFixed(3));
+      specificHeatSolid = roundVal(specificHeatSolid, 4);
+      loss.specificHeat = Number(specificHeatSolid.toFixed(3));
     }
     this.calculate();
   }

--- a/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-fixtures-form/explore-fixtures-form.component.ts
+++ b/src/app/phast/explore-phast-opportunities/explore-phast-opportunities-form/explore-fixtures-form/explore-fixtures-form.component.ts
@@ -7,12 +7,14 @@ import { FixtureLoss } from '../../../../shared/models/phast/losses/fixtureLoss'
 import { ConvertUnitsService } from '../../../../shared/convert-units/convert-units.service';
 import { FixtureFormService } from '../../../../calculator/furnaces/fixture/fixture-form.service';
 import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
+import { firstValueFrom } from 'rxjs';
+import { SolidLoadMaterialDbService } from '../../../../indexedDb/solid-load-material-db.service';
 
 @Component({
-    selector: 'app-explore-fixtures-form',
-    templateUrl: './explore-fixtures-form.component.html',
-    styleUrls: ['./explore-fixtures-form.component.css'],
-    standalone: false
+  selector: 'app-explore-fixtures-form',
+  templateUrl: './explore-fixtures-form.component.html',
+  styleUrls: ['./explore-fixtures-form.component.css'],
+  standalone: false
 })
 export class ExploreFixturesFormComponent implements OnInit {
   @Input()
@@ -35,10 +37,10 @@ export class ExploreFixturesFormComponent implements OnInit {
   baselineWarnings: Array<{ specificHeatWarning: string, feedRateWarning: string }>;
   modificationWarnings: Array<{ specificHeatWarning: string, feedRateWarning: string }>;
   showInitialTemp: Array<boolean>;
-  constructor(private sqlDbApiService: SqlDbApiService, private convertUnitsService: ConvertUnitsService, private fixtureFormService: FixtureFormService) { }
+  constructor(private solidLoadMaterialDbService: SolidLoadMaterialDbService, private convertUnitsService: ConvertUnitsService, private fixtureFormService: FixtureFormService) { }
 
   ngOnInit() {
-    this.materials = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+    this.setMaterials();
     this.initData();
     this.initTempData();
   }
@@ -50,6 +52,10 @@ export class ExploreFixturesFormComponent implements OnInit {
         this.initTempData();
       }
     }
+  }
+
+  async setMaterials() {
+    this.materials = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable())
   }
 
   initData() {
@@ -178,8 +184,8 @@ export class ExploreFixturesFormComponent implements OnInit {
   }
 
 
-  setSpecificHeat(loss: FixtureLoss) {
-    let material: SolidLoadChargeMaterial = this.sqlDbApiService.selectSolidLoadChargeMaterialById(loss.materialName);
+  async setSpecificHeat(loss: FixtureLoss) {
+    let material: SolidLoadChargeMaterial = await firstValueFrom(this.solidLoadMaterialDbService.getByIdWithObservable(loss.materialName));
     if (material) {
       if (this.settings.unitsOfMeasure === 'Metric') {
         material.specificHeatSolid = this.convertUnitsService.value(material.specificHeatSolid).from('btulbF').to('kJkgC');

--- a/src/app/phast/losses/fixture-losses/fixture-losses-form/fixture-losses-form.component.ts
+++ b/src/app/phast/losses/fixture-losses/fixture-losses-form/fixture-losses-form.component.ts
@@ -106,11 +106,12 @@ export class FixtureLossesFormComponent implements OnInit {
   async setSpecificHeat() {
     let tmpMaterial: SolidLoadChargeMaterial = this.getSelectedMaterial();
     if (tmpMaterial) {
+      let specificHeatSolid: number = tmpMaterial.specificHeatSolid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        tmpMaterial.specificHeatSolid = this.convertUnitsService.value(tmpMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
+        specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
       }
       this.lossesForm.patchValue({
-        specificHeat: roundVal(tmpMaterial.specificHeatSolid, 3)
+        specificHeat: roundVal(specificHeatSolid, 3)
       });
     }
     this.save();
@@ -120,11 +121,11 @@ export class FixtureLossesFormComponent implements OnInit {
     if (this.lossesForm.controls.materialName.value) {
       let material: SolidLoadChargeMaterial = this.getSelectedMaterial();
       if (material) {
-        let val = material.specificHeatSolid;
+        let specificHeatSolid: number = material.specificHeatSolid;
         if (this.settings.unitsOfMeasure === 'Metric') {
-          val = this.convertUnitsService.value(val).from('btulbF').to('kJkgC');
+          specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
         }
-        material.specificHeatSolid = roundVal(val, 3);
+        material.specificHeatSolid = roundVal(specificHeatSolid, 3);
         if (material.specificHeatSolid !== this.lossesForm.controls.specificHeat.value) {
           return true;
         } else {
@@ -169,18 +170,22 @@ export class FixtureLossesFormComponent implements OnInit {
   setProperties() {
     let selectedMaterial: SolidLoadChargeMaterial = this.getSelectedMaterial();
     if (selectedMaterial) {
+      let specificHeatSolid: number = selectedMaterial.specificHeatSolid;
+      let latentHeat: number = selectedMaterial.latentHeat;
+      let meltingPoint: number = selectedMaterial.meltingPoint;
+      let specificHeatLiquid: number = selectedMaterial.specificHeatLiquid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        selectedMaterial.specificHeatSolid = this.convertUnitsService.value(selectedMaterial.specificHeatSolid).from('btulbF').to('kJkgC');
-        selectedMaterial.latentHeat = this.convertUnitsService.value(selectedMaterial.latentHeat).from('btuLb').to('kJkg');
-        selectedMaterial.meltingPoint = this.convertUnitsService.value(selectedMaterial.meltingPoint).from('F').to('C');
-        selectedMaterial.specificHeatLiquid = this.convertUnitsService.value(selectedMaterial.specificHeatLiquid).from('btulbF').to('kJkgC');
+        specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
+        latentHeat = this.convertUnitsService.value(latentHeat).from('btuLb').to('kJkg');
+        meltingPoint = this.convertUnitsService.value(meltingPoint).from('F').to('C');
+        specificHeatLiquid = this.convertUnitsService.value(specificHeatLiquid).from('btulbF').to('kJkgC');
       }
 
       this.lossesForm.patchValue({
-        specificHeat: roundVal(selectedMaterial.specificHeatSolid, 4),
-        meltingPoint: selectedMaterial.meltingPoint,
-        specificHeatLiquid: selectedMaterial.specificHeatLiquid,
-        latentHeat: selectedMaterial.latentHeat
+        specificHeat: roundVal(specificHeatSolid, 4),
+        meltingPoint: meltingPoint,
+        specificHeatLiquid: specificHeatLiquid,
+        latentHeat: latentHeat
       });
     }
     this.save();

--- a/src/app/phast/phast-report/phast-input-summary/charge-material-summary/charge-material-summary.component.ts
+++ b/src/app/phast/phast-report/phast-input-summary/charge-material-summary/charge-material-summary.component.ts
@@ -177,11 +177,12 @@ export class ChargeMaterialSummaryComponent implements OnInit {
     if (loss.materialType === 'Solid') {
       let material: SolidLoadChargeMaterial = this.solidMaterialTypes.find(val => { return val.substance === loss.materialName; });
       if (material) {
+        let specificHeatSolid: number = material.specificHeatSolid;
         if (this.settings.unitsOfMeasure === 'Metric') {
-          material.specificHeatSolid = this.convertUnitsService.value(material.specificHeatSolid).from('btulbF').to('kJkgC');
+          specificHeatSolid = this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
         }
-        material.specificHeatSolid = roundVal(material.specificHeatSolid, 4);
-        if (material.specificHeatSolid !== loss.specificHeatSolid) {
+        specificHeatSolid = roundVal(specificHeatSolid, 4);
+        if (specificHeatSolid !== loss.specificHeatSolid) {
           return true;
         }
       }
@@ -200,12 +201,13 @@ export class ChargeMaterialSummaryComponent implements OnInit {
       material = liquidOptions.find(val => { return val.substance === loss.materialName; });
     }
     if (material) {
+      let specificHeatLiquid: number = material.specificHeatLiquid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        material.specificHeatLiquid = this.convertUnitsService.value(material.specificHeatLiquid).from('btulbF').to('kJkgC');
+        specificHeatLiquid = this.convertUnitsService.value(specificHeatLiquid).from('btulbF').to('kJkgC');
       }
-      material.specificHeatLiquid = roundVal(material.specificHeatLiquid, 4);
+      specificHeatLiquid = roundVal(specificHeatLiquid, 4);
 
-      if (material.specificHeatLiquid !== loss.specificHeatLiquid) {
+      if (specificHeatLiquid !== loss.specificHeatLiquid) {
         return true;
       }
     }
@@ -216,11 +218,12 @@ export class ChargeMaterialSummaryComponent implements OnInit {
     if (loss.materialType === 'Solid') {
       let material: SolidLoadChargeMaterial = this.solidMaterialTypes.find(val => { return val.substance === loss.materialName; });
       if (material) {
+        let meltingPoint: number = material.meltingPoint;
         if (this.settings.unitsOfMeasure === 'Metric') {
-          material.meltingPoint = this.convertUnitsService.value(material.meltingPoint).from('F').to('C');
+          meltingPoint = this.convertUnitsService.value(meltingPoint).from('F').to('C');
         }
-        material.meltingPoint = roundVal(material.meltingPoint, 4);
-        if (material.meltingPoint !== loss.meltingPoint) {
+        meltingPoint = roundVal(meltingPoint, 4);
+        if (meltingPoint !== loss.meltingPoint) {
           return true;
         }
       }
@@ -239,11 +242,12 @@ export class ChargeMaterialSummaryComponent implements OnInit {
       material = liquidOptions.find(val => { return val.substance === loss.materialName; });
     }
     if (material) {
+      let latentHeat: number = material.latentHeat;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        material.latentHeat = this.convertUnitsService.value(material.latentHeat).from('btuLb').to('kJkg');
+        latentHeat = this.convertUnitsService.value(latentHeat).from('btuLb').to('kJkg');
       }
-      material.latentHeat = roundVal(material.latentHeat, 4);
-      if (material.latentHeat !== loss.latentHeat) {
+      latentHeat = roundVal(latentHeat, 4);
+      if (latentHeat !== loss.latentHeat) {
         return true;
       }
     }

--- a/src/app/phast/phast-report/phast-input-summary/fixture-summary/fixture-summary.component.ts
+++ b/src/app/phast/phast-report/phast-input-summary/fixture-summary/fixture-summary.component.ts
@@ -4,9 +4,9 @@ import { Settings } from '../../../../shared/models/settings';
 import { SolidLoadChargeMaterial } from '../../../../shared/models/materials';
 import { FixtureLoss } from '../../../../shared/models/phast/losses/fixtureLoss';
 import { ConvertUnitsService } from '../../../../shared/convert-units/convert-units.service';
-import { SqlDbApiService } from '../../../../tools-suite-api/sql-db-api.service';
 import { SolidLoadMaterialDbService } from '../../../../indexedDb/solid-load-material-db.service';
 import { firstValueFrom } from 'rxjs';
+import { roundVal } from '../../../../shared/helperFunctions';
 @Component({
   selector: 'app-fixture-summary',
   templateUrl: './fixture-summary.component.html',
@@ -118,21 +118,19 @@ export class FixtureSummaryComponent implements OnInit {
   checkSpecificHeat(loss: FixtureLoss) {
     let material: SolidLoadChargeMaterial = this.materialOptions.find(val => { return val.id === loss.materialName; });
     if (material) {
+      let specificHeatSolid: number = material.specificHeatSolid;
       if (this.settings.unitsOfMeasure === 'Metric') {
-        let val = this.convertUnitsService.value(material.specificHeatSolid).from('btulbF').to('kJkgC');
-        material.specificHeatSolid = this.roundVal(val, 4);
+        specificHeatSolid= this.convertUnitsService.value(specificHeatSolid).from('btulbF').to('kJkgC');
+        specificHeatSolid = roundVal(specificHeatSolid, 4);
       }
-      if (material.specificHeatSolid !== loss.specificHeat) {
+      if (specificHeatSolid !== loss.specificHeat) {
         return true;
       } else {
         return false;
       }
     }
   }
-  roundVal(val: number, digits: number) {
-    let test = Number(val.toFixed(digits));
-    return test;
-  }
+
   toggleCollapse() {
     this.collapse = !this.collapse;
   }

--- a/src/app/shared/import-backup.service.ts
+++ b/src/app/shared/import-backup.service.ts
@@ -252,10 +252,7 @@ export class ImportBackupService {
     for await (let material of measurBackupFile.solidLoadChargeMaterials) {
       material.selected = false;
       delete material.id;
-      let isAdded = this.sqlDbApiService.insertSolidLoadChargeMaterial(material);
-      if (isAdded) {
-        await firstValueFrom(this.solidLoadMaterialDbService.addWithObservable(material));
-      }
+      await firstValueFrom(this.solidLoadMaterialDbService.addWithObservable(material));
     };
 
     for await (let material of measurBackupFile.atmosphereSpecificHeats) {

--- a/src/app/shared/models/materials.ts
+++ b/src/app/shared/models/materials.ts
@@ -23,6 +23,7 @@ export interface GasLoadChargeMaterial {
     selected?: boolean;
     specificHeatVapor: number;
     substance: string;
+    isDefault?: boolean
 }
 
 export interface LiquidLoadChargeMaterial {
@@ -58,6 +59,7 @@ export interface SolidLoadChargeMaterial {
     specificHeatLiquid: number;
     specificHeatSolid: number;
     substance: string;
+    isDefault?: boolean;
 }
 
 export interface AtmosphereSpecificHeat {

--- a/src/app/suiteDb/custom-materials/custom-materials.service.ts
+++ b/src/app/suiteDb/custom-materials/custom-materials.service.ts
@@ -155,12 +155,9 @@ export class CustomMaterialsService {
       let material: SolidLoadChargeMaterial = data[i];
       material.selected = false;
       delete material.id;
-      let test: boolean = this.sqlDbApiService.insertSolidLoadChargeMaterial(material);
-      if (test === true) {
-        await firstValueFrom(this.solidLoadMaterialDbService.addWithObservable(material));
-        let materials = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
-        this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
-      }
+      await firstValueFrom(this.solidLoadMaterialDbService.addWithObservable(material));
+      let materials = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
+      this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
     }
   }
 
@@ -257,15 +254,12 @@ export class CustomMaterialsService {
   }
 
   async deleteSolidLoadChargeMaterial(data: Array<SolidLoadChargeMaterial>) {
-    let sdbMaterials: Array<SolidLoadChargeMaterial> = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+    let materials: Array<SolidLoadChargeMaterial> = [];
     for (let i = 0; i < data.length; i++) {
       let material: SolidLoadChargeMaterial = data[i];
-      let materials = await firstValueFrom(this.solidLoadMaterialDbService.deleteByIdWithObservable(material.id));
-      this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
-
-      let sdbId: number = sdbMaterials.find((sdbMaterial) => { return material.substance === sdbMaterial.substance; }).id;
-      this.sqlDbApiService.deleteSolidLoadChargeMaterial(sdbId);
+      materials = await firstValueFrom(this.solidLoadMaterialDbService.deleteByIdWithObservable(material.id));
     };
+    this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
   }
 
   async deleteWallLossSurfaces(data: Array<WallLossesSurface>) {

--- a/src/app/suiteDb/solid-load-charge-material/solid-load-charge-material.component.ts
+++ b/src/app/suiteDb/solid-load-charge-material/solid-load-charge-material.component.ts
@@ -9,10 +9,10 @@ import { SolidLoadMaterialDbService } from '../../indexedDb/solid-load-material-
 import { firstValueFrom } from 'rxjs';
 
 @Component({
-    selector: 'app-solid-load-charge-material',
-    templateUrl: './solid-load-charge-material.component.html',
-    styleUrls: ['./solid-load-charge-material.component.css'],
-    standalone: false
+  selector: 'app-solid-load-charge-material',
+  templateUrl: './solid-load-charge-material.component.html',
+  styleUrls: ['./solid-load-charge-material.component.css'],
+  standalone: false
 })
 export class SolidLoadChargeMaterialComponent implements OnInit {
 
@@ -46,7 +46,7 @@ export class SolidLoadChargeMaterialComponent implements OnInit {
   idbEditMaterialId: number;
   sdbEditMaterialId: number;
   currentField: string = 'selectedMaterial';
-  constructor(private sqlDbApiService: SqlDbApiService, private settingsDbService: SettingsDbService, private solidLoadMaterialDbService: SolidLoadMaterialDbService, private convertUnitsService: ConvertUnitsService) { }
+  constructor(private settingsDbService: SettingsDbService, private solidLoadMaterialDbService: SolidLoadMaterialDbService, private convertUnitsService: ConvertUnitsService) { }
 
   ngOnInit() {
     if (!this.settings) {
@@ -57,16 +57,16 @@ export class SolidLoadChargeMaterialComponent implements OnInit {
     }
     else {
       this.canAdd = true;
-      this.allMaterials = this.sqlDbApiService.selectSolidLoadChargeMaterials();
+      this.setAllMaterials();
       this.checkMaterialName();
     }
   }
 
   async setAllMaterials() {
-    this.allMaterials = this.sqlDbApiService.selectSolidLoadChargeMaterials();
-    this.allCustomMaterials = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
-    this.sdbEditMaterialId = _.find(this.allMaterials, (material) => { return this.existingMaterial.substance === material.substance; }).id;
-    this.idbEditMaterialId = _.find(this.allCustomMaterials, (material) => { return this.existingMaterial.substance === material.substance; }).id;
+    this.allMaterials = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
+    this.allCustomMaterials = await firstValueFrom(this.solidLoadMaterialDbService.getAllCustomMaterials());
+    this.sdbEditMaterialId = _.find(this.allMaterials, (material) => { return this.existingMaterial?.substance === material.substance; })?.id;
+    this.idbEditMaterialId = _.find(this.allCustomMaterials, (material) => { return this.existingMaterial?.substance === material.substance; })?.id;
     this.setExisting();
   }
 
@@ -79,13 +79,10 @@ export class SolidLoadChargeMaterialComponent implements OnInit {
         this.newMaterial.specificHeatSolid = this.convertUnitsService.value(this.newMaterial.specificHeatSolid).from('kJkgC').to('btulbF');
         this.newMaterial.latentHeat = this.convertUnitsService.value(this.newMaterial.latentHeat).from('kJkg').to('btuLb');
       }
-      let suiteDbResult = this.sqlDbApiService.insertSolidLoadChargeMaterial(this.newMaterial);
-      if (suiteDbResult === true) {
-        await firstValueFrom(this.solidLoadMaterialDbService.addWithObservable(this.newMaterial));
-        let materials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
-        this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
-        this.closeModal.emit(this.newMaterial);
-      }
+      await firstValueFrom(this.solidLoadMaterialDbService.addWithObservable(this.newMaterial));
+      let materials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
+      this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
+      this.closeModal.emit(this.newMaterial);
     }
   }
 
@@ -97,26 +94,20 @@ export class SolidLoadChargeMaterialComponent implements OnInit {
       this.newMaterial.latentHeat = this.convertUnitsService.value(this.newMaterial.latentHeat).from('kJkg').to('btuLb');
     }
     this.newMaterial.id = this.sdbEditMaterialId;
-    let suiteDbResult = this.sqlDbApiService.updateSolidLoadChargeMaterial(this.newMaterial);
-    if (suiteDbResult === true) {
-      //need to set id for idb to put updates
-      this.newMaterial.id = this.idbEditMaterialId;
-      await firstValueFrom(this.solidLoadMaterialDbService.updateWithObservable(this.newMaterial))
-      let materials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
-      this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
-      this.closeModal.emit(this.newMaterial);
-    }
+    //need to set id for idb to put updates
+    this.newMaterial.id = this.idbEditMaterialId;
+    await firstValueFrom(this.solidLoadMaterialDbService.updateWithObservable(this.newMaterial))
+    let materials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
+    this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
+    this.closeModal.emit(this.newMaterial);
   }
 
   async deleteMaterial() {
     if (this.deletingMaterial && this.existingMaterial) {
-      let suiteDbResult = this.sqlDbApiService.deleteSolidLoadChargeMaterial(this.sdbEditMaterialId);
-      if (suiteDbResult === true) {
-        await firstValueFrom(this.solidLoadMaterialDbService.deleteByIdWithObservable(this.idbEditMaterialId));
-        let materials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
-        this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
-        this.closeModal.emit(this.newMaterial);
-      }
+      await firstValueFrom(this.solidLoadMaterialDbService.deleteByIdWithObservable(this.idbEditMaterialId));
+      let materials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
+      this.solidLoadMaterialDbService.dbSolidLoadChargeMaterials.next(materials);
+      this.closeModal.emit(this.newMaterial);
     }
   }
 

--- a/src/app/tools-suite-api/sql-db-api.service.ts
+++ b/src/app/tools-suite-api/sql-db-api.service.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { AtmosphereDbService } from '../indexedDb/atmosphere-db.service';
 import { FlueGasMaterialDbService } from '../indexedDb/flue-gas-material-db.service';
 import { GasLoadMaterialDbService } from '../indexedDb/gas-load-material-db.service';
 import { LiquidLoadMaterialDbService } from '../indexedDb/liquid-load-material-db.service';
 import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
-import { SolidLoadMaterialDbService } from '../indexedDb/solid-load-material-db.service';
-import { AtmosphereSpecificHeat, FlueGasMaterial, GasLoadChargeMaterial, LiquidLoadChargeMaterial, SolidLiquidFlueGasMaterial, SolidLoadChargeMaterial, SuiteDbMotor, SuiteDbPump } from '../shared/models/materials';
+import { FlueGasMaterial, GasLoadChargeMaterial, LiquidLoadChargeMaterial, SolidLiquidFlueGasMaterial, SuiteDbMotor, SuiteDbPump } from '../shared/models/materials';
 import { SuiteApiHelperService } from './suite-api-helper.service';
 
 declare var Module: any;
@@ -17,11 +15,9 @@ export class SqlDbApiService {
   constructor(private suiteApiHelperService: SuiteApiHelperService,
     private gasLoadMaterialDbService: GasLoadMaterialDbService,
     private liquidLoadMaterialDbService: LiquidLoadMaterialDbService,
-    private solidLoadMaterialDbService: SolidLoadMaterialDbService,
     private flueGasMaterialDbService: FlueGasMaterialDbService,
     private solidLiquidMaterialDbService: SolidLiquidMaterialDbService
   ) { }
-
 
   async initCustomDbMaterials() {
     let customGasLoadChargeMaterials: GasLoadChargeMaterial[] = await firstValueFrom(this.gasLoadMaterialDbService.getAllWithObservable());
@@ -29,15 +25,9 @@ export class SqlDbApiService {
       let suiteResult = this.insertGasLoadChargeMaterial(material);
     });
 
-
     let customLiquidLoadChargeMaterials: LiquidLoadChargeMaterial[] = await firstValueFrom(this.liquidLoadMaterialDbService.getAllWithObservable());
     customLiquidLoadChargeMaterials.forEach(material => {
       let suiteResult = this.insertLiquidLoadChargeMaterial(material);
-    });
-
-    let solidLoadChargeMaterials: SolidLoadChargeMaterial[] = await firstValueFrom(this.solidLoadMaterialDbService.getAllWithObservable());
-    solidLoadChargeMaterials.forEach(material => {
-      let suiteResult = this.insertSolidLoadChargeMaterial(material);
     });
 
     let flueGasMaterials: FlueGasMaterial[] = await firstValueFrom(this.flueGasMaterialDbService.getAllWithObservable());
@@ -433,103 +423,6 @@ export class SqlDbApiService {
   deleteLiquidLoadChargeMaterial(id: number): boolean {
     try {
       let success = dbInstance.deleteLiquidLoadChargeMaterial(id);
-      return success;
-    } catch (err) {
-      console.log(err);
-      return false;
-    }
-  }
-
-
-
-  selectSolidLoadChargeMaterials(): Array<SolidLoadChargeMaterial> {
-    try {
-      let solidLoadChargeMaterials: Array<SolidLoadChargeMaterial> = new Array();
-      let items = dbInstance.getSolidLoadChargeMaterials();
-      for (let index = 0; index < items.size(); index++) {
-        let solidLoadChargeMaterialPointer = items.get(index);
-        let solidLoadChargeMaterial: SolidLoadChargeMaterial = this.getSolidLoadChargeMaterialFromWASM(solidLoadChargeMaterialPointer);
-        solidLoadChargeMaterials.push(solidLoadChargeMaterial);
-        solidLoadChargeMaterialPointer.delete();
-      }
-      items.delete();
-      return solidLoadChargeMaterials;
-    }
-    catch (err) {
-      console.log(err);
-      return [];
-    }
-  }
-
-  getSolidLoadChargeMaterialFromWASM(solidLoadChargeMaterialPointer): SolidLoadChargeMaterial {
-    return {
-      id: solidLoadChargeMaterialPointer.getID(),
-      selected: false,
-      latentHeat: solidLoadChargeMaterialPointer.getLatentHeat(),
-      meltingPoint: solidLoadChargeMaterialPointer.getMeltingPoint(),
-      specificHeatLiquid: solidLoadChargeMaterialPointer.getSpecificHeatLiquid(),
-      specificHeatSolid: solidLoadChargeMaterialPointer.getSpecificHeatSolid(),
-      substance: solidLoadChargeMaterialPointer.getSubstance(),
-    };
-  }
-
-
-  selectSolidLoadChargeMaterialById(id: number): SolidLoadChargeMaterial {
-    try {
-      let solidLoadChargeMaterialPointer = dbInstance.getSolidLoadChargeMaterialById(id);
-      let solidLoadChargeMaterial: SolidLoadChargeMaterial = this.getSolidLoadChargeMaterialFromWASM(solidLoadChargeMaterialPointer);
-      solidLoadChargeMaterialPointer.delete();
-      return solidLoadChargeMaterial;
-    }
-    catch (err) {
-      console.log(err);
-      return undefined;
-    }
-  }
-
-  insertSolidLoadChargeMaterial(surface: SolidLoadChargeMaterial): boolean {
-    try {
-      let SolidLoadChargeMaterial = this.getSolidLoadChargeMaterial(surface);
-      dbInstance.insertSolidLoadChargeMaterials(SolidLoadChargeMaterial);
-      SolidLoadChargeMaterial.delete();
-      return true;
-    }
-    catch (err) {
-      console.log(err);
-      return undefined;
-    }
-  }
-
-  updateSolidLoadChargeMaterial(material: SolidLoadChargeMaterial): boolean {
-    try {
-      let SolidLoadChargeMaterial = this.getSolidLoadChargeMaterial(material);
-      dbInstance.updateSolidLoadChargeMaterial(SolidLoadChargeMaterial);
-      SolidLoadChargeMaterial.delete();
-      return true;
-    } catch (err) {
-      console.log(err);
-      return false;
-    }
-  }
-
-  getSolidLoadChargeMaterial(solidLoadChargeMaterial: SolidLoadChargeMaterial) {
-    let SolidLoadChargeMaterial = new Module.SolidLoadChargeMaterial();
-    SolidLoadChargeMaterial.selected = false;
-    SolidLoadChargeMaterial.setLatentHeat(solidLoadChargeMaterial.latentHeat);
-    SolidLoadChargeMaterial.setMeltingPoint(solidLoadChargeMaterial.meltingPoint);
-    SolidLoadChargeMaterial.setSpecificHeatLiquid(solidLoadChargeMaterial.specificHeatLiquid);
-    SolidLoadChargeMaterial.setSpecificHeatSolid(solidLoadChargeMaterial.specificHeatSolid);
-    SolidLoadChargeMaterial.setSubstance(solidLoadChargeMaterial.substance);
-
-    if (solidLoadChargeMaterial.id !== undefined) {
-      SolidLoadChargeMaterial.setID(solidLoadChargeMaterial.id);
-    }
-    return SolidLoadChargeMaterial;
-  }
-
-  deleteSolidLoadChargeMaterial(id: number): boolean {
-    try {
-      let success = dbInstance.deleteSolidLoadChargeMaterial(id);
       return success;
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
connects #7714 
This pull request refactors how solid load charge materials are accessed and managed across several furnace calculator components. The main change is the migration from using the `SqlDbApiService` to the new `SolidLoadMaterialDbService`, which provides asynchronous, observable-based access to material data and supports default material initialization. Several synchronous methods are now asynchronous, and helper functions have been centralized for consistency.

**Migration to SolidLoadMaterialDbService and Asynchronous Data Access:**

* Replaced all uses of `SqlDbApiService` for solid load charge material queries (e.g., `selectSolidLoadChargeMaterials`, `selectSolidLoadChargeMaterialById`) with asynchronous methods from `SolidLoadMaterialDbService`, such as `getAllWithObservable` and `getByIdWithObservable`, in `solid-material-form.component.ts` and `fixture-form.component.ts`. Many methods are now `async` and use `firstValueFrom` for observable resolution. [[1]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL1-R12) [[2]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL49-R53) [[3]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL65-R66) [[4]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fR86-R89) [[5]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL146-R155) [[6]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL159-R165) [[7]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL169-L182) [[8]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL196-R204) [[9]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dL4-R13) [[10]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dL58-R58) [[11]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dL72-R72) [[12]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dR104-R107) [[13]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dL143-R157) [[14]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dL165-R170) [[15]](diffhunk://#diff-d0b11486593d6294f9c28d0d8a5f5d00a7c1cf2509992fa69555c3c07159877dL264-R250)

* Added new methods to `SolidLoadMaterialDbService` to insert default materials (using WASM `Module.DefaultData`), retrieve all custom materials (filtering out defaults), and provide observable-based access to all or individual materials. [[1]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffL3-R6) [[2]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffR18-R45)

**Component and Service Updates:**

* Updated `CoreService` to inject `SolidLoadMaterialDbService` and call its `insertDefaultMaterials` method during default material creation, ensuring solid load materials are initialized alongside other process heating materials. [[1]](diffhunk://#diff-f3324df4e4abea297a96df4177898bbef7daaa15de2e3b50d9c520ea96157284R29) [[2]](diffhunk://#diff-f3324df4e4abea297a96df4177898bbef7daaa15de2e3b50d9c520ea96157284L57-R59) [[3]](diffhunk://#diff-f3324df4e4abea297a96df4177898bbef7daaa15de2e3b50d9c520ea96157284L186-R188)

**Code Cleanup and Removal of Redundant Methods:**

* Removed several helper and check methods that are no longer needed due to the new data access pattern (e.g., `checkSpecificHeatOfSolid`, `checkLatentHeatOfFusion`, `checkHeatOfLiquid`, `checkMeltingPoint` in `solid-material-form.component.ts`, and similar in `fixture-form.component.ts`). Also removed the local `roundVal` function in favor of a shared helper. [[1]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL169-L182) [[2]](diffhunk://#diff-9855e25c3040d4140e9ab45c44ae2490edfbf26630b1cb966275834b6abee53fL196-R204) [[3]](diffhunk://#diff-df62b513a4ebb5c48d12f28067d6fcb97b8abaffb1d416937969bdcfdc2e91cdL182-L201)
