### PR TITLE
FIX: windows bundle shell switch

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -159,6 +159,7 @@ jobs:
           restore-keys: npm-
       - *npm-setup
       - name: Bundle
+        shell: bash
         run: npm run dist -- --win --x64 --publish never
       - name: Upload codesign artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Using the default shell from the `windows-2025` causes the `bundle_win` workflow to error out upon reaching the `Bundle` step. Resolution of this can be done via switching the shell the step uses to `bash` in similar fashion to setting the shell to `bash` for the `*npm-setup` anchor.