### PR TITLE
ci/codesigning-relocation - Relocate codesigning process

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -145,7 +145,7 @@ jobs:
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-22.04
-    needs: [build,notarize]
+    needs: [build,notarize,sign]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -66,6 +66,7 @@ jobs:
           name: sign-win-artifact
           path: |
             output/*.exe
+            output/latest.yml
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
@@ -77,8 +78,8 @@ jobs:
             output/*.AppImage
             output/*.blockmap
             output/*.tar.gz
-            output/*.yml
             output/*.zip
+            output/latest-*.yml
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
@@ -136,9 +137,10 @@ jobs:
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-2-artifact
+          name: release-3-artifact
           path: |
             output/*.exe
+            output/latest.yml
 
   release:
     if: github.ref_name == 'master'

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -95,16 +95,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: notarize-mac-artifact
+          path: output/
       - name: Notarize
         run: |
-          xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $(find ./ -name "MEASUR-*.*.*.dmg") &&
+          BUNDLE_PATH=$(find output -name "MEASUR-*.*.*.dmg")
+          xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $BUNDLE_PATH &&
           sleep 60 &&
-          xcrun stapler staple $(find ./ -name "MEASUR-*.*.*.dmg")
+          xcrun stapler staple $BUNDLE_PATH
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-2-artifact
-          path: ./*.dmg
+          path: |
+            output/*.dmg
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
@@ -118,12 +121,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sign-win-artifact
+          path: output/
       - name: Codesign
         run: |
           TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
           BUNDLE_PATH=$(find output -name "MEASUR-Setup-*.*.*.exe")
 
-          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode $TMP_CERT_PATH
+          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode > $TMP_CERT_PATH
 
           jsign --storetype "${{ secrets.WIN_STORE_TYPE }}" \
                 --storepass "${{ secrets.WIN_STORE_SECRET }}" \
@@ -133,7 +137,7 @@ jobs:
 
           OLD_HASH=$(grep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
           NEW_HASH=$(gen_hash -f "$BUNDLE_PATH")
-          sed -i "s|$OLD_HASH|$NEW_HASH|g" output/latest.yml
+          sed -i "s|$OLD_HASH|$NEW_HASH|g" ./output/latest.yml
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
@@ -141,6 +145,11 @@ jobs:
           path: |
             output/*.exe
             output/latest.yml
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
+      - name: Cleanup
+        run: rm -rf ./output
 
   release:
     if: github.ref_name == 'master'

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -44,59 +44,48 @@ jobs:
       - name: Package
         run: |
           node ./node_modules/.bin/electron-builder --mac --universal --publish never &
-          (node ./node_modules/.bin/electron-builder --win --x64 --publish never &&
-            EXE_PATH=$(find ../output -name "MEASUR-Setup-*.*.*.exe") &&
-            java -jar ~/jsign.jar \
-              --storetype "${{ secrets.WIN_STORE_TYPE }}" \
-              --storepass "${{ secrets.WIN_STORE_SECRET }}" \
-              --tsaurl "http://timestamp.sectigo.com" \
-              --certfile ./wincert.pem \
-              $EXE_PATH &&
-            (OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ../output/latest.yml) &
-            NEW_HASH=$(node ~/gen_hash.js -f $EXE_PATH)) &&
-            docker run \
-              --env OLD_HASH="$OLD_HASH" \
-              --env NEW_HASH="$NEW_HASH" \
-              -v ../output:/output \
-              ubuntu:latest \
-              sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml) &
+          node ./node_modules/.bin/electron-builder --win --x64 --publish never &
           node ./node_modules/.bin/electron-builder --linux --x64 --publish never
       - name: Prepare output
         id: output
         run: |
-          VERSION=$(ggrep -A3 'version:' ../output/latest-mac.yml | head -n1 | awk '{print $2}')
+          VERSION=$(ggrep -A3 'version:' output/latest-mac.yml | head -n1 | awk '{print $2}')
           echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          OUTPUTS_DIR=$(cd ../output/ && pwd)
-          echo "RUNNER_OUTDIR=$OUTPUTS_DIR" >> "$GITHUB_ENV"
-      - name: Upload notarization artifacts
+      - name: Upload notarization artifact
         uses: actions/upload-artifact@v4
         with:
-          name: init-mac-output
+          name: notarize-mac-artifact
           path: |
-            ${{ env.RUNNER_OUTDIR }}/*.dmg
+            output/*.dmg
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload signing artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sign-win-artifact
+          path: |
+            output/*.exe
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
       - name: Upload remaining artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: final-winux-output
+          name: release-1-output
           path: |
-            ${{ env.RUNNER_OUTDIR }}/*
-            !${{ env.RUNNER_OUTDIR }}/*-unpacked
-            !${{ env.RUNNER_OUTDIR }}/*-universal
-            !${{ env.RUNNER_OUTDIR }}/*.dmg
-            !${{ env.RUNNER_OUTDIR }}/builder-debug.yml
+            output/*.AppImage
+            output/*.blockmap
+            output/*.tar.gz
+            output/*.yml
+            output/*.zip
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
-      - name: Cleanup
-        run: |
-          rm -rf ../output/*
     outputs:
       BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
-  notarization:
+  notarize:
     if: github.ref_name == 'master'
     runs-on: macos-13
     needs: [build]
@@ -104,7 +93,7 @@ jobs:
       - name: Get artifacts
         uses: actions/download-artifact@v4
         with:
-          name: init-mac-output
+          name: notarize-mac-artifact
       - name: Notarize
         run: |
           xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $(find ./ -name "MEASUR-*.*.*.dmg") &&
@@ -113,23 +102,57 @@ jobs:
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:
-          name: final-mac-output
+          name: release-2-artifact
           path: ./*.dmg
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
 
+  sign:
+    if: github.ref_name == 'master'
+    runs-on: [self-hosted, cs]
+    needs: [build]
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sign-win-artifact
+      - name: Codesign
+        run: |
+          TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
+          BUNDLE_PATH=$(find output -name "MEASUR-Setup-*.*.*.exe")
+
+          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode $TMP_CERT_PATH
+
+          jsign --storetype "${{ secrets.WIN_STORE_TYPE }}" \
+                --storepass "${{ secrets.WIN_STORE_SECRET }}" \
+                --tsaurl "http://timestamp.sectigo.com" \
+                --certfile $TMP_CERT_PATH \
+                $BUNDLE_PATH
+
+          OLD_HASH=$(grep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
+          NEW_HASH=$(gen_hash -f "$BUNDLE_PATH")
+          sed -i "s|$OLD_HASH|$NEW_HASH|g" output/latest.yml
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-2-artifact
+          path: |
+            output/*.exe
+
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-22.04
-    needs: [build,notarization]
+    needs: [build,notarize]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:
       - name: Get artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: final-*
+          pattern: release-*-artifact
+          path: release
+          merge-multiple: true
       - name: Release
         uses: softprops/action-gh-release@v1
         # if: startsWith(github.ref, 'refs/tags/') # Uncomment if enabling tag gating
@@ -139,5 +162,4 @@ jobs:
           draft: true # Comment out if enabling tag gating and publishing via action
           generate_release_notes: false
           files: |
-            final-mac-output/*
-            final-winux-output/*
+            release/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/dist
 /tmp
 .angular
+/output
 
 *.tsbuildinfo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ if: tag IS blank
 language: node_js
 node_js:
   - '12.8'
-  
+
 matrix:
   include:
     - name: "Linux Build"
       os: linux
-    
+
     - name: "Mac Build"
       os: osx
-      
+
     - name: "Windows Build"
       os: windows
-    
+
 before_install:
   - chmod 777 travis_scripts/*
   - travis_retry ./travis_scripts/before_install.sh
@@ -29,7 +29,7 @@ script:
   - travis_wait 40 ./travis_scripts/build.sh
   - echo "Build complete"
   #- export TRAVIS_TAG="release_draft"
-  
+
 before_deploy:
   #function keep_alive() {
   #  while true; do
@@ -44,13 +44,13 @@ deploy:
   api_key:
     secure: iRdxjibRf0cHrjX26NqqeH6jvqrnNbOYaxRe/zbQWXs3Lx1jZg8Rh7a3i5SCXY3UGKm0uVfeASPM7HAaRgwZaml2tXsJW4Gkz0YxOvfAWB+LRNredQSHHUHpfIxZU24oMDYgm2yWpsa2jEbJsdMtv3yoRyv2BHDCyCjmfwfFJpxqfrG1kJdjiGqahsuamv7mf3nPmnRCdVLPlwCPhp/BlcqYGNpkhXi0q4/RYU2BB4W+8ZOHfjkXN7ff8KHjz/Jux5U4LRHN0PBxfqnrLByZHFCXp7fT1SM8QUFTovHX7BsSdUWL2ufs+CMeG4H6pPk///VKx0AqVmY4T7pk0xnqbvTZvPQck0jXitDSjRQCo2J8v6tBzQfrWW5nnpqSGKsJyxXQMkjRMMn7VQ68H6VCJjgjKRV1duN7RMw2h8K04FZR0a0emyVyQZFw6HcnSlHQPSuy5/c04jpLZymKWlYVJXkXzrKO6W2ry0TTdRDJmQzxbeeYbmSKlnlZZWXnmeozVDy8mHv99134P93KzGDoet8CCo+WSiz7aYbcIvPwA72bSCnM+XOylHOD45kEV0a99xaLhHV6GjexY4yVPn0z4mRk5/f4WorR2te3rYJRobb29qRBR1TlMZb8LvHPz5cRSzHP2k5WdviEmuvTYhwx60CsOlxKKBo0cXi93ig3MJg=
   file:
-    - "../output/MEASUR-0.6.5-beta.AppImage"
-    - "../output/MEASUR-0.6.5-beta.tar.gz"
-    - "../output/latest-linux.yml"
-    - "../output/MEASUR-0.6.5-beta.dmg"
-    - "../output/latest-mac.yml"
-    - "../output/MEASUR-Setup-0.6.5-beta.exe"
-    - "../output/latest.yml"
+    - "output/MEASUR-0.6.5-beta.AppImage"
+    - "output/MEASUR-0.6.5-beta.tar.gz"
+    - "output/latest-linux.yml"
+    - "output/MEASUR-0.6.5-beta.dmg"
+    - "output/latest-mac.yml"
+    - "output/MEASUR-Setup-0.6.5-beta.exe"
+    - "output/latest.yml"
   overwrite: true
   skip_cleanup: true
   draft: true

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Change directory to `/AMO-Tools-Desktop`
 - Build the desktop installer:
     - `npm run build-prod-desktop` 
     - `npm run dist`
-    - The package will be placed in `../output`
+    - The package will be placed in `output`
 - Build the web dist:
     - `npm run build-prod-web` 
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "copyright": "Copyright 2017 ORNL. All rights reserved.",
     "productName": "MEASUR",
     "directories": {
-      "output": "../output/"
+      "output": "output/"
     },
     "files": [
       "!**/.angular",

--- a/travis_scripts/build.sh
+++ b/travis_scripts/build.sh
@@ -6,7 +6,7 @@ if [[ $TRAVIS_BRANCH == 'master' ]]; then
   npm run ng-high-memory;
   ./node_modules/.bin/build -"$OS_FLAG" --x64 --publish="never";
   ls;
-  ls ../output/;
+  ls output/;
 else
   npm run build;
 fi


### PR DESCRIPTION
## Changes
- Output path for electron bundles revised: `../output/` to `output/`
  - Relevant files updated to align with revision
- Codesigning revised in accordance to relocation
- Artifact naming and  artifact path updates
  - Align upload-artifact steps to output path update
  - Artifact names updated to clearly indicate purposes