### PR TITLE
Issue 7759: Modularized WASM Build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "file-saver": "^2.0.5",
         "font-awesome": "^4.7.0",
         "fs-jetpack": "^5.1.0",
-        "measur-tools-suite": "1.0.11-beta.44",
+        "measur-tools-suite": "1.0.11-beta.68",
         "ngx-indexed-db": "^16.0.0",
         "ngx-webstorage": "^19.0.1",
         "pako": "^2.1.0",
@@ -16148,13 +16148,13 @@
       }
     },
     "node_modules/measur-tools-suite": {
-      "version": "1.0.11-beta.44",
-      "resolved": "https://registry.npmjs.org/measur-tools-suite/-/measur-tools-suite-1.0.11-beta.44.tgz",
-      "integrity": "sha512-fKvst8EQDFqDIxVV4uJmyqE/+/FvDpzonXsQ9OBxMeDQGpegKur3z6jk7NvQRC6gaddnf4hrnaf1Xq6ELEJ5fQ==",
+      "version": "1.0.11-beta.68",
+      "resolved": "https://registry.npmjs.org/measur-tools-suite/-/measur-tools-suite-1.0.11-beta.68.tgz",
+      "integrity": "sha512-f1Jmd9x+x6/RzxTYBGgD9r/lHwCJ7LGjUaeY+VLGbMJZVNRy3mrsbNClQgmJvR6LmEQHbscClxLtVYB/0CGv3g==",
       "license": "MIT",
       "engines": {
-        "node": "20.16.0",
-        "npm": "10.8.1"
+        "node": "20.19.4",
+        "npm": "10.8.2"
       }
     },
     "node_modules/media-typer": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "file-saver": "^2.0.5",
     "font-awesome": "^4.7.0",
     "fs-jetpack": "^5.1.0",
-    "measur-tools-suite": "1.0.11-beta.44",
+    "measur-tools-suite": "1.0.11-beta.68",
     "ngx-indexed-db": "^16.0.0",
     "ngx-webstorage": "^19.0.1",
     "pako": "^2.1.0",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { ElectronService } from './electron/electron.service';
 import { AppErrorService } from './shared/errors/app-error.service';
 import { UpdateApplicationService } from './shared/update-application/update-application.service';
 import { MeasurAppError } from './shared/errors/errors';
+import { ToolsSuiteApiService } from './tools-suite-api/tools-suite-api.service';
 // declare ga as a function to access the JS code in TS
 declare let gtag: Function;
 
@@ -29,7 +30,8 @@ export class AppComponent {
     private updateApplicationService: UpdateApplicationService,
     private electronService: ElectronService,
     private appErrorService: AppErrorService,
-    private router: Router) {
+    private router: Router,
+    private toolsSuiteApiService: ToolsSuiteApiService) {
 
     if (environment.production) {
       // analytics handled through gatg() automatically manages sessions, visits, clicks, etc
@@ -98,6 +100,7 @@ export class AppComponent {
   }
 
   ngOnInit() {
+    this.initializeToolsSuiteApi();
     this.measurFormattedErrorSubscription = this.appErrorService.measurFormattedError.subscribe(error => {
       this.showAppErrorModal = (error !== undefined);
     });
@@ -111,5 +114,10 @@ export class AppComponent {
     this.appErrorService.measurFormattedError.next(undefined);
   }
 
+  async initializeToolsSuiteApi(){
+    console.log('initializing Tools Suite API...');
+    await this.toolsSuiteApiService.initializeModule();
+    console.log('Tools Suite API initialized');
+  }
 
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,6 @@ declare let gtag: Function;
 export class AppComponent {
   measurFormattedErrorSubscription: Subscription;
   showAppErrorModal: boolean;
-  toolsSuiteModuleInitialized: boolean = false;
   constructor(
     private analyticsService: AnalyticsService,
     private appRef: ApplicationRef,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -115,9 +115,7 @@ export class AppComponent {
   }
 
   async initializeToolsSuiteApi(){
-    console.log('initializing Tools Suite API...');
     await this.toolsSuiteApiService.initializeModule();
-    console.log('Tools Suite API initialized');
   }
 
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { AppErrorService } from './shared/errors/app-error.service';
 import { UpdateApplicationService } from './shared/update-application/update-application.service';
 import { MeasurAppError } from './shared/errors/errors';
 import { ToolsSuiteApiService } from './tools-suite-api/tools-suite-api.service';
+import { CoreService } from './core/core.service';
 // declare ga as a function to access the JS code in TS
 declare let gtag: Function;
 
@@ -22,7 +23,7 @@ declare let gtag: Function;
 export class AppComponent {
   measurFormattedErrorSubscription: Subscription;
   showAppErrorModal: boolean;
-
+  toolsSuiteModuleInitialized: boolean = false;
   constructor(
     private analyticsService: AnalyticsService,
     private appRef: ApplicationRef,
@@ -31,7 +32,8 @@ export class AppComponent {
     private electronService: ElectronService,
     private appErrorService: AppErrorService,
     private router: Router,
-    private toolsSuiteApiService: ToolsSuiteApiService) {
+    private toolsSuiteApiService: ToolsSuiteApiService,
+    private coreService: CoreService) {
 
     if (environment.production) {
       // analytics handled through gatg() automatically manages sessions, visits, clicks, etc
@@ -116,6 +118,7 @@ export class AppComponent {
 
   async initializeToolsSuiteApi(){
     await this.toolsSuiteApiService.initializeModule();
+    this.coreService.initializedToolsSuiteModule.next(true);
   }
 
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,30 +39,6 @@ import { filter, take } from 'rxjs/operators';
 })
 export class AppModule { }
 
-
-export function loadScriptFromPath(id: string, url: string): Promise<void> {
-  let script = <HTMLScriptElement>document.getElementById(id);
-  if (script) {
-    return Promise.resolve();
-  }
-
-  return new Promise<void>((resolve, reject) => {
-    script = document.createElement("script");
-    document.body.appendChild(script);
-    script.onload = () => {
-      resolve()
-    };
-    script.onerror = (ev: ErrorEvent) => {
-      reject(ev.error);
-    };
-    script.id = id;
-    script.async = true;
-    script.src = url;
-  });
-}
-
-
-
 export function initializeAppFactory(
   electronService: ElectronService,
   serviceWorkerUpdates: SwUpdate,
@@ -76,35 +52,6 @@ export function initializeAppFactory(
     const RELOAD_TRIES = 'measur_reload_tries';
     const RELOAD_REASON = 'measur_reload_reason';
     const LOAD_ERROR = 'measur_loading_error';
-
-    function initializeWASMScript() {
-      return new Promise((resolve, reject) => {
-        // Prepare global objects 
-        console.log('=== Initializing MEASUR Tools Suite module ===');
-        window['dbInstance'] = undefined;
-        window['Module'] = {
-          onRuntimeInitialized: function () {
-            // window['dbInstance'] = new window['Module'].SQLite(":memory:", true);
-            console.log('=== MEASUR Tools Suite module initialized ===');
-            console.timeEnd('initializeAppFactory');
-            resolve(module);
-          },
-          onAbort: function (err) {
-            new MeasurAppError('Error occurred in MEASUR Tools Suite', undefined);
-          }
-        };
-
-        // Load client.js, ensure module created before app init
-        loadScriptFromPath('wasmClient', `client.js`)
-          .then(() => {
-            console.log('=== Loading MEASUR Tools Suite client.js ===');
-            const module = <any>{ locateFile: (file: string) => { } };
-          })
-          .catch(err => {
-            reject(new MeasurAppError('Unable to load MEASUR Tools Suite', err));
-          });
-      });
-    }
 
     browserStorageService.detectAppStorageOptions().pipe(
       filter((val: BrowserStorageAvailable) => val !== undefined),
@@ -148,6 +95,6 @@ export function initializeAppFactory(
     } else {
       console.log('=== Initialize for electron or dev web');
     }
-    return initializeWASMScript();
+    return;
   }
 }

--- a/src/app/calculator/furnaces/flue-gas/flue-gas-form-volume/flue-gas-form-volume.component.html
+++ b/src/app/calculator/furnaces/flue-gas/flue-gas-form-volume/flue-gas-form-volume.component.html
@@ -36,7 +36,7 @@
           ({{byVolumeForm.controls.flueGasTemperature.errors.min.min}}<span
             [innerHTML]="settings.steamTemperatureMeasurement | settingsLabel"></span>).</span>
       </span>
-      <span class="alert-warning pull-right small" *ngIf="warnings.flueGasTemp !== null">{{warnings.flueGasTemp}}</span>
+      <span class="alert-warning pull-right small" *ngIf="warnings?.flueGasTemp !== null">{{warnings.flueGasTemp}}</span>
     </div>
 
     <div class="form-group">
@@ -75,7 +75,7 @@
         <span *ngIf="byVolumeForm.controls.o2InFlueGas.errors.required">Value Required</span>
       </span>
     </div>
-    <span class="alert-warning pull-right small" *ngIf="warnings.o2Warning !== null">{{warnings.o2Warning}}</span>
+    <span class="alert-warning pull-right small" *ngIf="warnings?.o2Warning !== null">{{warnings.o2Warning}}</span>
   </div>
       
 

--- a/src/app/calculator/furnaces/flue-gas/flue-gas-form.service.ts
+++ b/src/app/calculator/furnaces/flue-gas/flue-gas-form.service.ts
@@ -44,7 +44,10 @@ export class FlueGasFormService {
       'CO2': [0, Validators.required],
       'SO2': [0, Validators.required], 
       'O2': [0, Validators.required],
-      'name': ['Loss #' + lossNumber]
+      'name': ['Loss #' + lossNumber],
+      'specificGravity': [0],
+      'heatingValue': [0],
+      'heatingValueVolume': [0]
     });
 
     if (!loss) {

--- a/src/app/core/core.component.html
+++ b/src/app/core/core.component.html
@@ -1,18 +1,26 @@
-<div *ngIf="idbStarted" [ngClass]="{'modal-open': showSecurityAndPrivacyModal == true || showEmailMeasurDataModal == true}" >
+<div *ngIf="idbStarted"
+    [ngClass]="{'modal-open': showSecurityAndPrivacyModal == true || showEmailMeasurDataModal == true}">
     <div *ngIf="!hideTutorial" class="opening-tutorial">
         <app-opening-tutorial *ngIf="tutorialType == 'landing-screen'" (closeTutorial)="closeTutorial()">
         </app-opening-tutorial>
         <app-dashboard-tutorial *ngIf="tutorialType == 'dashboard-tutorial'" (closeTutorial)="closeTutorial()"
-        [inTutorials]="inTutorialsView"></app-dashboard-tutorial>
+            [inTutorials]="inTutorialsView"></app-dashboard-tutorial>
     </div>
-    <router-outlet></router-outlet>
+    <ng-template [ngIf]="toolsSuiteInitialized" [ngIfElse]="loading">
+        <router-outlet></router-outlet>
+    </ng-template>
+    <ng-template #loading>
+        <p class="mt-5 text-center">
+            {{loadingMessage}}
+        </p>
+    </ng-template>
 </div>
 
 <app-import-backup-modal *ngIf="showImportBackupModal === true"></app-import-backup-modal>
-<app-security-and-privacy-modal *ngIf="showSecurityAndPrivacyModal === true" 
-(emitModalClosed)="closeNoticeModal($event)"></app-security-and-privacy-modal>
-<app-email-measur-data-modal *ngIf="showEmailMeasurDataModal === true" 
-(emitModalClosed)="closeEmailModal($event)"></app-email-measur-data-modal>
+<app-security-and-privacy-modal *ngIf="showSecurityAndPrivacyModal === true"
+    (emitModalClosed)="closeNoticeModal($event)"></app-security-and-privacy-modal>
+<app-email-measur-data-modal *ngIf="showEmailMeasurDataModal === true"
+    (emitModalClosed)="closeEmailModal($event)"></app-email-measur-data-modal>
 <app-survey-modal *ngIf="showSurveyModal"></app-survey-modal>
 <app-subscribe-modal *ngIf="showSubscribeModal"></app-subscribe-modal>
 <app-release-notes-modal *ngIf="showReleaseNotesModal" (closeModal)="closeReleaseNotes()"></app-release-notes-modal>

--- a/src/app/core/core.component.ts
+++ b/src/app/core/core.component.ts
@@ -220,7 +220,6 @@ export class CoreComponent implements OnInit {
         await this.coreService.setNewApplicationInstanceData();
         await this.coreService.createDefaultDirectories();
         await this.coreService.createExamples();
-        await this.coreService.createDefaultProcessHeatingMaterials();
         await this.coreService.createDirectorySettings();
       } catch (e) {
         this.appErrorService.handleAppError(e, 'Error creating MEASUR database');

--- a/src/app/core/core.component.ts
+++ b/src/app/core/core.component.ts
@@ -24,6 +24,7 @@ import { CORE_DATA_WARNING, SECONDARY_DATA_WARNING, SnackbarService } from '../s
 import { BrowserStorageAvailable, BrowserStorageService } from '../shared/browser-storage.service';
 import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
 import { FlueGasMaterialDbService } from '../indexedDb/flue-gas-material-db.service';
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Component({
   selector: 'app-core',
@@ -88,7 +89,8 @@ export class CoreComponent implements OnInit {
     private browserStorageService: BrowserStorageService,
     private exportToJustifiTemplateService: ExportToJustifiTemplateService,
     private solidLiquidMaterialDbService: SolidLiquidMaterialDbService,
-    private flueGasMaterialDbService: FlueGasMaterialDbService
+    private flueGasMaterialDbService: FlueGasMaterialDbService,
+    private toolsSuiteApiService: ToolsSuiteApiService
   ) {
   }
 
@@ -274,6 +276,7 @@ export class CoreComponent implements OnInit {
           this.diagramIdbService.setAll(initializedData.diagrams);
           this.calculatorDbService.setAll(initializedData.calculators);
           this.inventoryDbService.setAll(initializedData.inventoryItems);
+          this.toolsSuiteApiService.initializeDefaultDbData();
           this.idbStarted = true;
           this.changeDetectorRef.detectChanges();
           if (this.electronService.isElectron) {

--- a/src/app/core/core.component.ts
+++ b/src/app/core/core.component.ts
@@ -65,6 +65,9 @@ export class CoreComponent implements OnInit {
   showShareDataModal: boolean = false;
   showShareDataModalSub: Subscription;
 
+  toolsSuiteInitialized: boolean;
+  toolsSuiteInitializedSub: Subscription;
+  loadingMessage: string;
   constructor(public electronService: ElectronService,
     private assessmentService: AssessmentService,
     private changeDetectorRef: ChangeDetectorRef,
@@ -95,6 +98,10 @@ export class CoreComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.setLoadingMessage();
+    this.toolsSuiteInitializedSub = this.coreService.initializedToolsSuiteModule.subscribe(val => {
+      this.toolsSuiteInitialized = val;
+    });
 
     if (this.electronService.isElectron) {
       this.electronService.sendAppReady('ready');
@@ -212,6 +219,7 @@ export class CoreComponent implements OnInit {
     this.emailVisibilitySubscription.unsubscribe();
     this.showExportToJustifiModalSub.unsubscribe();
     this.showShareDataModalSub.unsubscribe();
+    this.toolsSuiteInitializedSub.unsubscribe();
   }
 
   async initData() {
@@ -324,6 +332,28 @@ export class CoreComponent implements OnInit {
 
   closeReleaseNotes() {
     this.updateApplicationService.showReleaseNotesModal.next(false);
+  }
+
+  setLoadingMessage() {
+    const messages = [
+      "Loading... I hope you're having a nice day!",
+      "Just a moment, wishing you a wonderful day!",
+      "Preparing things for you. Hope your day is going well!",
+      "Hang tight! I hope you're having a fantastic day!",
+      "Almost there—hope your day is as great as you are!",
+      "Setting things up. I hope you're enjoying your day!",
+      "Loading your experience. Have a nice day!",
+      "Good things are coming. Hope your day is pleasant!",
+      "Getting ready... I hope you're having a nice day!",
+      "Thanks for your patience. Wishing you a great day!",
+      "Just a sec! I hope your day is going smoothly!",
+      "Loading magic. Hope you're having a nice day!",
+      "Almost done! I hope your day is wonderful!",
+      "Preparing your app. Have a fantastic day!",
+      "One moment please. I hope you're having a nice day!"
+    ];
+    const randomIndex = Math.floor(Math.random() * messages.length);
+    this.loadingMessage = messages[randomIndex];
   }
 
 }

--- a/src/app/core/core.service.ts
+++ b/src/app/core/core.service.ts
@@ -7,7 +7,7 @@ import { MockFsat, MockFsatSettings, MockFsatCalculator } from '../examples/mock
 import { MockSsmt, MockSsmtSettings } from '../examples/mockSsmt';
 import { MockTreasureHunt, MockTreasureHuntSettings } from '../examples/mockTreasureHunt';
 import { MockMotorInventory } from '../examples/mockMotorInventoryData';
-import { BehaviorSubject, firstValueFrom, forkJoin, Observable, ObservableInput } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, forkJoin } from 'rxjs';
 import { MockWasteWater, MockWasteWaterSettings } from '../examples/mockWasteWater';
 import { MockCompressedAirAssessment, MockCompressedAirAssessmentSettings } from '../examples/mockCompressedAirAssessment';
 import { DirectoryDbService } from '../indexedDb/directory-db.service';
@@ -23,13 +23,6 @@ import { DiagramIdbService } from '../indexedDb/diagram-idb.service';
 import { MockWaterdiagram } from '../examples/mockWaterDiagram';
 import { Diagram } from '../shared/models/diagram';
 import { ApplicationInstanceDbService, ApplicationInstanceData } from '../indexedDb/application-instance-db.service';
-import { WallLossesSurfaceDbService } from '../indexedDb/wall-losses-surface-db.service';
-import { AtmosphereDbService } from '../indexedDb/atmosphere-db.service';
-import { SolidLoadMaterialDbService } from '../indexedDb/solid-load-material-db.service';
-import { GasLoadMaterialDbService } from '../indexedDb/gas-load-material-db.service';
-import { LiquidLoadMaterialDbService } from '../indexedDb/liquid-load-material-db.service';
-import { FlueGasMaterialDbService } from '../indexedDb/flue-gas-material-db.service';
-import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
 @Injectable()
 export class CoreService {
 
@@ -56,14 +49,7 @@ export class CoreService {
     private electronService: ElectronService,
     private diagramIdbService: DiagramIdbService,
     private applicationDataService: ApplicationInstanceDbService,
-    private wallLossesSurfaceDbService: WallLossesSurfaceDbService,
-    private directoryDbService: DirectoryDbService,
-    private atmosphereDbService: AtmosphereDbService,
-    private solidLoadMaterialDbService: SolidLoadMaterialDbService,
-    private gasLoadMaterialDbService: GasLoadMaterialDbService,
-    private liquidLoadMaterialDbService: LiquidLoadMaterialDbService,
-    private flueGasMaterialDbService: FlueGasMaterialDbService,
-    private solidLiquidMaterialDbService: SolidLiquidMaterialDbService) {
+    private directoryDbService: DirectoryDbService,) {
     this.showShareDataModal = new BehaviorSubject<boolean>(false);
   }
 
@@ -189,16 +175,6 @@ export class CoreService {
     await firstValueFrom(this.calculatorDbService.addWithObservable(MockFsatCalculator));
   }
 
-  async createDefaultProcessHeatingMaterials(): Promise<void> {
-    await firstValueFrom(this.wallLossesSurfaceDbService.insertDefaultMaterials());
-    await firstValueFrom(this.atmosphereDbService.insertDefaultMaterials());
-    await firstValueFrom(this.solidLoadMaterialDbService.insertDefaultMaterials());
-    await firstValueFrom(this.gasLoadMaterialDbService.insertDefaultMaterials());
-    await firstValueFrom(this.liquidLoadMaterialDbService.insertDefaultMaterials());
-    await this.flueGasMaterialDbService.insertDefaultMaterials();
-    await this.solidLiquidMaterialDbService.insertDefaultMaterials();
-  }
-
   async createDirectorySettings() {
     // Add settings for 'All Assessments'
     let defaultSettings: Settings = this.getDefaultSettingsObject();
@@ -245,5 +221,7 @@ export class CoreService {
 
     MockWaterAssessmentSettings.assessmentId = this.exampleWaterAssessmentId;
     await firstValueFrom(this.settingsDbService.addWithObservable(MockWaterAssessmentSettings));
+
+    await this.settingsDbService.setAll();
   }
 }

--- a/src/app/core/core.service.ts
+++ b/src/app/core/core.service.ts
@@ -41,6 +41,7 @@ export class CoreService {
   exampleWaterDiagramId: number;
 
   showShareDataModal: BehaviorSubject<boolean>;
+  initializedToolsSuiteModule: BehaviorSubject<boolean>;
   constructor(
     private settingsDbService: SettingsDbService,
     private calculatorDbService: CalculatorDbService,
@@ -49,8 +50,9 @@ export class CoreService {
     private electronService: ElectronService,
     private diagramIdbService: DiagramIdbService,
     private applicationDataService: ApplicationInstanceDbService,
-    private directoryDbService: DirectoryDbService,) {
+    private directoryDbService: DirectoryDbService) {
     this.showShareDataModal = new BehaviorSubject<boolean>(false);
+    this.initializedToolsSuiteModule = new BehaviorSubject<boolean>(false);
   }
 
   getDefaultSettingsObject(): Settings {

--- a/src/app/fsat/fanOptions.ts
+++ b/src/app/fsat/fanOptions.ts
@@ -1,5 +1,3 @@
-declare var Module: any;
-
 export const FanTypes: Array<{ value: number, display: string, enumVal?: any }> = [
   {
     value: 5,

--- a/src/app/indexedDb/atmosphere-db.service.ts
+++ b/src/app/indexedDb/atmosphere-db.service.ts
@@ -3,19 +3,21 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, Observable, map } from 'rxjs';
 import { AtmosphereSpecificHeat } from '../shared/models/materials';
 import { AtmosphereStoreMeta } from './dbConfig';
-declare var Module: any;
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class AtmosphereDbService {
   storeName: string = AtmosphereStoreMeta.store;
   dbAtmospherSpecificHeatMaterials: BehaviorSubject<Array<AtmosphereSpecificHeat>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) {
     this.dbAtmospherSpecificHeatMaterials = new BehaviorSubject<Array<AtmosphereSpecificHeat>>([]);
   }
 
   insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getAtmosphereSpecificHeat();
 
     let defaultMaterials: Array<AtmosphereSpecificHeat> = [];

--- a/src/app/indexedDb/atmosphere-db.service.ts
+++ b/src/app/indexedDb/atmosphere-db.service.ts
@@ -3,35 +3,18 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, Observable, map } from 'rxjs';
 import { AtmosphereSpecificHeat } from '../shared/models/materials';
 import { AtmosphereStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class AtmosphereDbService {
   storeName: string = AtmosphereStoreMeta.store;
   dbAtmospherSpecificHeatMaterials: BehaviorSubject<Array<AtmosphereSpecificHeat>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService
+  constructor(private dbService: NgxIndexedDBService
   ) {
     this.dbAtmospherSpecificHeatMaterials = new BehaviorSubject<Array<AtmosphereSpecificHeat>>([]);
   }
 
-  insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getAtmosphereSpecificHeat();
-
-    let defaultMaterials: Array<AtmosphereSpecificHeat> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({ 
-        substance: wasmClass.getSubstance(), 
-        specificHeat: wasmClass.getSpecificHeat(),
-        isDefault: true 
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  insertDefaultMaterials(defaultMaterials: Array<AtmosphereSpecificHeat>): Observable<number[]> {
     return this.dbService.bulkAdd(this.storeName, defaultMaterials);
   }
 

--- a/src/app/indexedDb/flue-gas-material-db.service.ts
+++ b/src/app/indexedDb/flue-gas-material-db.service.ts
@@ -3,19 +3,21 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { FlueGasMaterial } from '../shared/models/materials';
 import { FlueGasMaterialStoreMeta } from './dbConfig';
-declare var Module: any;
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class FlueGasMaterialDbService {
   storeName: string = FlueGasMaterialStoreMeta.store;
   dbFlueGasMaterials: BehaviorSubject<Array<FlueGasMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) {
     this.dbFlueGasMaterials = new BehaviorSubject<Array<FlueGasMaterial>>([]);
 
   }
   async insertDefaultMaterials(): Promise<void> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getGasFlueGasMaterials();
 
     let defaultMaterials: Array<FlueGasMaterial> = [];

--- a/src/app/indexedDb/flue-gas-material-db.service.ts
+++ b/src/app/indexedDb/flue-gas-material-db.service.ts
@@ -3,49 +3,18 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { FlueGasMaterial } from '../shared/models/materials';
 import { FlueGasMaterialStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class FlueGasMaterialDbService {
   storeName: string = FlueGasMaterialStoreMeta.store;
   dbFlueGasMaterials: BehaviorSubject<Array<FlueGasMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService
+  constructor(private dbService: NgxIndexedDBService
   ) {
     this.dbFlueGasMaterials = new BehaviorSubject<Array<FlueGasMaterial>>([]);
 
   }
-  async insertDefaultMaterials(): Promise<void> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getGasFlueGasMaterials();
-
-    let defaultMaterials: Array<FlueGasMaterial> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      //GasComposition
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({
-        substance: wasmClass.getSubstance(),
-        C2H6: wasmClass.getGasByVol("C2H6"),
-        C3H8: wasmClass.getGasByVol("C3H8"),
-        C4H10_CnH2n: wasmClass.getGasByVol("C4H10_CnH2n"),
-        CH4: wasmClass.getGasByVol("CH4"),
-        CO: wasmClass.getGasByVol("CO"),
-        CO2: wasmClass.getGasByVol("CO2"),
-        H2: wasmClass.getGasByVol("H2"),
-        H2O: wasmClass.getGasByVol("H2O"),
-        N2: wasmClass.getGasByVol("N2"),
-        O2: wasmClass.getGasByVol("O2"),
-        SO2: wasmClass.getGasByVol("SO2"),
-        heatingValue: wasmClass.getHeatingValue(),
-        heatingValueVolume: wasmClass.getHeatingValueVolume(),
-        specificGravity: wasmClass.getSpecificGravity(),
-        isDefault: true
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  async insertDefaultMaterials(defaultMaterials: Array<FlueGasMaterial>): Promise<void> {
     await firstValueFrom(this.dbService.bulkAdd(this.storeName, defaultMaterials));
     await this.setAllMaterialsFromDb();
   }

--- a/src/app/indexedDb/gas-load-material-db.service.ts
+++ b/src/app/indexedDb/gas-load-material-db.service.ts
@@ -3,36 +3,18 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { GasLoadChargeMaterial } from '../shared/models/materials';
 import { GasLoadMaterialStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class GasLoadMaterialDbService {
   storeName: string = GasLoadMaterialStoreMeta.store;
   dbGasLoadChargeMaterials: BehaviorSubject<Array<GasLoadChargeMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService
+  constructor(private dbService: NgxIndexedDBService
   ) {
     this.dbGasLoadChargeMaterials = new BehaviorSubject<Array<GasLoadChargeMaterial>>([]);
-
   }
 
-  insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getGasLoadChargeMaterials();
-
-    let defaultMaterials: Array<GasLoadChargeMaterial> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({
-        specificHeatVapor: wasmClass.getSpecificHeatVapor(),
-        substance: wasmClass.getSubstance(),
-        isDefault: true
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  insertDefaultMaterials(defaultMaterials: Array<GasLoadChargeMaterial>): Observable<number[]> {
     return this.dbService.bulkAdd(this.storeName, defaultMaterials);
   }
 

--- a/src/app/indexedDb/gas-load-material-db.service.ts
+++ b/src/app/indexedDb/gas-load-material-db.service.ts
@@ -3,21 +3,22 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { GasLoadChargeMaterial } from '../shared/models/materials';
 import { GasLoadMaterialStoreMeta } from './dbConfig';
-declare var Module: any;
-
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class GasLoadMaterialDbService {
   storeName: string = GasLoadMaterialStoreMeta.store;
   dbGasLoadChargeMaterials: BehaviorSubject<Array<GasLoadChargeMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) {
     this.dbGasLoadChargeMaterials = new BehaviorSubject<Array<GasLoadChargeMaterial>>([]);
 
   }
 
   insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getGasLoadChargeMaterials();
 
     let defaultMaterials: Array<GasLoadChargeMaterial> = [];

--- a/src/app/indexedDb/liquid-load-material-db.service.ts
+++ b/src/app/indexedDb/liquid-load-material-db.service.ts
@@ -3,38 +3,17 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { LiquidLoadChargeMaterial } from '../shared/models/materials';
 import { LiquidLoadMaterialStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
-
 
 @Injectable()
 export class LiquidLoadMaterialDbService {
   storeName: string = LiquidLoadMaterialStoreMeta.store;
   dbLiquidLoadChargeMaterials: BehaviorSubject<Array<LiquidLoadChargeMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService) {
+  constructor(private dbService: NgxIndexedDBService) {
     this.dbLiquidLoadChargeMaterials = new BehaviorSubject<Array<LiquidLoadChargeMaterial>>([]);
   }
 
-  insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getLiquidLoadChargeMaterials();
-
-    let defaultMaterials: Array<LiquidLoadChargeMaterial> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({
-        latentHeat: wasmClass.getLatentHeat(),
-        specificHeatLiquid: wasmClass.getSpecificHeatLiquid(),
-        specificHeatVapor: wasmClass.getSpecificHeatVapor(),
-        vaporizationTemperature: wasmClass.getVaporizingTemperature(),
-        substance: wasmClass.getSubstance(),
-        isDefault: true
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  insertDefaultMaterials(defaultMaterials: Array<LiquidLoadChargeMaterial>): Observable<number[]> {
     return this.dbService.bulkAdd(this.storeName, defaultMaterials);
   }
 

--- a/src/app/indexedDb/liquid-load-material-db.service.ts
+++ b/src/app/indexedDb/liquid-load-material-db.service.ts
@@ -3,7 +3,7 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { LiquidLoadChargeMaterial } from '../shared/models/materials';
 import { LiquidLoadMaterialStoreMeta } from './dbConfig';
-declare var Module: any;
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 
 @Injectable()
@@ -11,12 +11,13 @@ export class LiquidLoadMaterialDbService {
   storeName: string = LiquidLoadMaterialStoreMeta.store;
   dbLiquidLoadChargeMaterials: BehaviorSubject<Array<LiquidLoadChargeMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService) {
     this.dbLiquidLoadChargeMaterials = new BehaviorSubject<Array<LiquidLoadChargeMaterial>>([]);
   }
 
   insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getLiquidLoadChargeMaterials();
 
     let defaultMaterials: Array<LiquidLoadChargeMaterial> = [];

--- a/src/app/indexedDb/settings-db.service.ts
+++ b/src/app/indexedDb/settings-db.service.ts
@@ -7,7 +7,7 @@ import { DirectoryDbService } from './directory-db.service';
 import { Directory } from '../shared/models/directory';
 import { InventoryItem } from '../shared/models/inventory/inventory';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, combineLatestWith, firstValueFrom, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import { SettingsStoreMeta } from './dbConfig';
 import { environment } from '../../environments/environment';
 import { Diagram } from '../shared/models/diagram';

--- a/src/app/indexedDb/solid-liquid-material-db.service.ts
+++ b/src/app/indexedDb/solid-liquid-material-db.service.ts
@@ -3,18 +3,19 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { SolidLiquidFlueGasMaterial } from '../shared/models/materials';
 import { SolidLiquidFlueGasMaterialStoreMeta } from './dbConfig';
-declare var Module: any;
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class SolidLiquidMaterialDbService {
   storeName: string = SolidLiquidFlueGasMaterialStoreMeta.store;
   dbSolidLiquidFlueGasMaterials: BehaviorSubject<Array<SolidLiquidFlueGasMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService) {
     this.dbSolidLiquidFlueGasMaterials = new BehaviorSubject<Array<SolidLiquidFlueGasMaterial>>([]);
   }
   async insertDefaultMaterials(): Promise<void> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getSolidLiquidFlueGasMaterials();
 
     let defaultMaterials: Array<SolidLiquidFlueGasMaterial> = [];

--- a/src/app/indexedDb/solid-liquid-material-db.service.ts
+++ b/src/app/indexedDb/solid-liquid-material-db.service.ts
@@ -1,43 +1,18 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import { SolidLiquidFlueGasMaterial } from '../shared/models/materials';
 import { SolidLiquidFlueGasMaterialStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class SolidLiquidMaterialDbService {
   storeName: string = SolidLiquidFlueGasMaterialStoreMeta.store;
   dbSolidLiquidFlueGasMaterials: BehaviorSubject<Array<SolidLiquidFlueGasMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService) {
+  constructor(private dbService: NgxIndexedDBService) {
     this.dbSolidLiquidFlueGasMaterials = new BehaviorSubject<Array<SolidLiquidFlueGasMaterial>>([]);
   }
-  async insertDefaultMaterials(): Promise<void> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getSolidLiquidFlueGasMaterials();
-
-    let defaultMaterials: Array<SolidLiquidFlueGasMaterial> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      //GasComposition
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({
-        substance: wasmClass.getSubstance(),
-        carbon: wasmClass.getCarbon(),
-        hydrogen: wasmClass.getHydrogen(),
-        inertAsh: wasmClass.getInertAsh(),
-        moisture: wasmClass.getMoisture(),
-        nitrogen: wasmClass.getNitrogen(),
-        o2: wasmClass.getO2(),
-        sulphur: wasmClass.getSulphur(),
-        heatingValue: wasmClass.getHeatingValueFuel(),
-        isDefault: true
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  async insertDefaultMaterials(defaultMaterials: Array<SolidLiquidFlueGasMaterial>): Promise<void> {
     await firstValueFrom(this.dbService.bulkAdd(this.storeName, defaultMaterials));
     await this.setAllMaterialsFromDb();
   }

--- a/src/app/indexedDb/solid-load-material-db.service.ts
+++ b/src/app/indexedDb/solid-load-material-db.service.ts
@@ -3,20 +3,21 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { SolidLoadChargeMaterial } from '../shared/models/materials';
 import { SolidLoadMaterialStoreMeta } from './dbConfig';
-declare var Module: any;
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class SolidLoadMaterialDbService {
   storeName: string = SolidLoadMaterialStoreMeta.store;
   dbSolidLoadChargeMaterials: BehaviorSubject<Array<SolidLoadChargeMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService) {
     this.dbSolidLoadChargeMaterials = new BehaviorSubject<Array<SolidLoadChargeMaterial>>([]);
 
   }
 
   insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getSolidLoadChargeMaterials();
 
     let defaultMaterials: Array<SolidLoadChargeMaterial> = [];

--- a/src/app/indexedDb/solid-load-material-db.service.ts
+++ b/src/app/indexedDb/solid-load-material-db.service.ts
@@ -3,38 +3,17 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { SolidLoadChargeMaterial } from '../shared/models/materials';
 import { SolidLoadMaterialStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class SolidLoadMaterialDbService {
   storeName: string = SolidLoadMaterialStoreMeta.store;
   dbSolidLoadChargeMaterials: BehaviorSubject<Array<SolidLoadChargeMaterial>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService) {
+  constructor(private dbService: NgxIndexedDBService) {
     this.dbSolidLoadChargeMaterials = new BehaviorSubject<Array<SolidLoadChargeMaterial>>([]);
-
   }
 
-  insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getSolidLoadChargeMaterials();
-
-    let defaultMaterials: Array<SolidLoadChargeMaterial> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({
-        latentHeat: wasmClass.getLatentHeat(),
-        meltingPoint: wasmClass.getMeltingPoint(),
-        specificHeatLiquid: wasmClass.getSpecificHeatLiquid(),
-        specificHeatSolid: wasmClass.getSpecificHeatSolid(),
-        substance: wasmClass.getSubstance(),
-        isDefault: true
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  insertDefaultMaterials(defaultMaterials: Array<SolidLoadChargeMaterial>): Observable<number[]> {
     return this.dbService.bulkAdd(this.storeName, defaultMaterials);
   }
 

--- a/src/app/indexedDb/wall-losses-surface-db.service.ts
+++ b/src/app/indexedDb/wall-losses-surface-db.service.ts
@@ -3,7 +3,6 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { WallLossesSurface } from '../shared/models/materials';
 import { WallLossesSurfaceStoreMeta } from './dbConfig';
-import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
 @Injectable()
 export class WallLossesSurfaceDbService {
@@ -11,29 +10,12 @@ export class WallLossesSurfaceDbService {
   storeName: string = WallLossesSurfaceStoreMeta.store;
   dbWallLossesSurfaceMaterials: BehaviorSubject<Array<WallLossesSurface>>;
 
-  constructor(private dbService: NgxIndexedDBService,
-    private toolsSuiteApiService: ToolsSuiteApiService
+  constructor(private dbService: NgxIndexedDBService
   ) {
     this.dbWallLossesSurfaceMaterials = new BehaviorSubject<Array<WallLossesSurface>>([]);
-
   }
 
-  insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
-    let suiteDefaultMaterials = DefaultData.getWallLossesSurface();
-
-    let defaultMaterials: Array<WallLossesSurface> = [];
-    for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
-      let wasmClass = suiteDefaultMaterials.get(i);
-      defaultMaterials.push({
-        surface: wasmClass.getSurface(),
-        conditionFactor: wasmClass.getConditionFactor(),
-        isDefault: true
-      });
-      wasmClass.delete();
-    }
-    DefaultData.delete();
-    suiteDefaultMaterials.delete();
+  insertDefaultMaterials(defaultMaterials: Array<WallLossesSurface>): Observable<number[]> {
     return this.dbService.bulkAdd(this.storeName, defaultMaterials);
   }
 

--- a/src/app/indexedDb/wall-losses-surface-db.service.ts
+++ b/src/app/indexedDb/wall-losses-surface-db.service.ts
@@ -3,21 +3,23 @@ import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { WallLossesSurface } from '../shared/models/materials';
 import { WallLossesSurfaceStoreMeta } from './dbConfig';
+import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 
-declare var Module: any;
 @Injectable()
 export class WallLossesSurfaceDbService {
 
   storeName: string = WallLossesSurfaceStoreMeta.store;
   dbWallLossesSurfaceMaterials: BehaviorSubject<Array<WallLossesSurface>>;
 
-  constructor(private dbService: NgxIndexedDBService) {
+  constructor(private dbService: NgxIndexedDBService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) {
     this.dbWallLossesSurfaceMaterials = new BehaviorSubject<Array<WallLossesSurface>>([]);
 
   }
 
   insertDefaultMaterials(): Observable<number[]> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getWallLossesSurface();
 
     let defaultMaterials: Array<WallLossesSurface> = [];

--- a/src/app/psat/psatConstants.ts
+++ b/src/app/psat/psatConstants.ts
@@ -1,5 +1,3 @@
-declare var Module: any;
-
 export const pumpTypesConstant: Array<{ value: number, display: string }> = [
     {
         value: 0,

--- a/src/app/shared/models/settings.ts
+++ b/src/app/shared/models/settings.ts
@@ -125,6 +125,9 @@ export interface Settings {
     steamRollupUnit?: string,
     wasteWaterRollupUnit?: string,
     compressedAirRollupUnit?: string,
+
+    //global
+    suiteDbItemsInitialized?: boolean;
 }
 
 

--- a/src/app/tools-suite-api/calculator-suite-api.service.ts
+++ b/src/app/tools-suite-api/calculator-suite-api.service.ts
@@ -1,17 +1,18 @@
 import { Injectable } from '@angular/core';
 import { AirLeakSurveyData, AirLeakSurveyInput, AirLeakSurveyResult, CompressedAirReductionInput, CompressedAirReductionResult, ElectricityReductionInput, ElectricityReductionResult, NaturalGasReductionInput, NaturalGasReductionResult, PipeInsulationReductionInput, PipeInsulationReductionResult, PowerFactorTriangleModeInputs, PowerFactorTriangleOutputs, SteamReductionInput, SteamReductionOutput, SteamReductionResult, TankInsulationReductionInput, TankInsulationReductionResult, WaterReductionInput, WaterReductionResult } from '../shared/models/standalone';
 import { SuiteApiHelperService } from './suite-api-helper.service';
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
-declare var Module: any;
 
 @Injectable()
 export class CalculatorSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   electricityReduction(inputObj: ElectricityReductionInput): ElectricityReductionResult {
-    let inputs = new Module.ElectricityReductionInputV();
-
+    let inputs = new this.toolsSuiteApiService.ToolsSuiteModule.ElectricityReductionInputV();
     inputObj.electricityReductionInputVec.forEach(electricityReduction => {
       // TODO calc only get results if valid
       electricityReduction.electricityCost = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(electricityReduction.electricityCost);
@@ -32,18 +33,18 @@ export class CalculatorSuiteApiService {
       electricityReduction.powerMeterData.power = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(electricityReduction.powerMeterData.power);
       electricityReduction.otherMethodData.energy = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(electricityReduction.otherMethodData.energy);
 
-      let MultimeterData = new Module.MultimeterData(
+      let MultimeterData = new this.toolsSuiteApiService.ToolsSuiteModule.MultimeterData(
         electricityReduction.multimeterData.numberOfPhases,
         electricityReduction.multimeterData.supplyVoltage,
         electricityReduction.multimeterData.averageCurrent,
         electricityReduction.multimeterData.powerFactor
       );
-      let NameplateData = new Module.NameplateData(electricityReduction.nameplateData.ratedMotorPower, electricityReduction.nameplateData.variableSpeedMotor,
+      let NameplateData = new this.toolsSuiteApiService.ToolsSuiteModule.NameplateData(electricityReduction.nameplateData.ratedMotorPower, electricityReduction.nameplateData.variableSpeedMotor,
         electricityReduction.nameplateData.operationalFrequency, electricityReduction.nameplateData.lineFrequency, electricityReduction.nameplateData.motorAndDriveEfficiency, electricityReduction.nameplateData.loadFactor);
-      let PowerMeterData = new Module.PowerMeterData(electricityReduction.powerMeterData.power);
-      let OtherMethodData = new Module.OtherMethodData(electricityReduction.otherMethodData.energy);
+      let PowerMeterData = new this.toolsSuiteApiService.ToolsSuiteModule.PowerMeterData(electricityReduction.powerMeterData.power);
+      let OtherMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.OtherMethodData(electricityReduction.otherMethodData.energy);
 
-      let wasmConvertedInput = new Module.ElectricityReductionInput(
+      let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.ElectricityReductionInput(
         electricityReduction.operatingHours,
         electricityReduction.electricityCost,
         electricityReduction.measurementMethod,
@@ -63,7 +64,7 @@ export class CalculatorSuiteApiService {
       OtherMethodData.delete();
     });
 
-    let ElectricityReductionCalculator = new Module.ElectricityReduction(inputs);
+    let ElectricityReductionCalculator = new this.toolsSuiteApiService.ToolsSuiteModule.ElectricityReduction(inputs);
     let output = ElectricityReductionCalculator.calculate();
     let results: ElectricityReductionResult = {
       energyUse: output.energyUse,
@@ -77,7 +78,7 @@ export class CalculatorSuiteApiService {
   }
 
   naturalGasReduction(inputObj: NaturalGasReductionInput): NaturalGasReductionResult {
-    let inputs = new Module.NaturalGasReductionInputV();
+    let inputs = new this.toolsSuiteApiService.ToolsSuiteModule.NaturalGasReductionInputV();
 
     inputObj.naturalGasReductionInputVec.forEach(naturalGasReduction => {
       // TODO calc only get results if valid
@@ -100,17 +101,17 @@ export class CalculatorSuiteApiService {
       naturalGasReduction.waterMassFlowData.systemEfficiency = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(naturalGasReduction.waterMassFlowData.systemEfficiency);
       naturalGasReduction.waterMassFlowData.waterFlow = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(naturalGasReduction.waterMassFlowData.waterFlow);
 
-      let FlowMeterMethodData = new Module.FlowMeterMethodData(naturalGasReduction.flowMeterMethodData.flowRate);
-      let NaturalGasOtherMethodData = new Module.NaturalGasOtherMethodData(naturalGasReduction.otherMethodData.consumption);
-      let AirMassFlowMeasuredData = new Module.AirMassFlowMeasuredData(naturalGasReduction.airMassFlowData.airMassFlowMeasuredData.areaOfDuct,
+      let FlowMeterMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.FlowMeterMethodData(naturalGasReduction.flowMeterMethodData.flowRate);
+      let NaturalGasOtherMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.NaturalGasOtherMethodData(naturalGasReduction.otherMethodData.consumption);
+      let AirMassFlowMeasuredData = new this.toolsSuiteApiService.ToolsSuiteModule.AirMassFlowMeasuredData(naturalGasReduction.airMassFlowData.airMassFlowMeasuredData.areaOfDuct,
         naturalGasReduction.airMassFlowData.airMassFlowMeasuredData.airVelocity);
-      let AirMassFlowNameplateData = new Module.AirMassFlowNameplateData(naturalGasReduction.airMassFlowData.airMassFlowNameplateData.airFlow);
-      let AirMassFlowData = new Module.AirMassFlowData(naturalGasReduction.airMassFlowData.isNameplate, AirMassFlowMeasuredData, AirMassFlowNameplateData,
+      let AirMassFlowNameplateData = new this.toolsSuiteApiService.ToolsSuiteModule.AirMassFlowNameplateData(naturalGasReduction.airMassFlowData.airMassFlowNameplateData.airFlow);
+      let AirMassFlowData = new this.toolsSuiteApiService.ToolsSuiteModule.AirMassFlowData(naturalGasReduction.airMassFlowData.isNameplate, AirMassFlowMeasuredData, AirMassFlowNameplateData,
         naturalGasReduction.airMassFlowData.inletTemperature, naturalGasReduction.airMassFlowData.outletTemperature, naturalGasReduction.airMassFlowData.systemEfficiency);
-      let WaterMassFlowData = new Module.WaterMassFlowData(naturalGasReduction.waterMassFlowData.waterFlow,
+      let WaterMassFlowData = new this.toolsSuiteApiService.ToolsSuiteModule.WaterMassFlowData(naturalGasReduction.waterMassFlowData.waterFlow,
         naturalGasReduction.waterMassFlowData.inletTemperature, naturalGasReduction.waterMassFlowData.outletTemperature, naturalGasReduction.waterMassFlowData.systemEfficiency);
 
-      let wasmConvertedInput = new Module.NaturalGasReductionInput(
+      let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.NaturalGasReductionInput(
         naturalGasReduction.operatingHours,
         naturalGasReduction.fuelCost,
         naturalGasReduction.measurementMethod,
@@ -130,7 +131,7 @@ export class CalculatorSuiteApiService {
       WaterMassFlowData.delete();
     });
 
-    let NaturalGasReductionCalculator = new Module.NaturalGasReduction(inputs);
+    let NaturalGasReductionCalculator = new this.toolsSuiteApiService.ToolsSuiteModule.NaturalGasReduction(inputs);
     let output = NaturalGasReductionCalculator.calculate();
     let results: NaturalGasReductionResult = {
       energyUse: output.energyUse,
@@ -145,7 +146,7 @@ export class CalculatorSuiteApiService {
   }
 
   compressedAirReduction(inputObj: CompressedAirReductionInput): CompressedAirReductionResult {
-    let inputs = new Module.CompressedAirReductionInputV();
+    let inputs = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirReductionInputV();
 
     inputObj.compressedAirReductionInputVec.forEach(compressedAirReduction => {
       compressedAirReduction.units = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(compressedAirReduction.units);
@@ -164,16 +165,16 @@ export class CalculatorSuiteApiService {
       compressedAirReduction.compressorElectricityData.compressorControlAdjustment = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(compressedAirReduction.compressorElectricityData.compressorControlAdjustment);
       compressedAirReduction.compressorElectricityData.compressorSpecificPower = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(compressedAirReduction.compressorElectricityData.compressorSpecificPower);
 
-      let CompressedAirFlowMeterMethodData = new Module.CompressedAirFlowMeterMethodData(compressedAirReduction.flowMeterMethodData.meterReading);
+      let CompressedAirFlowMeterMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirFlowMeterMethodData(compressedAirReduction.flowMeterMethodData.meterReading);
        // hardcoded 1 - always calculate as single unit
-      let BagMethod = new Module.BagMethod(compressedAirReduction.bagMethodData.operatingTime, compressedAirReduction.bagMethodData.bagFillTime, compressedAirReduction.bagMethodData.bagVolume, 1);
-      let PressureMethodData = new Module.PressureMethodData(compressedAirReduction.pressureMethodData.nozzleType, compressedAirReduction.pressureMethodData.numberOfNozzles,
+      let BagMethod = new this.toolsSuiteApiService.ToolsSuiteModule.BagMethod(compressedAirReduction.bagMethodData.operatingTime, compressedAirReduction.bagMethodData.bagFillTime, compressedAirReduction.bagMethodData.bagVolume, 1);
+      let PressureMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.PressureMethodData(compressedAirReduction.pressureMethodData.nozzleType, compressedAirReduction.pressureMethodData.numberOfNozzles,
         compressedAirReduction.pressureMethodData.supplyPressure);
-      let CompressedAirOtherMethodData = new Module.CompressedAirOtherMethodData(compressedAirReduction.otherMethodData.consumption);
-      let CompressorElectricityData = new Module.CompressorElectricityData(compressedAirReduction.compressorElectricityData.compressorControlAdjustment,
+      let CompressedAirOtherMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirOtherMethodData(compressedAirReduction.otherMethodData.consumption);
+      let CompressorElectricityData = new this.toolsSuiteApiService.ToolsSuiteModule.CompressorElectricityData(compressedAirReduction.compressorElectricityData.compressorControlAdjustment,
         compressedAirReduction.compressorElectricityData.compressorSpecificPower);
       
-      let wasmConvertedInput = new Module.CompressedAirReductionInput(
+      let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirReductionInput(
         compressedAirReduction.hoursPerYear,
         compressedAirReduction.utilityType,
         compressedAirReduction.utilityCost,
@@ -189,7 +190,7 @@ export class CalculatorSuiteApiService {
       CompressorElectricityData.delete();
     });
 
-    let CompressedAirReductionCalculator = new Module.CompressedAirReduction(inputs);
+    let CompressedAirReductionCalculator = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirReduction(inputs);
     let output = CompressedAirReductionCalculator.calculate();
     let results: CompressedAirReductionResult = {
       energyUse: output.energyUse,
@@ -235,29 +236,29 @@ export class CalculatorSuiteApiService {
       input.decibelsMethodData.secondFlowB = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.decibelsMethodData.secondFlowB);
       return input;
     });
-    let inputs = new Module.CompressedAirLeakSurveyInputV();
+    let inputs = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirLeakSurveyInputV();
 
     convertedInput.forEach((airLeakSurvey: AirLeakSurveyData) => {
-      let EstimateMethodData = new Module.EstimateMethodData(airLeakSurvey.estimateMethodData.leakRateEstimate);
+      let EstimateMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.EstimateMethodData(airLeakSurvey.estimateMethodData.leakRateEstimate);
       airLeakSurvey.bagMethodData.bagFillTime = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(airLeakSurvey.bagMethodData.bagFillTime);
       airLeakSurvey.bagMethodData.bagVolume = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(airLeakSurvey.bagMethodData.bagVolume);
 
       // make TH backwards compatible. hours are undefined in update-data service. There is probably a bug in TH init for air leak daa 
       let operatingTime = airLeakSurvey.bagMethodData.operatingTime? airLeakSurvey.bagMethodData.operatingTime : airLeakSurvey.hoursPerYear;
       // hardcoded 1 - always calculate as single unit
-      let BagMethod = new Module.BagMethod(operatingTime, airLeakSurvey.bagMethodData.bagFillTime, airLeakSurvey.bagMethodData.bagVolume, 1);
-      let DecibelsMethodData = new Module.DecibelsMethodData(airLeakSurvey.decibelsMethodData.linePressure,
+      let BagMethod = new this.toolsSuiteApiService.ToolsSuiteModule.BagMethod(operatingTime, airLeakSurvey.bagMethodData.bagFillTime, airLeakSurvey.bagMethodData.bagVolume, 1);
+      let DecibelsMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.DecibelsMethodData(airLeakSurvey.decibelsMethodData.linePressure,
         airLeakSurvey.decibelsMethodData.decibels, airLeakSurvey.decibelsMethodData.decibelRatingA, airLeakSurvey.decibelsMethodData.pressureA,
         airLeakSurvey.decibelsMethodData.firstFlowA, airLeakSurvey.decibelsMethodData.secondFlowA, airLeakSurvey.decibelsMethodData.decibelRatingB,
         airLeakSurvey.decibelsMethodData.pressureB, airLeakSurvey.decibelsMethodData.firstFlowB, airLeakSurvey.decibelsMethodData.secondFlowB);
 
-      let OrificeMethodData = new Module.OrificeMethodData(airLeakSurvey.orificeMethodData.compressorAirTemp,
+      let OrificeMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.OrificeMethodData(airLeakSurvey.orificeMethodData.compressorAirTemp,
         airLeakSurvey.orificeMethodData.atmosphericPressure, airLeakSurvey.orificeMethodData.dischargeCoefficient,
         airLeakSurvey.orificeMethodData.orificeDiameter, airLeakSurvey.orificeMethodData.supplyPressure, airLeakSurvey.orificeMethodData.numberOfOrifices);
-      let CompressorElectricityData = new Module.CompressorElectricityData(airLeakSurvey.compressorElectricityData.compressorControlAdjustment,
+      let CompressorElectricityData = new this.toolsSuiteApiService.ToolsSuiteModule.CompressorElectricityData(airLeakSurvey.compressorElectricityData.compressorControlAdjustment,
         airLeakSurvey.compressorElectricityData.compressorSpecificPower);
 
-      let wasmConvertedInput = new Module.CompressedAirLeakSurveyInput(
+      let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirLeakSurveyInput(
         airLeakSurvey.hoursPerYear,
         airLeakSurvey.utilityType,
         airLeakSurvey.utilityCost,
@@ -279,7 +280,7 @@ export class CalculatorSuiteApiService {
       CompressorElectricityData.delete();
     });
 
-    let CompressedAirLeakSurveyCalculator = new Module.CompressedAirLeakSurvey(inputs);
+    let CompressedAirLeakSurveyCalculator = new this.toolsSuiteApiService.ToolsSuiteModule.CompressedAirLeakSurvey(inputs);
     let output = CompressedAirLeakSurveyCalculator.calculate();
     let results: AirLeakSurveyResult = {
       totalFlowRate: output.totalFlowRate,
@@ -296,7 +297,7 @@ export class CalculatorSuiteApiService {
 
 
   waterReduction(inputObj: WaterReductionInput): WaterReductionResult {
-    let inputs = new Module.WaterReductionInputV();
+    let inputs = new this.toolsSuiteApiService.ToolsSuiteModule.WaterReductionInputV();
 
     inputObj.waterReductionInputVec.forEach(waterReduction => {
       waterReduction.waterCost = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(waterReduction.waterCost);
@@ -312,13 +313,13 @@ export class CalculatorSuiteApiService {
       waterReduction.bucketMethodData.bucketVolume = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(waterReduction.bucketMethodData.bucketVolume);
       waterReduction.otherMethodData.consumption = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(waterReduction.otherMethodData.consumption);
 
-      let MeteredFlowMethodData = new Module.MeteredFlowMethodData(waterReduction.meteredFlowMethodData.meterReading);
-      let VolumeMeterMethodData = new Module.VolumeMeterMethodData(waterReduction.volumeMeterMethodData.initialMeterReading,
+      let MeteredFlowMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.MeteredFlowMethodData(waterReduction.meteredFlowMethodData.meterReading);
+      let VolumeMeterMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.VolumeMeterMethodData(waterReduction.volumeMeterMethodData.initialMeterReading,
         waterReduction.volumeMeterMethodData.finalMeterReading, waterReduction.volumeMeterMethodData.elapsedTime);
-      let BucketMethodData = new Module.BucketMethodData(waterReduction.bucketMethodData.bucketVolume, waterReduction.bucketMethodData.bucketFillTime);
-      let OtherMethodData = new Module.WaterOtherMethodData(waterReduction.otherMethodData.consumption);
+      let BucketMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.BucketMethodData(waterReduction.bucketMethodData.bucketVolume, waterReduction.bucketMethodData.bucketFillTime);
+      let OtherMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.WaterOtherMethodData(waterReduction.otherMethodData.consumption);
 
-      let wasmConvertedInput = new Module.WaterReductionInput(
+      let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.WaterReductionInput(
         waterReduction.hoursPerYear,
         waterReduction.waterCost,
         waterReduction.measurementMethod,
@@ -336,7 +337,7 @@ export class CalculatorSuiteApiService {
       OtherMethodData.delete();
     });
 
-    let WaterReductionCalculator = new Module.WaterReduction(inputs);
+    let WaterReductionCalculator = new this.toolsSuiteApiService.ToolsSuiteModule.WaterReduction(inputs);
     let output = WaterReductionCalculator.calculate();
     let results: WaterReductionResult = {
       waterUse: output.waterUse,
@@ -351,30 +352,30 @@ export class CalculatorSuiteApiService {
   }
 
   steamReduction(inputObj: SteamReductionInput): SteamReductionResult {
-    let inputs = new Module.SteamReductionInputV();
+    let inputs = new this.toolsSuiteApiService.ToolsSuiteModule.SteamReductionInputV();
 
     inputObj.steamReductionInputVec.forEach(steamReduction => {
-      let FlowMeterMethodData = new Module.SteamFlowMeterMethodData(steamReduction.flowMeterMethodData.flowRate);
+      let FlowMeterMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamFlowMeterMethodData(steamReduction.flowMeterMethodData.flowRate);
 
-      let MassFlowMeasuredData = new Module.SteamMassFlowMeasuredData(steamReduction.airMassFlowMethodData.massFlowMeasuredData.areaOfDuct,
+      let MassFlowMeasuredData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamMassFlowMeasuredData(steamReduction.airMassFlowMethodData.massFlowMeasuredData.areaOfDuct,
         steamReduction.airMassFlowMethodData.massFlowMeasuredData.airVelocity);
-      let MassFlowNameplateData = new Module.SteamMassFlowNameplateData(steamReduction.airMassFlowMethodData.massFlowNameplateData.flowRate);
-      let AirMassFlowMethodData = new Module.SteamMassFlowMethodData(steamReduction.airMassFlowMethodData.isNameplate,
+      let MassFlowNameplateData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamMassFlowNameplateData(steamReduction.airMassFlowMethodData.massFlowNameplateData.flowRate);
+      let AirMassFlowMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamMassFlowMethodData(steamReduction.airMassFlowMethodData.isNameplate,
         MassFlowMeasuredData, MassFlowNameplateData,
         steamReduction.airMassFlowMethodData.inletTemperature, steamReduction.airMassFlowMethodData.outletTemperature);
 
-      MassFlowMeasuredData = new Module.SteamMassFlowMeasuredData(steamReduction.waterMassFlowMethodData.massFlowMeasuredData.areaOfDuct,
+      MassFlowMeasuredData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamMassFlowMeasuredData(steamReduction.waterMassFlowMethodData.massFlowMeasuredData.areaOfDuct,
         steamReduction.waterMassFlowMethodData.massFlowMeasuredData.airVelocity);
-      MassFlowNameplateData = new Module.SteamMassFlowNameplateData(steamReduction.waterMassFlowMethodData.massFlowNameplateData.flowRate);
-      let WaterMassFlowMethodData = new Module.SteamMassFlowMethodData(steamReduction.waterMassFlowMethodData.isNameplate,
+      MassFlowNameplateData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamMassFlowNameplateData(steamReduction.waterMassFlowMethodData.massFlowNameplateData.flowRate);
+      let WaterMassFlowMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamMassFlowMethodData(steamReduction.waterMassFlowMethodData.isNameplate,
         MassFlowMeasuredData, MassFlowNameplateData,
         steamReduction.waterMassFlowMethodData.inletTemperature, steamReduction.waterMassFlowMethodData.outletTemperature);
 
-      let OtherMethodData = new Module.SteamOffsheetMethodData(steamReduction.otherMethodData.consumption);
+      let OtherMethodData = new this.toolsSuiteApiService.ToolsSuiteModule.SteamOffsheetMethodData(steamReduction.otherMethodData.consumption);
 
       let steamVariableOptionThermodynamicQuantity = this.suiteApiHelperService.getThermodynamicQuantityType(steamReduction.steamVariableOption)
 
-      let wasmConvertedInput = new Module.SteamReductionInput(
+      let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.SteamReductionInput(
         steamReduction.hoursPerYear,
         steamReduction.utilityType,
         steamReduction.utilityCost,
@@ -401,7 +402,7 @@ export class CalculatorSuiteApiService {
       FlowMeterMethodData.delete();
     });
 
-    let SteamReductionCalculator = new Module.SteamReduction(inputs);
+    let SteamReductionCalculator = new this.toolsSuiteApiService.ToolsSuiteModule.SteamReduction(inputs);
     let output = SteamReductionCalculator.calculate();
     let results: SteamReductionResult = {
       energyCost: output.energyCost,
@@ -415,13 +416,13 @@ export class CalculatorSuiteApiService {
   }
 
   pipeInsulationReduction(inputObj: PipeInsulationReductionInput): PipeInsulationReductionResult {
-    let pipeMaterialCoefficients = new Module.DoubleVector();
-    let insulationMaterialCoefficients = new Module.DoubleVector();
+    let pipeMaterialCoefficients = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector();
+    let insulationMaterialCoefficients = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector();
     inputObj.pipeMaterialCoefficients.forEach(coefficient => pipeMaterialCoefficients.push_back(coefficient));
     inputObj.insulationMaterialCoefficients.forEach(coefficient => insulationMaterialCoefficients.push_back(coefficient));
 
     inputObj.systemEfficiency = inputObj.systemEfficiency / 100;
-    let wasmConvertedInput = new Module.InsulatedPipeInput(
+    let wasmConvertedInput = new this.toolsSuiteApiService.ToolsSuiteModule.InsulatedPipeInput(
       inputObj.operatingHours,
       inputObj.pipeLength,
       inputObj.pipeDiameter,
@@ -436,7 +437,7 @@ export class CalculatorSuiteApiService {
       pipeMaterialCoefficients,
       insulationMaterialCoefficients);
 
-    let InsulatedPipeReduction = new Module.InsulatedPipeReduction(wasmConvertedInput);
+    let InsulatedPipeReduction = new this.toolsSuiteApiService.ToolsSuiteModule.InsulatedPipeReduction(wasmConvertedInput);
 
     let rawOutput = InsulatedPipeReduction.calculate();
     let pipeInsulationReductionResult: PipeInsulationReductionResult = {
@@ -453,7 +454,7 @@ export class CalculatorSuiteApiService {
   }
 
   tankInsulationReduction(inputObj: TankInsulationReductionInput): TankInsulationReductionResult {
-    let input = new Module.InsulatedTankInput(
+    let input = new this.toolsSuiteApiService.ToolsSuiteModule.InsulatedTankInput(
       inputObj.operatingHours,
       inputObj.tankHeight,
       inputObj.tankDiameter,
@@ -468,7 +469,7 @@ export class CalculatorSuiteApiService {
       inputObj.jacketEmissivity,
       inputObj.surfaceTemperature
     );
-    let InsulatedTankReduction = new Module.InsulatedTankReduction(input);
+    let InsulatedTankReduction = new this.toolsSuiteApiService.ToolsSuiteModule.InsulatedTankReduction(input);
     let rawOutput = InsulatedTankReduction.calculate();
     let tankInsulationReductionResult: TankInsulationReductionResult = {
       heatLoss: rawOutput.getHeatLoss(),
@@ -487,7 +488,7 @@ export class CalculatorSuiteApiService {
     inputObj.input1 = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputObj.input1);    
     inputObj.input2 = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputObj.input2);
     inputObj.inputPowerFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputObj.inputPowerFactor);
-    let PowerFactor = new Module.PowerFactor();
+    let PowerFactor = new this.toolsSuiteApiService.ToolsSuiteModule.PowerFactor();
     let rawOutput = PowerFactor.calculate(inputObj.mode, inputObj.input1, inputObj.input2, inputObj.inputPowerFactor);
     let powerFactorTriangleOutputs: PowerFactorTriangleOutputs = {
       apparentPower: rawOutput.apparentPower,

--- a/src/app/tools-suite-api/chillers-suite-api.service.ts
+++ b/src/app/tools-suite-api/chillers-suite-api.service.ts
@@ -2,13 +2,14 @@ import { Injectable } from '@angular/core';
 import { ChillerPerformanceInput, ChillerPerformanceOutput, ChillerStagingInput, ChillerStagingOutput, CoolingTowerBasinInput, CoolingTowerBasinOutput, CoolingTowerBasinResult, CoolingTowerFanInput, CoolingTowerFanOutput, CoolingTowerInput, CoolingTowerOutput } from '../shared/models/chillers';
 // import { ChillerPerformanceInput, ChillerPerformanceOutput, ChillerStagingInput, ChillerStagingOutput, CoolingTowerBasinInput, CoolingTowerBasinOutput, CoolingTowerFanInput, CoolingTowerFanOutput, CoolingTowerInput, CoolingTowerOutput } from '../shared/models/chillers';
 import { SuiteApiHelperService } from './suite-api-helper.service';
-
-declare var Module: any;
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
 @Injectable()
 export class ChillersSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   coolingTowerMakeupWater(input: CoolingTowerInput): CoolingTowerOutput {
     input.coolingTowerMakeupWaterCalculator.operatingConditionsData.coolingLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.coolingTowerMakeupWaterCalculator.operatingConditionsData.coolingLoad);
@@ -16,23 +17,23 @@ export class ChillersSuiteApiService {
     input.coolingTowerMakeupWaterCalculator.operatingConditionsData.lossCorrectionFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.coolingTowerMakeupWaterCalculator.operatingConditionsData.lossCorrectionFactor);
     input.coolingTowerMakeupWaterCalculator.operatingConditionsData.operationalHours = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.coolingTowerMakeupWaterCalculator.operatingConditionsData.operationalHours);
 
-    let OperatingConditionsData = new Module.CoolingTowerOperatingConditionsData(
+    let OperatingConditionsData = new this.toolsSuiteApiService.ToolsSuiteModule.CoolingTowerOperatingConditionsData(
       input.coolingTowerMakeupWaterCalculator.operatingConditionsData.flowRate,
       input.coolingTowerMakeupWaterCalculator.operatingConditionsData.coolingLoad,
       input.coolingTowerMakeupWaterCalculator.operatingConditionsData.operationalHours,
       input.coolingTowerMakeupWaterCalculator.operatingConditionsData.lossCorrectionFactor,
     );
     input.coolingTowerMakeupWaterCalculator.waterConservationBaselineData.cyclesOfConcentration = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.coolingTowerMakeupWaterCalculator.waterConservationBaselineData.cyclesOfConcentration);
-    let BaselineWaterConservationData = new Module.CoolingTowerWaterConservationData(
+    let BaselineWaterConservationData = new this.toolsSuiteApiService.ToolsSuiteModule.CoolingTowerWaterConservationData(
       input.coolingTowerMakeupWaterCalculator.waterConservationBaselineData.cyclesOfConcentration,
       input.coolingTowerMakeupWaterCalculator.waterConservationBaselineData.driftLossFactor,
     );
     input.coolingTowerMakeupWaterCalculator.waterConservationModificationData.cyclesOfConcentration = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.coolingTowerMakeupWaterCalculator.waterConservationModificationData.cyclesOfConcentration);
-    let ModificationConservationData = new Module.CoolingTowerWaterConservationData(
+    let ModificationConservationData = new this.toolsSuiteApiService.ToolsSuiteModule.CoolingTowerWaterConservationData(
       input.coolingTowerMakeupWaterCalculator.waterConservationModificationData.cyclesOfConcentration,
       input.coolingTowerMakeupWaterCalculator.waterConservationModificationData.driftLossFactor,
     );
-    let CoolingTowerMakeupWaterInstance = new Module.CoolingTowerMakeupWaterCalculator(
+    let CoolingTowerMakeupWaterInstance = new this.toolsSuiteApiService.ToolsSuiteModule.CoolingTowerMakeupWaterCalculator(
       OperatingConditionsData,
       BaselineWaterConservationData,
       ModificationConservationData
@@ -59,7 +60,7 @@ export class ChillersSuiteApiService {
   }
 
   basinHeaterEnergyConsumption(input: CoolingTowerBasinInput) {
-    let output = Module.BasinHeaterEnergyConsumption(
+    let output = this.toolsSuiteApiService.ToolsSuiteModule.BasinHeaterEnergyConsumption(
       input.ratedCapacity,
       input.ratedTempSetPoint,
       input.ratedTempDryBulb,
@@ -90,7 +91,7 @@ export class ChillersSuiteApiService {
   fanEnergyConsumption(input: CoolingTowerFanInput): CoolingTowerFanOutput {
     let fanSpeedTypeBaseline: number = this.suiteApiHelperService.getCoolingTowerFanControlSpeedType(input.baselineSpeedType)
     let fanSpeedTypeModification: number = this.suiteApiHelperService.getCoolingTowerFanControlSpeedType(input.modSpeedType)
-    let output = Module.FanEnergyConsumption(
+    let output = this.toolsSuiteApiService.ToolsSuiteModule.FanEnergyConsumption(
       input.ratedFanPower, 
       input.waterLeavingTemp,
       input.waterEnteringTemp,
@@ -120,7 +121,7 @@ export class ChillersSuiteApiService {
     let condenserCoolingType: number = this.suiteApiHelperService.getCoolingTowerCondenserCoolingType(input.condenserCoolingType)
     let compressorConfigType: number = this.suiteApiHelperService.getCoolingTowerCompressorConfigType(input.compressorConfigType)
 
-    let output = Module.ChillerCapacityEfficiency(
+    let output = this.toolsSuiteApiService.ToolsSuiteModule.ChillerCapacityEfficiency(
       chillerType, 
       condenserCoolingType, 
       compressorConfigType,
@@ -162,7 +163,7 @@ export class ChillersSuiteApiService {
     let baselineLoadList = this.suiteApiHelperService.returnDoubleVector(input.baselineLoadList);
     let modLoadList = this.suiteApiHelperService.returnDoubleVector(input.modLoadList);
 
-    let rawOutput = Module.ChillerStagingEfficiency(
+    let rawOutput = this.toolsSuiteApiService.ToolsSuiteModule.ChillerStagingEfficiency(
       chillerType, 
       condenserCoolingType, 
       compressorConfigType,

--- a/src/app/tools-suite-api/compressed-air-suite-api.service.ts
+++ b/src/app/tools-suite-api/compressed-air-suite-api.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { CentrifugalInput, CompressorCalcResult, CompressorsCalcInput } from '../compressed-air-assessment/compressed-air-calculation.service';
 import { CompEEM_kWAdjustedInput, CompressedAirPressureReductionInput, CompressedAirPressureReductionResult } from '../shared/models/standalone';
 import { SuiteApiHelperService } from './suite-api-helper.service';
-
-declare var Module: any;
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
 @Injectable()
 export class CompressedAirSuiteApiService {
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
   compressedAirPressureReduction(inputObj: CompressedAirPressureReductionInput): CompressedAirPressureReductionResult {
     if (inputObj.compressedAirPressureReductionInputVec && inputObj.compressedAirPressureReductionInputVec.length > 0) {
       inputObj.compressedAirPressureReductionInputVec[0].compressorPower = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputObj.compressedAirPressureReductionInputVec[0].compressorPower);
@@ -22,7 +23,7 @@ export class CompressedAirSuiteApiService {
         P_alt: inputObj.compressedAirPressureReductionInputVec[0].atmosphericPressure,
         P_atm: 14.7
       }
-      let kW_adjusted: number = Module.kWAdjusted(input.kW_fl_rated, input.P_fl_rated, input.P_discharge, input.P_alt, input.P_atm);
+      let kW_adjusted: number = this.toolsSuiteApiService.ToolsSuiteModule.kWAdjusted(input.kW_fl_rated, input.P_fl_rated, input.P_discharge, input.P_alt, input.P_atm);
       let annualEnergyUsage: number = kW_adjusted * inputObj.compressedAirPressureReductionInputVec[0].hoursPerYear;
       let annualEnergyCost: number = annualEnergyUsage * inputObj.compressedAirPressureReductionInputVec[0].electricityCost;
       return {
@@ -45,36 +46,36 @@ export class CompressedAirSuiteApiService {
     inputData.stageType = this.suiteApiHelperService.getStageEnum(inputData.stageType);
     inputData.computeFrom = this.suiteApiHelperService.getComputeFromEnum(inputData.computeFrom);
 
-    if (inputData.controlType == Module.ControlType.LoadUnload) {
+    if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.LoadUnload) {
       instance = this.compressorsCalcLoadUnload(inputData);
-    } else if (inputData.controlType == Module.ControlType.ModulationWOUnload) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.ModulationWOUnload) {
       instance = this.compressorsCalcModulationWOUnload(inputData);
-    } else if (inputData.controlType == Module.ControlType.ModulationUnload) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.ModulationUnload) {
       instance = this.compressorsCalcModulationWithUnload(inputData);
-    } else if (inputData.controlType == Module.ControlType.VariableDisplacementUnload) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.VariableDisplacementUnload) {
       instance = this.compressorsCalcVariableDisplacement(inputData);
-    } else if (inputData.controlType == Module.ControlType.MultiStepUnloading) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.MultiStepUnloading) {
       instance = this.compressorsCalcMultiStepUnloading(inputData);
-    } else if (inputData.controlType == Module.ControlType.StartStop) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.StartStop) {
       instance = this.compressorsCalcStartStop(inputData);
-    } else if (inputData.controlType == Module.ControlType.VFD) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.VFD) {
       instance = this.compressorsCalcVFD(inputData);
     }
 
     let suiteOutput;
-    if (inputData.computeFrom == Module.ComputeFrom.PercentagePower) {
+    if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentagePower) {
       suiteOutput = instance.calculateFromPerkW(inputData.computeFromVal);
     }
-    else if (inputData.computeFrom == Module.ComputeFrom.PercentageCapacity) {
+    else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentageCapacity) {
       suiteOutput = instance.calculateFromPerC(inputData.computeFromVal);
     }
-    else if (inputData.computeFrom == Module.ComputeFrom.PowerMeasured) {
+    else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerMeasured) {
       suiteOutput = instance.calculateFromkWMeasured(inputData.computeFromVal);
     }
-    else if (inputData.computeFrom == Module.ComputeFrom.CapacityMeasured) {
+    else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.CapacityMeasured) {
       suiteOutput = instance.calculateFromCMeasured(inputData.computeFromVal);
     }
-    else if (inputData.computeFrom == Module.ComputeFrom.PowerFactor) {
+    else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerFactor) {
       suiteOutput = instance.calculateFromVIPFMeasured(inputData.computeFromVal, inputData.computeFromPFVoltage, inputData.computeFromPFAmps);
     }
 
@@ -93,7 +94,7 @@ export class CompressedAirSuiteApiService {
     let powerAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.powerAtFullLoad);
     let capacityAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.capacityAtFullLoad);
     let powerAtNoLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.powerAtNoLoad);
-    return new Module.Compressors_ModulationWOUnload(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_ModulationWOUnload(
       powerAtFullLoad,
       capacityAtFullLoad,
       powerAtNoLoad
@@ -105,7 +106,7 @@ export class CompressedAirSuiteApiService {
     let capacityAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.capacityAtFullLoad);
     let powerMaxPercentage = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.powerMaxPercentage);
     let powerAtFullLoadPercentage = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.powerAtFullLoadPercentage);
-    return new Module.Compressors_StartStop(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_StartStop(
       powerAtFullLoad,
       capacityAtFullLoad,
       powerMaxPercentage,
@@ -121,7 +122,7 @@ export class CompressedAirSuiteApiService {
     let capacityAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.capacityAtFullLoad);
     let midTurndownAirflow = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.midTurndownAirflow);
     let turndownAirflow = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.turndownAirflow);
-    return new Module.Compressor_VFD(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressor_VFD(
       powerAtFullLoad,
       midTurndownPower,
       turndownPower,
@@ -150,7 +151,7 @@ export class CompressedAirSuiteApiService {
     let unloadSumpPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.unloadSumpPressure);
     let noLoadPowerFM = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.noLoadPowerFM);
 
-    return new Module.Compressors_LoadUnload(powerAtFullLoad,
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_LoadUnload(powerAtFullLoad,
       capacityAtFullLoad,
       receiverVolume,
       powerMax,
@@ -189,7 +190,7 @@ export class CompressedAirSuiteApiService {
     let pressureAtUnload = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.pressureAtUnload);
     let capacityAtUnload = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.capacityAtUnload);
 
-    return new Module.Compressors_ModulationWithUnload(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_ModulationWithUnload(
       powerAtFullLoad,
       capacityAtFullLoad,
       receiverVolume,
@@ -226,7 +227,7 @@ export class CompressedAirSuiteApiService {
     let unloadSumpPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.unloadSumpPressure)
     let noLoadPowerFM = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.noLoadPowerFM)
 
-    return new Module.Compressors_ModulationWithUnload(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_ModulationWithUnload(
       powerAtFullLoad,
       capacityAtFullLoad,
       receiverVolume,
@@ -265,7 +266,7 @@ export class CompressedAirSuiteApiService {
     let blowdownTime = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.blowdownTime);
     let unloadSumpPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.unloadSumpPressure);
     let noLoadPowerFM = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.noLoadPowerFM);
-    return new Module.Compressors_LoadUnload(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_LoadUnload(
       powerAtFullLoad,
       capacityAtFullLoad,
       receiverVolume,
@@ -294,48 +295,48 @@ export class CompressedAirSuiteApiService {
     inputData.computeFrom = this.suiteApiHelperService.getComputeFromEnum(inputData.computeFrom);
 
     let instance;
-    if (inputData.controlType == Module.ControlType.LoadUnload) {
+    if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.LoadUnload) {
       instance = this.compressorsCalcCentrifugalLoadUnload(inputData)
     }
-    else if (inputData.controlType == Module.ControlType.ModulationUnload) {
+    else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.ModulationUnload) {
       instance = this.compressorsCalcCentrifugalModulationUnload(inputData);
-    } else if (inputData.controlType == Module.ControlType.BlowOff) {
+    } else if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.BlowOff) {
       instance = this.compressorsCalcCentrifugalBlowoff(inputData);
     }
 
     //TODO: Blowoff results added
     let suiteOutput;
-    if (inputData.controlType == Module.ControlType.BlowOff) {
-      if (inputData.computeFrom == Module.ComputeFrom.PercentagePower) {
+    if (inputData.controlType == this.toolsSuiteApiService.ToolsSuiteModule.ControlType.BlowOff) {
+      if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentagePower) {
         suiteOutput = instance.calculateFromPerkW_BlowOff(inputData.computeFromVal, inputData.percentageBlowOff);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.PercentageCapacity) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentageCapacity) {
         suiteOutput = instance.calculateFromPerC_BlowOff(inputData.computeFromVal);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.PowerMeasured) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerMeasured) {
         suiteOutput = instance.calculateFromkWMeasured_BlowOff(inputData.computeFromVal, inputData.percentageBlowOff);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.CapacityMeasured) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.CapacityMeasured) {
         suiteOutput = instance.calculateFromCMeasured_BlowOff(inputData.computeFromVal);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.PowerFactor) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerFactor) {
         suiteOutput = instance.calculateFromVIPFMeasured_BlowOff(inputData.computeFromVal, inputData.computeFromPFVoltage, inputData.computeFromPFAmps, inputData.percentageBlowOff);
       }
     }
     else {
-      if (inputData.computeFrom == Module.ComputeFrom.PercentagePower) {
+      if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentagePower) {
         suiteOutput = instance.calculateFromPerkW(inputData.computeFromVal);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.PercentageCapacity) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentageCapacity) {
         suiteOutput = instance.calculateFromPerC(inputData.computeFromVal);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.PowerMeasured) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerMeasured) {
         suiteOutput = instance.calculateFromkWMeasured(inputData.computeFromVal);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.CapacityMeasured) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.CapacityMeasured) {
         suiteOutput = instance.calculateFromCMeasured(inputData.computeFromVal);
       }
-      else if (inputData.computeFrom == Module.ComputeFrom.PowerFactor) {
+      else if (inputData.computeFrom == this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerFactor) {
         suiteOutput = instance.calculateFromVIPFMeasured(inputData.computeFromVal, inputData.computeFromPFVoltage, inputData.computeFromPFAmps);
       }
     }
@@ -356,7 +357,7 @@ export class CompressedAirSuiteApiService {
     let powerAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.powerAtFullLoad);
     let capacityAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.capacityAtFullLoad);
     let powerAtNoLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.powerAtNoLoad);
-    return new Module.Compressors_Centrifugal_LoadUnload(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_Centrifugal_LoadUnload(
       powerAtFullLoad,
       capacityAtFullLoad,
       powerAtNoLoad
@@ -370,7 +371,7 @@ export class CompressedAirSuiteApiService {
     let capacityAtMaxFullFlow = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.capacityAtMaxFullFlow)
     let powerAtUnload = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.powerAtUnload)
     let capacityAtUnload = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.capacityAtUnload)
-    return new Module.Compressors_Centrifugal_ModulationUnload(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_Centrifugal_ModulationUnload(
       powerAtFullLoad,
       capacityAtFullLoad,
       powerAtNoLoad,
@@ -385,7 +386,7 @@ export class CompressedAirSuiteApiService {
     let capacityAtFullLoad = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.capacityAtFullLoad)
     let powerAtBlowOff = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.powerAtBlowOff)
     let surgeFlow = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.surgeFlow)
-    return new Module.Compressors_Centrifugal_BlowOff(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.Compressors_Centrifugal_BlowOff(
       powerAtFullLoad,
       capacityAtFullLoad,
       powerAtBlowOff,

--- a/src/app/tools-suite-api/fans-suite-api.service.ts
+++ b/src/app/tools-suite-api/fans-suite-api.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { FanEfficiencyInputs } from '../calculator/fans/fan-efficiency/fan-efficiency.service';
 import { BaseGasDensity, CompressibilityFactor, Fan203Inputs, Fan203Results, FsatInput, FsatOutput, Plane, PlaneResult, PlaneResults, PsychrometricResults } from '../shared/models/fans';
 import { SuiteApiHelperService } from './suite-api-helper.service';
-
-declare var Module: any;
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 @Injectable()
 export class FansSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   //results
   calculateExisting(input: FsatInput): FsatOutput {
@@ -19,10 +20,10 @@ export class FansSuiteApiService {
     //convert from percent to fraction
     let specifiedDriveEfficiencyFraction: number = input.specifiedDriveEfficiency / 100;
     input.compressibilityFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.compressibilityFactor);
-    let fanInput = new Module.FanInput(input.fanSpeed, input.airDensity, driveEnum, specifiedDriveEfficiencyFraction);
-    let motor = new Module.Motor(lineFrequencyEnum, input.motorRatedPower, input.motorRpm, efficiencyClassEnum, input.specifiedEfficiency, input.motorRatedVoltage, input.fullLoadAmps, input.sizeMargin);
-    let baselineFieldData = new Module.FieldDataBaseline(input.measuredPower, input.measuredVoltage, input.measuredAmps, input.flowRate, input.inletPressure, input.outletPressure, input.compressibilityFactor, loadEstimationMethodEnum, input.velocityPressure);
-    let fanResult = new Module.FanResult(fanInput, motor, input.operatingHours, input.unitCost);
+    let fanInput = new this.toolsSuiteApiService.ToolsSuiteModule.FanInput(input.fanSpeed, input.airDensity, driveEnum, specifiedDriveEfficiencyFraction);
+    let motor = new this.toolsSuiteApiService.ToolsSuiteModule.Motor(lineFrequencyEnum, input.motorRatedPower, input.motorRpm, efficiencyClassEnum, input.specifiedEfficiency, input.motorRatedVoltage, input.fullLoadAmps, input.sizeMargin);
+    let baselineFieldData = new this.toolsSuiteApiService.ToolsSuiteModule.FieldDataBaseline(input.measuredPower, input.measuredVoltage, input.measuredAmps, input.flowRate, input.inletPressure, input.outletPressure, input.compressibilityFactor, loadEstimationMethodEnum, input.velocityPressure);
+    let fanResult = new this.toolsSuiteApiService.ToolsSuiteModule.FanResult(fanInput, motor, input.operatingHours, input.unitCost);
     let output = fanResult.calculateExisting(baselineFieldData);
     let results: FsatOutput = {
       fanEfficiency: output.fanEfficiency,
@@ -66,12 +67,12 @@ export class FansSuiteApiService {
     let specifiedDriveEfficiencyFraction: number = input.specifiedDriveEfficiency / 100;
     let fanEfficiencyFraction: number = input.fanEfficiency / 100;
 
-    let fanInput = new Module.FanInput(input.fanSpeed, input.airDensity, driveEnum, specifiedDriveEfficiencyFraction);
+    let fanInput = new this.toolsSuiteApiService.ToolsSuiteModule.FanInput(input.fanSpeed, input.airDensity, driveEnum, specifiedDriveEfficiencyFraction);
     // No default on new modification
     input.compressibilityFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.compressibilityFactor);
-    let fanFieldData = new Module.FieldDataModified(input.measuredVoltage, input.measuredAmps, input.flowRate, input.inletPressure, input.outletPressure, input.compressibilityFactor, input.velocityPressure);
-    let motor = new Module.Motor(lineFrequencyEnum, input.motorRatedPower, input.motorRpm, efficiencyClassEnum, input.specifiedEfficiency, input.motorRatedVoltage, input.fullLoadAmps, input.sizeMargin);
-    let fanResult = new Module.FanResult(fanInput, motor, input.operatingHours, input.unitCost);
+    let fanFieldData = new this.toolsSuiteApiService.ToolsSuiteModule.FieldDataModified(input.measuredVoltage, input.measuredAmps, input.flowRate, input.inletPressure, input.outletPressure, input.compressibilityFactor, input.velocityPressure);
+    let motor = new this.toolsSuiteApiService.ToolsSuiteModule.Motor(lineFrequencyEnum, input.motorRatedPower, input.motorRpm, efficiencyClassEnum, input.specifiedEfficiency, input.motorRatedVoltage, input.fullLoadAmps, input.sizeMargin);
+    let fanResult = new this.toolsSuiteApiService.ToolsSuiteModule.FanResult(fanInput, motor, input.operatingHours, input.unitCost);
     let output = fanResult.calculateModified(fanFieldData, fanEfficiencyFraction);
     let results: FsatOutput = {
       fanEfficiency: output.fanEfficiency,
@@ -122,7 +123,7 @@ export class FansSuiteApiService {
     let inputType = this.suiteApiHelperService.getBasGensityInputTypeEnum(inputs.inputType);
     let result: PsychrometricResults;
     if (inputs.dryBulbTemp != undefined && inputs.staticPressure != undefined && inputs.barometricPressure != undefined && inputs.dewPoint != undefined && gasType != undefined && inputType != undefined && inputs.specificGravity != undefined) {
-      let dewPointInstance = new Module.BaseGasDensity(inputs.dryBulbTemp, inputs.staticPressure, inputs.barometricPressure, inputs.dewPoint, gasType, inputType, inputs.specificGravity);
+      let dewPointInstance = new this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensity(inputs.dryBulbTemp, inputs.staticPressure, inputs.barometricPressure, inputs.dewPoint, gasType, inputType, inputs.specificGravity);
       result = this.getGasDensityPsychometricResults(dewPointInstance);
       dewPointInstance.delete();
     }
@@ -134,7 +135,7 @@ export class FansSuiteApiService {
     let inputType = this.suiteApiHelperService.getBasGensityInputTypeEnum(inputs.inputType);
     let result: PsychrometricResults;
     if (inputs.dryBulbTemp != undefined && inputs.staticPressure != undefined && inputs.barometricPressure != undefined && inputs.relativeHumidity != undefined && gasType != undefined && inputType != undefined && inputs.specificGravity != undefined) {
-      let relativeHumidityInstance = new Module.BaseGasDensity(inputs.dryBulbTemp, inputs.staticPressure, inputs.barometricPressure, inputs.relativeHumidity, gasType, inputType, inputs.specificGravity);
+      let relativeHumidityInstance = new this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensity(inputs.dryBulbTemp, inputs.staticPressure, inputs.barometricPressure, inputs.relativeHumidity, gasType, inputType, inputs.specificGravity);
       result = this.getGasDensityPsychometricResults(relativeHumidityInstance);
       relativeHumidityInstance.delete();
     }
@@ -146,7 +147,7 @@ export class FansSuiteApiService {
     let inputType = this.suiteApiHelperService.getBasGensityInputTypeEnum(inputs.inputType);
     let result: PsychrometricResults;
     if (inputs.dryBulbTemp != undefined && inputs.staticPressure != undefined && inputs.barometricPressure != undefined && inputs.wetBulbTemp != undefined && gasType != undefined && inputType != undefined && inputs.specificGravity != undefined && inputs.specificHeatGas != undefined) {
-      let wetBulbInstance = new Module.BaseGasDensity(inputs.dryBulbTemp, inputs.staticPressure, inputs.barometricPressure, inputs.wetBulbTemp, gasType, inputType, inputs.specificGravity, inputs.specificHeatGas);
+      let wetBulbInstance = new this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensity(inputs.dryBulbTemp, inputs.staticPressure, inputs.barometricPressure, inputs.wetBulbTemp, gasType, inputType, inputs.specificGravity, inputs.specificHeatGas);
       result = this.getGasDensityPsychometricResults(wetBulbInstance);
       wetBulbInstance.delete();
     }
@@ -173,7 +174,7 @@ export class FansSuiteApiService {
 
 
   getVelocityPressureData(inputs: Plane): { pv3: number, percent75Rule: number } {
-    let traversePlaneTraverseData = new Module.DoubleVector2D();
+    let traversePlaneTraverseData = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector2D();
     let doubleVector;
 
     let traverseData: Array<Array<number>> = inputs.traverseData.map(row => {
@@ -184,7 +185,7 @@ export class FansSuiteApiService {
       traversePlaneTraverseData.push_back(doubleVector);
       doubleVector.delete();
     });
-    let traversePlaneInstance = new Module.TraversePlane(inputs.area, inputs.dryBulbTemp, inputs.barometricPressure, inputs.staticPressure, inputs.pitotTubeCoefficient, traversePlaneTraverseData);
+    let traversePlaneInstance = new this.toolsSuiteApiService.ToolsSuiteModule.TraversePlane(inputs.area, inputs.dryBulbTemp, inputs.barometricPressure, inputs.staticPressure, inputs.pitotTubeCoefficient, traversePlaneTraverseData);
 
     let pv3 = traversePlaneInstance.getPv3Value();
     let percent75Rule = traversePlaneInstance.get75percentRule() * 100; // Convert to percentage
@@ -205,14 +206,14 @@ export class FansSuiteApiService {
     let barometricPressure = input.BaseGasDensity.barometricPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.BaseGasDensity.barometricPressure); 
     let gasDensity = input.BaseGasDensity.gasDensity = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.BaseGasDensity.gasDensity); 
     
-    let baseGasDensityInstance = new Module.BaseGasDensity(
+    let baseGasDensityInstance = new this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensity(
       dryBulbTemp, 
       staticPressure, 
       barometricPressure, 
       gasDensity, 
       gasType
     );
-    let output = Module.PlaneDataNodeBindingCalculate(planeDataInstance, baseGasDensityInstance);
+    let output = this.toolsSuiteApiService.ToolsSuiteModule.PlaneDataNodeBindingCalculate(planeDataInstance, baseGasDensityInstance);
     let AddlTraversePlanes: Array<PlaneResult> = new Array();
     for (let i = 0; i < output.addlTravPlanes.size(); i++) { // error: length = 0, was .size
       let traversPlane = output.addlTravPlanes.get(i)
@@ -284,16 +285,16 @@ export class FansSuiteApiService {
 
   fan203(input: Fan203Inputs): Fan203Results {
     //FanRatedInfo
-    let fanRatedInfoInstance = new Module.FanRatedInfo(input.FanRatedInfo.fanSpeed, input.FanRatedInfo.motorSpeed, input.FanRatedInfo.fanSpeedCorrected, input.FanRatedInfo.densityCorrected, input.FanRatedInfo.pressureBarometricCorrected);
+    let fanRatedInfoInstance = new this.toolsSuiteApiService.ToolsSuiteModule.FanRatedInfo(input.FanRatedInfo.fanSpeed, input.FanRatedInfo.motorSpeed, input.FanRatedInfo.fanSpeedCorrected, input.FanRatedInfo.densityCorrected, input.FanRatedInfo.pressureBarometricCorrected);
     //BaseGasDensity
     let gasType = this.suiteApiHelperService.getGasTypeEnum(input.BaseGasDensity.gasType);
-    let baseGasDensityInstance = new Module.BaseGasDensity(input.BaseGasDensity.dryBulbTemp, input.BaseGasDensity.staticPressure, input.BaseGasDensity.barometricPressure, input.BaseGasDensity.gasDensity, gasType);
+    let baseGasDensityInstance = new this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensity(input.BaseGasDensity.dryBulbTemp, input.BaseGasDensity.staticPressure, input.BaseGasDensity.barometricPressure, input.BaseGasDensity.gasDensity, gasType);
     //FanShaftPower
-    let fanShaftPowerInstance = new Module.FanShaftPower(input.FanShaftPower.motorShaftPower, input.FanShaftPower.efficiencyMotor, input.FanShaftPower.efficiencyVFD, input.FanShaftPower.efficiencyBelt, input.FanShaftPower.sumSEF);
+    let fanShaftPowerInstance = new this.toolsSuiteApiService.ToolsSuiteModule.FanShaftPower(input.FanShaftPower.motorShaftPower, input.FanShaftPower.efficiencyMotor, input.FanShaftPower.efficiencyVFD, input.FanShaftPower.efficiencyBelt, input.FanShaftPower.sumSEF);
     //plane data instance
     let planeDataInstance = this.getPlaneDataInstance(input);
     //Calculation procedure
-    let fan203Instance = new Module.Fan203(fanRatedInfoInstance, planeDataInstance, baseGasDensityInstance, fanShaftPowerInstance);
+    let fan203Instance = new this.toolsSuiteApiService.ToolsSuiteModule.Fan203(fanRatedInfoInstance, planeDataInstance, baseGasDensityInstance, fanShaftPowerInstance);
     let fan203Output = fan203Instance.calculate();
     let results: Fan203Results = {
       fanEfficiencyTotalPressure: fan203Output.fanEfficiencyTotalPressure,
@@ -324,13 +325,13 @@ export class FansSuiteApiService {
   getPlaneDataInstance(input: Fan203Inputs) {
     //FlangePlane
     //FanInletFlange
-    let flangePlaneInstance = new Module.FlangePlane(input.PlaneData.FanInletFlange.area, input.PlaneData.FanInletFlange.dryBulbTemp, input.PlaneData.FanInletFlange.barometricPressure);
+    let flangePlaneInstance = new this.toolsSuiteApiService.ToolsSuiteModule.FlangePlane(input.PlaneData.FanInletFlange.area, input.PlaneData.FanInletFlange.dryBulbTemp, input.PlaneData.FanInletFlange.barometricPressure);
     //FanEvaseOrOutletFlange
-    let flangePlaneInstance2 = new Module.FlangePlane(input.PlaneData.FanEvaseOrOutletFlange.area, input.PlaneData.FanEvaseOrOutletFlange.dryBulbTemp, input.PlaneData.FanEvaseOrOutletFlange.barometricPressure);
+    let flangePlaneInstance2 = new this.toolsSuiteApiService.ToolsSuiteModule.FlangePlane(input.PlaneData.FanEvaseOrOutletFlange.area, input.PlaneData.FanEvaseOrOutletFlange.dryBulbTemp, input.PlaneData.FanEvaseOrOutletFlange.barometricPressure);
 
     //TraversePlane
     //FlowTraverse
-    let traversePlaneTraverseData = new Module.DoubleVector2D();
+    let traversePlaneTraverseData = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector2D();
     let doubleVector;
 
     let traverseData: Array<Array<number>> = input.PlaneData.FlowTraverse.traverseData.map(row => {
@@ -341,15 +342,15 @@ export class FansSuiteApiService {
       traversePlaneTraverseData.push_back(doubleVector);
       doubleVector.delete();
     });
-    let traversePlaneInstance = new Module.TraversePlane(input.PlaneData.FlowTraverse.area, input.PlaneData.FlowTraverse.dryBulbTemp, input.PlaneData.FlowTraverse.barometricPressure, input.PlaneData.FlowTraverse.staticPressure, input.PlaneData.FlowTraverse.pitotTubeCoefficient, traversePlaneTraverseData);
+    let traversePlaneInstance = new this.toolsSuiteApiService.ToolsSuiteModule.TraversePlane(input.PlaneData.FlowTraverse.area, input.PlaneData.FlowTraverse.dryBulbTemp, input.PlaneData.FlowTraverse.barometricPressure, input.PlaneData.FlowTraverse.staticPressure, input.PlaneData.FlowTraverse.pitotTubeCoefficient, traversePlaneTraverseData);
     // Release memory
     traversePlaneTraverseData.delete();
 
     //AddlTraversePlanes
     //traverse_plane_vector
-    let addlTraversePlanes = new Module.TraversePlaneVector();
+    let addlTraversePlanes = new this.toolsSuiteApiService.ToolsSuiteModule.TraversePlaneVector();
     if (input.FanRatedInfo.traversePlanes > 1) {
-      traversePlaneTraverseData = new Module.DoubleVector2D();
+      traversePlaneTraverseData = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector2D();
       let traversePlane: Plane = input.PlaneData.AddlTraversePlanes[0];
 
       let doubleVector;
@@ -358,7 +359,7 @@ export class FansSuiteApiService {
         traversePlaneTraverseData.push_back(doubleVector);
         doubleVector.delete();
       });
-      let traversePlaneInstance2 = new Module.TraversePlane(traversePlane.area, traversePlane.dryBulbTemp, traversePlane.barometricPressure, traversePlane.staticPressure, traversePlane.pitotTubeCoefficient, traversePlaneTraverseData);
+      let traversePlaneInstance2 = new this.toolsSuiteApiService.ToolsSuiteModule.TraversePlane(traversePlane.area, traversePlane.dryBulbTemp, traversePlane.barometricPressure, traversePlane.staticPressure, traversePlane.pitotTubeCoefficient, traversePlaneTraverseData);
       addlTraversePlanes.push_back(traversePlaneInstance2);
       traversePlaneInstance2.delete();
       traversePlaneTraverseData.delete();
@@ -366,7 +367,7 @@ export class FansSuiteApiService {
 
     //addlTraversePlane2
     if (input.FanRatedInfo.traversePlanes == 3) {
-      traversePlaneTraverseData = new Module.DoubleVector2D();
+      traversePlaneTraverseData = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector2D();
       let traversePlane: Plane = input.PlaneData.AddlTraversePlanes[1];
       let doubleVector;
       traversePlane.traverseData.forEach(dataRow => {
@@ -374,7 +375,7 @@ export class FansSuiteApiService {
         traversePlaneTraverseData.push_back(doubleVector);
         doubleVector.delete();
       });
-      let traversePlaneInstance3 = new Module.TraversePlane(traversePlane.area, traversePlane.dryBulbTemp, traversePlane.barometricPressure, traversePlane.staticPressure, traversePlane.pitotTubeCoefficient, traversePlaneTraverseData);
+      let traversePlaneInstance3 = new this.toolsSuiteApiService.ToolsSuiteModule.TraversePlane(traversePlane.area, traversePlane.dryBulbTemp, traversePlane.barometricPressure, traversePlane.staticPressure, traversePlane.pitotTubeCoefficient, traversePlaneTraverseData);
       addlTraversePlanes.push_back(traversePlaneInstance3);
       traversePlaneInstance3.delete();
       // Release memory
@@ -383,16 +384,16 @@ export class FansSuiteApiService {
 
     //MstPlane
     //InletMstPlane
-    let mstPlaneInstance = new Module.MstPlane(input.PlaneData.InletMstPlane.area, input.PlaneData.InletMstPlane.dryBulbTemp, input.PlaneData.InletMstPlane.barometricPressure, input.PlaneData.InletMstPlane.staticPressure);
+    let mstPlaneInstance = new this.toolsSuiteApiService.ToolsSuiteModule.MstPlane(input.PlaneData.InletMstPlane.area, input.PlaneData.InletMstPlane.dryBulbTemp, input.PlaneData.InletMstPlane.barometricPressure, input.PlaneData.InletMstPlane.staticPressure);
 
     //OutletMstPlane
-    let mstPlaneInstance2 = new Module.MstPlane(input.PlaneData.OutletMstPlane.area, input.PlaneData.OutletMstPlane.dryBulbTemp, input.PlaneData.OutletMstPlane.barometricPressure, input.PlaneData.OutletMstPlane.staticPressure);
+    let mstPlaneInstance2 = new this.toolsSuiteApiService.ToolsSuiteModule.MstPlane(input.PlaneData.OutletMstPlane.area, input.PlaneData.OutletMstPlane.dryBulbTemp, input.PlaneData.OutletMstPlane.barometricPressure, input.PlaneData.OutletMstPlane.staticPressure);
 
     //getPlaneData()
     let totalPressureLossBtwnPlanes1and4 = input.PlaneData.totalPressureLossBtwnPlanes1and4;
     let totalPressureLossBtwnPlanes2and5 = input.PlaneData.totalPressureLossBtwnPlanes2and5;
     let plane5upstreamOfPlane2 = input.PlaneData.plane5upstreamOfPlane2;
-    let planeDataInstance = new Module.PlaneData(flangePlaneInstance, flangePlaneInstance2, traversePlaneInstance, addlTraversePlanes, mstPlaneInstance, mstPlaneInstance2, totalPressureLossBtwnPlanes1and4, totalPressureLossBtwnPlanes2and5, plane5upstreamOfPlane2);
+    let planeDataInstance = new this.toolsSuiteApiService.ToolsSuiteModule.PlaneData(flangePlaneInstance, flangePlaneInstance2, traversePlaneInstance, addlTraversePlanes, mstPlaneInstance, mstPlaneInstance2, totalPressureLossBtwnPlanes1and4, totalPressureLossBtwnPlanes2and5, plane5upstreamOfPlane2);
 
     // Release memory
     flangePlaneInstance.delete();
@@ -408,7 +409,7 @@ export class FansSuiteApiService {
     let fanType = this.suiteApiHelperService.getFanTypeEnum(inputs.fanType);
     // No default on new modification
     inputs.compressibility = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputs.compressibility);
-    let optimalEfficiencyFactor = new Module.OptimalFanEfficiency(fanType, inputs.fanSpeed, inputs.flowRate, inputs.inletPressure, inputs.outletPressure, inputs.compressibility);
+    let optimalEfficiencyFactor = new this.toolsSuiteApiService.ToolsSuiteModule.OptimalFanEfficiency(fanType, inputs.fanSpeed, inputs.flowRate, inputs.inletPressure, inputs.outletPressure, inputs.compressibility);
     let optimalEfficiencyFactorResult = optimalEfficiencyFactor.calculate();
     let result = optimalEfficiencyFactorResult * 100;
     optimalEfficiencyFactor.delete();
@@ -423,7 +424,7 @@ export class FansSuiteApiService {
     inputs.specificHeatRatio = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputs.specificHeatRatio);
     inputs.barometricPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputs.barometricPressure);
     
-    let compressibilityFactor = new Module.CompressibilityFactor(inputs.moverShaftPower, inputs.inletPressure, inputs.outletPressure, inputs.barometricPressure, inputs.flowRate, inputs.specificHeatRatio);
+    let compressibilityFactor = new this.toolsSuiteApiService.ToolsSuiteModule.CompressibilityFactor(inputs.moverShaftPower, inputs.inletPressure, inputs.outletPressure, inputs.barometricPressure, inputs.flowRate, inputs.specificHeatRatio);
     let compressibilityFactorResult = compressibilityFactor.calculate();
     compressibilityFactor.delete();
     return compressibilityFactorResult;

--- a/src/app/tools-suite-api/motor-data-api.service.ts
+++ b/src/app/tools-suite-api/motor-data-api.service.ts
@@ -1,18 +1,19 @@
 import { Injectable } from '@angular/core';
 import { SuiteDbMotor } from '../shared/models/materials';
 import { SuiteApiHelperService } from './suite-api-helper.service';
-declare var Module: any;
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class MotorDataApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
   ) { }
 
   getMotors(): Array<SuiteDbMotor> {
-    let DefaultData = new Module.DefaultData();
+    let DefaultData = new this.toolsSuiteApiService.ToolsSuiteModule.DefaultData();
     let suiteDefaultMaterials = DefaultData.getMotorData();
 
     let defaultMotors: Array<SuiteDbMotor> = [];

--- a/src/app/tools-suite-api/process-heating-api.service.ts
+++ b/src/app/tools-suite-api/process-heating-api.service.ts
@@ -9,7 +9,6 @@ import { AuxiliaryPowerLoss } from '../shared/models/phast/losses/auxiliaryPower
 import { GasChargeMaterial, LiquidChargeMaterial, SolidChargeMaterial } from '../shared/models/phast/losses/chargeMaterial';
 import { GasCoolingLoss, LiquidCoolingLoss } from '../shared/models/phast/losses/coolingLoss';
 import { EnergyInputEAF } from '../shared/models/phast/losses/energyInputEAF';
-import { EnergyInputExhaustGasLoss } from '../shared/models/phast/losses/energyInputExhaustGasLosses';
 import { ExhaustGasEAF } from '../shared/models/phast/losses/exhaustGasEAF';
 import { FixtureLoss } from '../shared/models/phast/losses/fixtureLoss';
 import { FlueGasByMass, FlueGasByVolume, FlueGasByVolumeSuiteResults, MaterialInputProperties } from '../shared/models/phast/losses/flueGas';

--- a/src/app/tools-suite-api/process-heating-api.service.ts
+++ b/src/app/tools-suite-api/process-heating-api.service.ts
@@ -23,12 +23,14 @@ import { CondensingEconomizerOutput, CondensingEconomizerSuiteInput } from '../s
 import { FeedwaterEconomizerOutput, FeedwaterEconomizerSuiteInput } from '../shared/models/steam/feedwaterEconomizer';
 import { WaterHeatingInput, WaterHeatingOutput } from '../shared/models/steam/waterHeating';
 import { SuiteApiHelperService } from './suite-api-helper.service';
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
-declare var Module: any;
 @Injectable()
 export class ProcessHeatingApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   atmosphere(input: AtmosphereLoss): number {
     input.inletTemperature = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.inletTemperature);
@@ -37,7 +39,7 @@ export class ProcessHeatingApiService {
     input.correctionFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.correctionFactor);
     input.specificHeat = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.specificHeat);
 
-    let AtmosphereInstance = new Module.Atmosphere(input.inletTemperature, input.outletTemperature, input.flowRate, input.correctionFactor, input.specificHeat);
+    let AtmosphereInstance = new this.toolsSuiteApiService.ToolsSuiteModule.Atmosphere(input.inletTemperature, input.outletTemperature, input.flowRate, input.correctionFactor, input.specificHeat);
     let output = AtmosphereInstance.getTotalHeat();
     AtmosphereInstance.delete();
     return output;
@@ -51,14 +53,14 @@ export class ProcessHeatingApiService {
     input.finalTemperature = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.finalTemperature);
     input.correctionFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.correctionFactor);
 
-    let FixtureInstance = new Module.FixtureLosses(input.specificHeat, input.feedRate, input.initialTemperature, input.finalTemperature, input.correctionFactor);
+    let FixtureInstance = new this.toolsSuiteApiService.ToolsSuiteModule.FixtureLosses(input.specificHeat, input.feedRate, input.initialTemperature, input.finalTemperature, input.correctionFactor);
     let output = FixtureInstance.getHeatLoss();
     FixtureInstance.delete();
     return output;
   }
 
   gasCoolingLosses(input: GasCoolingLoss): number {
-    let CoolingInstance = new Module.GasCoolingLosses(
+    let CoolingInstance = new this.toolsSuiteApiService.ToolsSuiteModule.GasCoolingLosses(
       input.flowRate, input.initialTemperature,
       input.finalTemperature, input.specificHeat,
       input.correctionFactor, input.gasDensity
@@ -69,7 +71,7 @@ export class ProcessHeatingApiService {
   }
 
   liquidCoolingLosses(input: LiquidCoolingLoss): number {
-    let LiquidCoolingInstance = new Module.LiquidCoolingLosses(
+    let LiquidCoolingInstance = new this.toolsSuiteApiService.ToolsSuiteModule.LiquidCoolingLosses(
       input.flowRate, input.density,
       input.initialTemperature, input.outletTemperature,
       input.specificHeat, input.correctionFactor,
@@ -81,7 +83,7 @@ export class ProcessHeatingApiService {
 
   gasLoadChargeMaterial(input: GasChargeMaterial): number {
     let thermicReactionType = this.suiteApiHelperService.getMaterialThermicReactionType(input.thermicReactionType);
-    let GasChargeMaterialInstance = new Module.GasLoadChargeMaterial(
+    let GasChargeMaterialInstance = new this.toolsSuiteApiService.ToolsSuiteModule.GasLoadChargeMaterial(
       thermicReactionType,
       input.specificHeatGas,
       input.feedRate,
@@ -100,7 +102,7 @@ export class ProcessHeatingApiService {
 
   liquidLoadChargeMaterial(input: LiquidChargeMaterial): number {
     let thermicReactionType = this.suiteApiHelperService.getMaterialThermicReactionType(input.thermicReactionType);
-    let LiquidChargeMaterialInstance = new Module.LiquidLoadChargeMaterial(
+    let LiquidChargeMaterialInstance = new this.toolsSuiteApiService.ToolsSuiteModule.LiquidLoadChargeMaterial(
       thermicReactionType,
       input.specificHeatLiquid,
       input.vaporizingTemperature,
@@ -121,7 +123,7 @@ export class ProcessHeatingApiService {
 
   solidLoadChargeMaterial(input: SolidChargeMaterial): number {
     let thermicReactionType = this.suiteApiHelperService.getMaterialThermicReactionType(input.thermicReactionType);
-    let SolidChargeMaterialInstance = new Module.SolidLoadChargeMaterial(
+    let SolidChargeMaterialInstance = new this.toolsSuiteApiService.ToolsSuiteModule.SolidLoadChargeMaterial(
       thermicReactionType,
       input.specificHeatSolid,
       input.latentHeat,
@@ -144,7 +146,7 @@ export class ProcessHeatingApiService {
   }
 
   viewFactorCalculation(input: ViewFactorInput): number {
-    let OpeningLossesInstance = new Module.OpeningLosses();
+    let OpeningLossesInstance = new this.toolsSuiteApiService.ToolsSuiteModule.OpeningLosses();
     let output;
 
     if (input.openingShape == 0) {
@@ -163,7 +165,7 @@ export class ProcessHeatingApiService {
   }
 
   openingLossesQuad(input: QuadOpeningLoss): number {
-    let OpeningLossesQuadInstance = new Module.OpeningLosses(
+    let OpeningLossesQuadInstance = new this.toolsSuiteApiService.ToolsSuiteModule.OpeningLosses(
       input.emissivity, input.length,
       input.width, input.thickness, input.ratio, input.ambientTemperature,
       input.insideTemperature, input.percentTimeOpen, input.viewFactor);
@@ -174,7 +176,7 @@ export class ProcessHeatingApiService {
   }
 
   openingLossesCircular(input: CircularOpeningLoss): number {
-    let OpeningLossesCircularInstance = new Module.OpeningLosses(
+    let OpeningLossesCircularInstance = new this.toolsSuiteApiService.ToolsSuiteModule.OpeningLosses(
       input.emissivity, input.diameter,
       input.thickness, input.ratio, input.ambientTemperature,
       input.insideTemperature, input.percentTimeOpen, input.viewFactor);
@@ -194,7 +196,7 @@ export class ProcessHeatingApiService {
     input.conditionFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.conditionFactor);
     input.correctionFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.correctionFactor);
 
-    let WallLossesInstance = new Module.WallLosses(
+    let WallLossesInstance = new this.toolsSuiteApiService.ToolsSuiteModule.WallLosses(
       input.surfaceArea, input.ambientTemperature, input.surfaceTemperature,
       input.windVelocity, input.surfaceEmissivity, input.conditionFactor,
       input.correctionFactor
@@ -214,7 +216,7 @@ export class ProcessHeatingApiService {
     input.specificGravity = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.specificGravity);
     input.correctionFactor = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.correctionFactor);
 
-    let LeakageLossesInstance = new Module.LeakageLosses(
+    let LeakageLossesInstance = new this.toolsSuiteApiService.ToolsSuiteModule.LeakageLosses(
       input.draftPressure, input.openingArea, input.leakageGasTemperature,
       input.ambientTemperature, input.coefficient,
       input.specificGravity, input.correctionFactor
@@ -225,7 +227,7 @@ export class ProcessHeatingApiService {
   }
 
   flueGasLossesByVolume(input: FlueGasByVolume): FlueGasByVolumeSuiteResults {
-    let GasCompositionsInstance = new Module.GasCompositions(
+    let GasCompositionsInstance = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       "",
       input.CH4,
       input.C2H6,
@@ -264,7 +266,7 @@ export class ProcessHeatingApiService {
   }
 
   flueGasLossesByMass(input: FlueGasByMass): number {
-    let SolidLiquidFlueGasMaterial = new Module.SolidLiquidFlueGasMaterial(
+    let SolidLiquidFlueGasMaterial = new this.toolsSuiteApiService.ToolsSuiteModule.SolidLiquidFlueGasMaterial(
       input.flueGasTemperature,
       input.excessAirPercentage,
       input.combustionAirTemperature,
@@ -288,7 +290,7 @@ export class ProcessHeatingApiService {
   }
 
   flueGasCalculateExcessAir(input: MaterialInputProperties): number {
-    let GasCompositions = new Module.GasCompositions(
+    let GasCompositions = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       "",
       input.CH4,
       input.C2H6,
@@ -311,7 +313,7 @@ export class ProcessHeatingApiService {
   }
 
   flueGasCalculateO2(input: MaterialInputProperties): number {
-    let GasCompositions = new Module.GasCompositions(
+    let GasCompositions = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       "",
       input.CH4,
       input.C2H6,
@@ -347,7 +349,7 @@ export class ProcessHeatingApiService {
 
     // todo fix phast 4855
     input.moistureInAirCombustion = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.moistureInAirCombustion)
-    let SolidLiquidFlueGasMaterial = new Module.SolidLiquidFlueGasMaterial(
+    let SolidLiquidFlueGasMaterial = new this.toolsSuiteApiService.ToolsSuiteModule.SolidLiquidFlueGasMaterial(
       '',
       input.carbon,
       input.hydrogen,
@@ -374,7 +376,7 @@ export class ProcessHeatingApiService {
     input.moisture = input.moisture / 100;
     input.nitrogen = input.nitrogen / 100;
 
-    let SolidLiquidFlueGasMaterial = new Module.SolidLiquidFlueGasMaterial();
+    let SolidLiquidFlueGasMaterial = new this.toolsSuiteApiService.ToolsSuiteModule.SolidLiquidFlueGasMaterial();
 
 
     // todo fix phast 4855
@@ -396,7 +398,7 @@ export class ProcessHeatingApiService {
   }
 
   flueGasByVolumeCalculateHeatingValue(input: MaterialInputProperties): HeatingValueByVolumeOutput {
-    let GasCompositions = new Module.GasCompositions(
+    let GasCompositions = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       "",
       input.CH4,
       input.C2H6,
@@ -422,7 +424,7 @@ export class ProcessHeatingApiService {
   }
 
   flueGasByMassCalculateHeatingValue(input: MaterialInputProperties): number {
-    let SolidLiquidFlueGasMaterial = new Module.SolidLiquidFlueGasMaterial();
+    let SolidLiquidFlueGasMaterial = new this.toolsSuiteApiService.ToolsSuiteModule.SolidLiquidFlueGasMaterial();
 
     let output: number = SolidLiquidFlueGasMaterial.calculateHeatingValueFuel(
       input.carbon,
@@ -438,7 +440,7 @@ export class ProcessHeatingApiService {
   }
 
   slagOtherMaterialLosses(input: Slag): number {
-    let SlagInstance = new Module.SlagOtherMaterialLosses(
+    let SlagInstance = new this.toolsSuiteApiService.ToolsSuiteModule.SlagOtherMaterialLosses(
       input.weight, input.inletTemperature,
       input.outletTemperature, input.specificHeat,
       input.correctionFactor,
@@ -449,7 +451,7 @@ export class ProcessHeatingApiService {
   }
 
   auxiliaryPowerLoss(input: AuxiliaryPowerLoss): number {
-    let AuxPowerInstance = new Module.AuxiliaryPower(
+    let AuxPowerInstance = new this.toolsSuiteApiService.ToolsSuiteModule.AuxiliaryPower(
       input.motorPhase, input.supplyVoltage,
       input.avgCurrent, input.powerFactor,
     );
@@ -467,7 +469,7 @@ export class ProcessHeatingApiService {
     input.otherFuels = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.otherFuels);
     input.electricityInput = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.electricityInput);
 
-    let EnergyInputEAFInstance = new Module.EnergyInputEAF(
+    let EnergyInputEAFInstance = new this.toolsSuiteApiService.ToolsSuiteModule.EnergyInputEAF(
       input.naturalGasHeatInput, input.coalCarbonInjection,
       input.coalHeatingValue, input.electrodeUse,
       input.electrodeHeatingValue, input.otherFuels,
@@ -483,7 +485,7 @@ export class ProcessHeatingApiService {
   }
 
   exhaustGasEAF(input: ExhaustGasEAF): number {
-    let ExhaustGasEAFInstance = new Module.ExhaustGasEAF(
+    let ExhaustGasEAFInstance = new this.toolsSuiteApiService.ToolsSuiteModule.ExhaustGasEAF(
       input.offGasTemp, input.CO,
       input.H2, input.combustibleGases, input.vfr,
       input.dustLoading,
@@ -503,7 +505,7 @@ export class ProcessHeatingApiService {
     input.newCombustionAirTemp = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.newCombustionAirTemp)
     input.currentEnergyInput = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.currentEnergyInput)
 
-    let EfficiencyImprovementInstance = new Module.EfficiencyImprovement(
+    let EfficiencyImprovementInstance = new this.toolsSuiteApiService.ToolsSuiteModule.EfficiencyImprovement(
       input.currentFlueGasOxygen,
       input.newFlueGasOxygen,
       input.currentFlueGasTemp,
@@ -531,7 +533,7 @@ export class ProcessHeatingApiService {
     input.electricallyHeatedEfficiency = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.electricallyHeatedEfficiency);
     input.fuelFiredHeatInput = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.fuelFiredHeatInput);
 
-    let EnergyEquivalencyElectricInstance = new Module.ElectricalEnergyEquivalency(
+    let EnergyEquivalencyElectricInstance = new this.toolsSuiteApiService.ToolsSuiteModule.ElectricalEnergyEquivalency(
       input.fuelFiredEfficiency,
       input.electricallyHeatedEfficiency,
       input.fuelFiredHeatInput
@@ -550,7 +552,7 @@ export class ProcessHeatingApiService {
     input.fuelFiredEfficiency = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.fuelFiredEfficiency);
     input.electricalHeatInput = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.electricalHeatInput);
 
-    let EnergyEquivalencyFuelInstance = new Module.FuelFiredEnergyEquivalency(
+    let EnergyEquivalencyFuelInstance = new this.toolsSuiteApiService.ToolsSuiteModule.FuelFiredEnergyEquivalency(
       input.electricallyHeatedEfficiency,
       input.fuelFiredEfficiency,
       input.electricalHeatInput
@@ -578,7 +580,7 @@ export class ProcessHeatingApiService {
     input.gasPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.gasPressure)
     input.orificePressureDrop = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.orificePressureDrop)
 
-    let FlowCalculationsInstance = new Module.FlowCalculationsEnergyUse(
+    let FlowCalculationsInstance = new this.toolsSuiteApiService.ToolsSuiteModule.FlowCalculationsEnergyUse(
       gasType,
       input.specificGravity,
       input.orificeDiameter,
@@ -613,7 +615,7 @@ export class ProcessHeatingApiService {
     input.combAirTempEnriched = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.combAirTempEnriched);
     input.fuelConsumption = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.fuelConsumption);
 
-    let O2EnrichmentInstance = new Module.O2Enrichment(
+    let O2EnrichmentInstance = new this.toolsSuiteApiService.ToolsSuiteModule.O2Enrichment(
       input.o2CombAir, input.o2CombAirEnriched,
       input.flueGasTemp, input.flueGasTempEnriched,
       input.o2FlueGas, input.o2FlueGasEnriched,
@@ -635,7 +637,7 @@ export class ProcessHeatingApiService {
   }
 
   waterHeatingUsingSteam(input: WaterHeatingInput): WaterHeatingOutput {
-    let WaterHeatingInstance = new Module.WaterHeatingUsingSteam();
+    let WaterHeatingInstance = new this.toolsSuiteApiService.ToolsSuiteModule.WaterHeatingUsingSteam();
     let output = WaterHeatingInstance.calculate(
       input.pressureSteamIn, input.flowSteamRate,
       input.temperatureWaterIn, input.pressureWaterOut,
@@ -673,7 +675,7 @@ export class ProcessHeatingApiService {
     let airHeatingInstance;
     let output;
     if (input.gasFuelType) {
-      let GasCompositions = new Module.GasCompositions(
+      let GasCompositions = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
         input.substance,
         input.CH4,
         input.C2H6,
@@ -687,10 +689,10 @@ export class ProcessHeatingApiService {
         input.SO2,
         input.O2
       );
-      airHeatingInstance = new Module.AirHeatingUsingExhaust(GasCompositions);
+      airHeatingInstance = new this.toolsSuiteApiService.ToolsSuiteModule.AirHeatingUsingExhaust(GasCompositions);
       GasCompositions.delete();
     } else {
-      let SolidLiquidFlueGasMaterial = new Module.SolidLiquidFlueGasMaterial(
+      let SolidLiquidFlueGasMaterial = new this.toolsSuiteApiService.ToolsSuiteModule.SolidLiquidFlueGasMaterial(
         input.substance,
         input.carbon,
         input.hydrogen,
@@ -700,7 +702,7 @@ export class ProcessHeatingApiService {
         input.moisture,
         input.nitrogen
       );
-      airHeatingInstance = new Module.AirHeatingUsingExhaust(SolidLiquidFlueGasMaterial, true);
+      airHeatingInstance = new this.toolsSuiteApiService.ToolsSuiteModule.AirHeatingUsingExhaust(SolidLiquidFlueGasMaterial, true);
       SolidLiquidFlueGasMaterial.delete();
     }
 
@@ -731,7 +733,7 @@ export class ProcessHeatingApiService {
   }
 
   airWaterCoolingUsingFlue(input: CondensingEconomizerSuiteInput): CondensingEconomizerOutput {
-    let GasCompositionsInstance = new Module.GasCompositions(
+    let GasCompositionsInstance = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       input.substance,
       input.CH4,
       input.C2H6,
@@ -746,7 +748,7 @@ export class ProcessHeatingApiService {
       input.O2
     );
 
-    let airWaterCoolingUsingFlueInstance = new Module.AirWaterCoolingUsingFlue();
+    let airWaterCoolingUsingFlueInstance = new this.toolsSuiteApiService.ToolsSuiteModule.AirWaterCoolingUsingFlue();
     let output = airWaterCoolingUsingFlueInstance.calculate(GasCompositionsInstance,
       input.heatInput,
       input.tempFlueGasInF,
@@ -782,7 +784,7 @@ export class ProcessHeatingApiService {
   }
 
   waterHeatingUsingFlue(input: FeedwaterEconomizerSuiteInput) {
-    let GasCompositionsInstance = new Module.GasCompositions(
+    let GasCompositionsInstance = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       input.substance,
       input.CH4,
       input.C2H6,
@@ -798,7 +800,7 @@ export class ProcessHeatingApiService {
     );
 
     let steamCondition = this.suiteApiHelperService.getSteamCondition(input.condSteam);
-    let WaterHeatingUsingFlueInstance = new Module.WaterHeatingUsingFlue();
+    let WaterHeatingUsingFlueInstance = new this.toolsSuiteApiService.ToolsSuiteModule.WaterHeatingUsingFlue();
 
     let output = WaterHeatingUsingFlueInstance.calculate(GasCompositionsInstance,
       input.tempFlueGas,
@@ -846,7 +848,7 @@ export class ProcessHeatingApiService {
 
 
   cascadeHeatHighToLow(input: HeatCascadingInput): HeatCascadingOutput {
-    let GasCompositionsInstance = new Module.GasCompositions(
+    let GasCompositionsInstance = new this.toolsSuiteApiService.ToolsSuiteModule.GasCompositions(
       'Gas',
       input.CH4,
       input.C2H6,
@@ -861,7 +863,7 @@ export class ProcessHeatingApiService {
       input.O2
     );
 
-    let cascadeHeatHighToLowInstance = new Module.CascadeHeatHighToLow(
+    let cascadeHeatHighToLowInstance = new this.toolsSuiteApiService.ToolsSuiteModule.CascadeHeatHighToLow(
       GasCompositionsInstance,
       input.fuelHV,
       input.fuelCost,
@@ -902,7 +904,7 @@ export class ProcessHeatingApiService {
   }
 
   waterHeatingUsingExhaust(input: WasteHeatInput): WasteHeatOutput {
-    let WaterHeatingInstance = new Module.WaterHeatingUsingExhaust();
+    let WaterHeatingInstance = new this.toolsSuiteApiService.ToolsSuiteModule.WaterHeatingUsingExhaust();
     let output = WaterHeatingInstance.calculate(input.availableHeat, input.heatInput,
       input.hxEfficiency, input.chillerInTemperature,
       input.chillerOutTemperature, input.copChiller,

--- a/src/app/tools-suite-api/pumps-suite-api.service.ts
+++ b/src/app/tools-suite-api/pumps-suite-api.service.ts
@@ -3,15 +3,14 @@ import { MotorPerformanceResults } from '../calculator/motors/motor-performance/
 import { HeadToolResults } from '../shared/models/calculators';
 import { PsatInputs, PsatOutputs } from '../shared/models/psat';
 import { SuiteApiHelperService } from './suite-api-helper.service';
-
-//wasm module
-declare var Module: any;
-
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
 @Injectable()
 export class PumpsSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   //results
   resultsExisting(psatInput: PsatInputs): PsatOutputs {
@@ -88,7 +87,7 @@ export class PumpsSuiteApiService {
     let stageCount = psatInput.stages;
     let speed = this.suiteApiHelperService.getFixedSpeedEnum(psatInput.fixed_speed);
     let specifiedDriveEfficiency = psatInput.specifiedDriveEfficiency / 100;
-    let pumpInput = new Module.PumpResultInput(pumpStyle, pumpEfficiency, rpm, drive, kviscosity, specificGravity, stageCount, speed, specifiedDriveEfficiency);
+    let pumpInput = new this.toolsSuiteApiService.ToolsSuiteModule.PumpResultInput(pumpStyle, pumpEfficiency, rpm, drive, kviscosity, specificGravity, stageCount, speed, specifiedDriveEfficiency);
     //motor
     let lineFrequency = this.suiteApiHelperService.getLineFrequencyEnum(psatInput.line_frequency);
     let motorRatedPower = psatInput.motor_rated_power;
@@ -99,7 +98,7 @@ export class PumpsSuiteApiService {
     let fullLoadAmps = psatInput.motor_rated_fla;
     // TODO New assessment, no margin. What should default margin be. Applied on backend?
     let sizeMargin = psatInput.margin ? psatInput.margin : 0;
-    let motor = new Module.Motor(lineFrequency, motorRatedPower, motorRpm, efficiencyClass, specifiedMotorEfficiency, motorRatedVoltage, fullLoadAmps, sizeMargin);
+    let motor = new this.toolsSuiteApiService.ToolsSuiteModule.Motor(lineFrequency, motorRatedPower, motorRpm, efficiencyClass, specifiedMotorEfficiency, motorRatedVoltage, fullLoadAmps, sizeMargin);
 
     let flowRate = psatInput.flow_rate;
     let head = psatInput.head;
@@ -109,8 +108,8 @@ export class PumpsSuiteApiService {
     let voltage = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(psatInput.motor_field_voltage);
     let operating_hours = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(psatInput.operating_hours);
     let cost_kw_hour = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(psatInput.cost_kw_hour);
-    let fieldData = new Module.PumpFieldData(flowRate, head, loadEstimationMethod, motorPower, motorAmps, voltage);
-    let psat = new Module.PumpResult(pumpInput, motor, fieldData, operating_hours, cost_kw_hour);
+    let fieldData = new this.toolsSuiteApiService.ToolsSuiteModule.PumpFieldData(flowRate, head, loadEstimationMethod, motorPower, motorAmps, voltage);
+    let psat = new this.toolsSuiteApiService.ToolsSuiteModule.PumpResult(pumpInput, motor, fieldData, operating_hours, cost_kw_hour);
     fieldData.delete();
     motor.delete();
     pumpInput.delete();
@@ -119,7 +118,7 @@ export class PumpsSuiteApiService {
 
   //calculators
   headToolSuctionTank(specificGravity: number, flowRate: number, suctionPipeDiameter: number, suctionTankGasOverPressure: number, suctionTankFluidSurfaceElevation: number, suctionLineLossCoefficients: number, dischargePipeDiameter: number, dischargeGaugePressure: number, dischargeGaugeElevation: number, dischargeLineLossCoefficients: number): HeadToolResults {
-    let instance = new Module.HeadToolSuctionTank(specificGravity, flowRate, suctionPipeDiameter, suctionTankGasOverPressure, suctionTankFluidSurfaceElevation, suctionLineLossCoefficients, dischargePipeDiameter, dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.HeadToolSuctionTank(specificGravity, flowRate, suctionPipeDiameter, suctionTankGasOverPressure, suctionTankFluidSurfaceElevation, suctionLineLossCoefficients, dischargePipeDiameter, dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
     let headToolSuctionTankResults = instance.calculate();
     let results: HeadToolResults = {
       differentialElevationHead: headToolSuctionTankResults.differentialElevationHead,
@@ -135,7 +134,7 @@ export class PumpsSuiteApiService {
   }
 
   headTool(specificGravity: number, flowRate: number, suctionPipeDiameter: number, suctionGaugePressure: number, suctionGaugeElevation: number, suctionLineLossCoefficients: number, dischargePipeDiameter: number, dischargeGaugePressure: number, dischargeGaugeElevation: number, dischargeLineLossCoefficients: number): HeadToolResults {
-    let instance = new Module.HeadTool(specificGravity, flowRate, suctionPipeDiameter, suctionGaugePressure, suctionGaugeElevation, suctionLineLossCoefficients, dischargePipeDiameter, dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.HeadTool(specificGravity, flowRate, suctionPipeDiameter, suctionGaugePressure, suctionGaugeElevation, suctionLineLossCoefficients, dischargePipeDiameter, dischargeGaugePressure, dischargeGaugeElevation, dischargeLineLossCoefficients);
     let headToolResults = instance.calculate();
     let results: HeadToolResults = {
       differentialElevationHead: headToolResults.differentialElevationHead,
@@ -152,7 +151,7 @@ export class PumpsSuiteApiService {
 
   achievableEfficiency(pumpStyle: number, specificSpeed: number): number {
     let pumpStyleEnum = this.suiteApiHelperService.getPumpStyleEnum(pumpStyle);
-    let instance = new Module.OptimalSpecificSpeedCorrection(pumpStyleEnum, specificSpeed);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.OptimalSpecificSpeedCorrection(pumpStyleEnum, specificSpeed);
     let results: number = instance.calculate() * 100;
     instance.delete();
     return results;
@@ -166,7 +165,7 @@ export class PumpsSuiteApiService {
       head: number,
       pumpEfficiencyInput: number): { average: number, max: number } {
     let pumpStyleEnum = this.suiteApiHelperService.getPumpStyleEnum(pumpStyle);
-    let instance = new Module.PumpEfficiency(pumpStyleEnum, pumpEfficiencyInput, rpm, kinematicViscosity, stageCount, flowRate, head);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.PumpEfficiency(pumpStyleEnum, pumpEfficiencyInput, rpm, kinematicViscosity, stageCount, flowRate, head);
     let pumpEfficiency = instance.calculate();
     let results: { average: number, max: number } = {
       average: pumpEfficiency.average,
@@ -181,7 +180,7 @@ export class PumpsSuiteApiService {
     let lineFrequency = this.suiteApiHelperService.getLineFrequencyEnum(frequency);
     let motorEfficiencyEnum = this.suiteApiHelperService.getMotorEfficiencyEnum(efficiencyClass);
     let efficiency = efficiencyPercent / 100;
-    let instance = new Module.EstimateFLA(motorRatedPower, motorRPM, lineFrequency, motorEfficiencyEnum, efficiency, motorVoltage);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.EstimateFLA(motorRatedPower, motorRPM, lineFrequency, motorEfficiencyEnum, efficiency, motorVoltage);
     let estimatedFLA: number = instance.getEstimatedFLA();
     instance.delete();
     return estimatedFLA;
@@ -190,7 +189,7 @@ export class PumpsSuiteApiService {
   motorPerformance(lineFreq: number, efficiencyClass: number, motorRatedPower: number, motorRPM: number, specifiedEfficiency: number, motorRatedVoltage: number, fullLoadAmps: number, loadFactor: number): MotorPerformanceResults {
     let lineFrequency = this.suiteApiHelperService.getLineFrequencyEnum(lineFreq);
     let motorEfficiencyClass = this.suiteApiHelperService.getMotorEfficiencyEnum(efficiencyClass);
-    let instance = new Module.MotorPerformance(lineFrequency, motorRPM, motorEfficiencyClass, motorRatedPower, specifiedEfficiency, loadFactor, motorRatedVoltage, fullLoadAmps);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.MotorPerformance(lineFrequency, motorRPM, motorEfficiencyClass, motorRatedPower, specifiedEfficiency, loadFactor, motorRatedVoltage, fullLoadAmps);
     let tmpResults = instance.calculate();
     let results: MotorPerformanceResults = {
       efficiency: tmpResults.efficiency,
@@ -206,7 +205,7 @@ export class PumpsSuiteApiService {
   nema(lineFreq: number, motorRPM: number, efficiencyClass: number, efficiency: number, motorRatedPower: number): number {
     let lineFrequency = this.suiteApiHelperService.getLineFrequencyEnum(lineFreq);
     let efficiencyClassEnum = this.suiteApiHelperService.getMotorEfficiencyEnum(efficiencyClass);
-    let instance = new Module.MotorEfficiency(lineFrequency, motorRPM, efficiencyClassEnum, motorRatedPower);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.MotorEfficiency(lineFrequency, motorRPM, efficiencyClassEnum, motorRatedPower);
     //loadFactor hard coded to 1 for nema
     let loadFactor: number = 1;
     let motorEfficiency: number = instance.calculate(loadFactor, efficiency / 100) * 100;
@@ -224,7 +223,7 @@ export class PumpsSuiteApiService {
   motorEfficiency(lineFreq: number, motorRPM: number, efficiencyClass: number, efficiencyPercent: number, motorRatedPower: number, loadFactorPercent: number): number {
     let lineFrequency = this.suiteApiHelperService.getLineFrequencyEnum(lineFreq);
     let efficiencyClassEnum = this.suiteApiHelperService.getMotorEfficiencyEnum(efficiencyClass);
-    let instance = new Module.MotorEfficiency(lineFrequency, motorRPM, efficiencyClassEnum, motorRatedPower);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.MotorEfficiency(lineFrequency, motorRPM, efficiencyClassEnum, motorRatedPower);
     
     let efficiency = efficiencyPercent / 100;
     // * if efficiency class 0,1,2 (Standard, EE, Prem), efficiency input is not used and result is returned in decimal
@@ -244,7 +243,7 @@ export class PumpsSuiteApiService {
  */
   motorPowerFactor(motorRatedPower: number, loadFactorPercent: number, motorCurrent: number, motorEfficiencyPercent: number, ratedVoltage: number): number {
     // * will be incorrect if incorrect estimated efficiency values are generated
-    let instance = new Module.MotorPowerFactor(motorRatedPower, loadFactorPercent / 100, motorCurrent, motorEfficiencyPercent / 100, ratedVoltage);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.MotorPowerFactor(motorRatedPower, loadFactorPercent / 100, motorCurrent, motorEfficiencyPercent / 100, ratedVoltage);
     let powerFactor: number = instance.calculate();
     powerFactor = powerFactor* 100;
     instance.delete();
@@ -262,7 +261,7 @@ export class PumpsSuiteApiService {
   motorCurrent(motorRatedPower: number, motorRPM: number, lineFreq: number, efficiencyClass: number, specifiedEfficiencyPercent: number, loadFactorPercent: number, ratedVoltage: number, fullLoadAmps: number): number {
     let lineFrequency = this.suiteApiHelperService.getLineFrequencyEnum(lineFreq);
     let efficiencyClassEnum = this.suiteApiHelperService.getMotorEfficiencyEnum(efficiencyClass);
-    let instance = new Module.MotorCurrent(motorRatedPower, motorRPM, lineFrequency, efficiencyClassEnum, specifiedEfficiencyPercent, loadFactorPercent / 100, ratedVoltage);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.MotorCurrent(motorRatedPower, motorRPM, lineFrequency, efficiencyClassEnum, specifiedEfficiencyPercent, loadFactorPercent / 100, ratedVoltage);
     let motorCurrent: number = instance.calculateCurrent(fullLoadAmps);
     instance.delete();
     return motorCurrent;

--- a/src/app/tools-suite-api/standalone-suite-api.service.ts
+++ b/src/app/tools-suite-api/standalone-suite-api.service.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@angular/core';
 import { AirSystemCapacityInput, AirSystemCapacityOutput, AirVelocityInput, BagMethodInput, BagMethodOutput, CalculateUsableCapacity, CombinedHeatPower, CombinedHeatPowerOutput, CompressedAirPressureReductionInput, CompressedAirPressureReductionResult, CompressedAirReductionInput, CompressedAirReductionResult, ElectricityReductionInput, ElectricityReductionResult, NaturalGasReductionInput, NaturalGasReductionResult, OperatingCostInput, OperatingCostOutput, PipeInsulationReductionInput, PipeInsulationReductionResult, PipeSizes, PipeSizingInput, PipeSizingOutput, PneumaticAirRequirementInput, PneumaticAirRequirementOutput, ReceiverTankBridgingCompressor, ReceiverTankDedicatedStorage, ReceiverTankGeneral, ReceiverTankMeteredResults, ReceiverTankMeteredStorage } from '../shared/models/standalone';
 import { SuiteApiHelperService } from './suite-api-helper.service';
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
-declare var Module: any;
 @Injectable()
 export class StandaloneSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   pneumaticAirRequirement(input: PneumaticAirRequirementInput): PneumaticAirRequirementOutput {
     let pistonType = this.suiteApiHelperService.getPistonTypeEnum(input.pistonType);
@@ -17,9 +19,9 @@ export class StandaloneSuiteApiService {
     input.cylinderStroke = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.cylinderStroke);
     input.pistonRodDiameter = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.pistonRodDiameter);
     if (input.pistonType === 1) {
-      PneumaticAirRequirement = new Module.PneumaticAirRequirement(pistonType, input.cylinderDiameter, input.cylinderStroke, input.pistonRodDiameter, input.airPressure, input.cyclesPerMinute);
+      PneumaticAirRequirement = new this.toolsSuiteApiService.ToolsSuiteModule.PneumaticAirRequirement(pistonType, input.cylinderDiameter, input.cylinderStroke, input.pistonRodDiameter, input.airPressure, input.cyclesPerMinute);
     } else {
-      PneumaticAirRequirement = new Module.PneumaticAirRequirement(pistonType, input.cylinderDiameter, input.cylinderStroke, input.airPressure, input.cyclesPerMinute);
+      PneumaticAirRequirement = new this.toolsSuiteApiService.ToolsSuiteModule.PneumaticAirRequirement(pistonType, input.cylinderDiameter, input.cylinderStroke, input.airPressure, input.cyclesPerMinute);
     }
     let output = PneumaticAirRequirement.calculate();
     let results: PneumaticAirRequirementOutput = {
@@ -36,7 +38,7 @@ export class StandaloneSuiteApiService {
     input.airDemand = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.airDemand);
     input.allowablePressureDrop = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.allowablePressureDrop);
     input.atmosphericPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.atmosphericPressure);
-    let ReceiverTank = new Module.ReceiverTank(Module.ReceiverTankMethod.General, input.airDemand, input.allowablePressureDrop, input.atmosphericPressure);
+    let ReceiverTank = new this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTank(this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTankMethod.General, input.airDemand, input.allowablePressureDrop, input.atmosphericPressure);
     let output: number = ReceiverTank.calculateSize();
     ReceiverTank.delete();
     return output;
@@ -48,7 +50,7 @@ export class StandaloneSuiteApiService {
     input.initialTankPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.initialTankPressure);
     input.lengthOfDemand = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.lengthOfDemand);
     input.finalTankPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.finalTankPressure);
-    let ReceiverTank = new Module.ReceiverTank(Module.ReceiverTankMethod.DedicatedStorage, input.lengthOfDemand, input.airFlowRequirement, input.atmosphericPressure, input.initialTankPressure, input.finalTankPressure);
+    let ReceiverTank = new this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTank(this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTankMethod.DedicatedStorage, input.lengthOfDemand, input.airFlowRequirement, input.atmosphericPressure, input.initialTankPressure, input.finalTankPressure);
     let output: number = ReceiverTank.calculateSize();
     ReceiverTank.delete();
     return output;
@@ -60,7 +62,7 @@ export class StandaloneSuiteApiService {
     input.atmosphericPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.atmosphericPressure);
     input.airDemand = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.airDemand);
     input.allowablePressureDrop = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.allowablePressureDrop);
-    let ReceiverTank = new Module.ReceiverTank(Module.ReceiverTankMethod.BridgingCompressorReactionDelay, input.distanceToCompressorRoom, input.speedOfAir, input.atmosphericPressure, input.airDemand, input.allowablePressureDrop);
+    let ReceiverTank = new this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTank(this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTankMethod.BridgingCompressorReactionDelay, input.distanceToCompressorRoom, input.speedOfAir, input.atmosphericPressure, input.airDemand, input.allowablePressureDrop);
     let output: number = ReceiverTank.calculateSize();
     ReceiverTank.delete();
     return output;
@@ -73,7 +75,7 @@ export class StandaloneSuiteApiService {
     input.initialTankPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.initialTankPressure);
     input.finalTankPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.finalTankPressure);
     input.meteredControl = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.meteredControl);
-    let ReceiverTank = new Module.ReceiverTank(Module.ReceiverTankMethod.MeteredStorage, input.lengthOfDemand, input.airFlowRequirement, input.atmosphericPressure, input.initialTankPressure, input.finalTankPressure, input.meteredControl);
+    let ReceiverTank = new this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTank(this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTankMethod.MeteredStorage, input.lengthOfDemand, input.airFlowRequirement, input.atmosphericPressure, input.initialTankPressure, input.finalTankPressure, input.meteredControl);
     let volume: number = ReceiverTank.calculateSize();
     let refillTime: number = ReceiverTank.calculateRefillTime();
     ReceiverTank.delete();
@@ -94,7 +96,7 @@ export class StandaloneSuiteApiService {
     input.efficiencyUnloaded = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.efficiencyUnloaded);
     input.costOfElectricity = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.costOfElectricity);
 
-    let OperatingCost = new Module.OperatingCost(
+    let OperatingCost = new this.toolsSuiteApiService.ToolsSuiteModule.OperatingCost(
       input.motorBhp,
       input.bhpUnloaded,
       input.annualOperatingHours,
@@ -121,7 +123,7 @@ export class StandaloneSuiteApiService {
     });
     let receiverCapacitiesInput = this.suiteApiHelperService.returnDoubleVector(receiverCapacities);
 
-    let PipeData = new Module.PipeData(
+    let PipeData = new this.toolsSuiteApiService.ToolsSuiteModule.PipeData(
       input.oneHalf,
       input.threeFourths,
       input.one,
@@ -144,7 +146,7 @@ export class StandaloneSuiteApiService {
       input.twentyFour,
     );
 
-    let AirSystemCapacity = new Module.AirSystemCapacity(PipeData, receiverCapacitiesInput);
+    let AirSystemCapacity = new this.toolsSuiteApiService.ToolsSuiteModule.AirSystemCapacity(PipeData, receiverCapacitiesInput);
     let rawOutput = AirSystemCapacity.calculate();
 
 
@@ -193,7 +195,7 @@ export class StandaloneSuiteApiService {
     input.airFlow = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.airFlow);
     input.pipePressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.pipePressure);
     input.atmosphericPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.atmosphericPressure);
-    let AirVelocity = new Module.AirVelocity(input.airFlow, input.pipePressure, input.atmosphericPressure);
+    let AirVelocity = new this.toolsSuiteApiService.ToolsSuiteModule.AirVelocity(input.airFlow, input.pipePressure, input.atmosphericPressure);
     let output = AirVelocity.calculate();
     let results: PipeSizes = {
       oneHalf: output.oneHalf,
@@ -228,7 +230,7 @@ export class StandaloneSuiteApiService {
     input.designVelocity = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.designVelocity);
     input.atmosphericPressure = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.atmosphericPressure);
 
-    let PipeSizing = new Module.PipeSizing(input.airFlow, input.airlinePressure, input.designVelocity, input.atmosphericPressure);
+    let PipeSizing = new this.toolsSuiteApiService.ToolsSuiteModule.PipeSizing(input.airFlow, input.airlinePressure, input.designVelocity, input.atmosphericPressure);
     let output = PipeSizing.calculate();
     let results: PipeSizingOutput = {
       crossSectionalArea: output.crossSectionalArea,
@@ -240,14 +242,14 @@ export class StandaloneSuiteApiService {
   }
 
   // pneumaticValveCalculateFlowRate(input: PneumaticValveFlowRateInput): PneumaticValveFlowRateOutput {
-  //   let PneumaticValve = new Module.PneumaticValve(input.inletPressure, input.outletPressure);
+  //   let PneumaticValve = new this.toolsSuiteApiService.ToolsSuiteModule.PneumaticValve(input.inletPressure, input.outletPressure);
   //   let output: PneumaticValveFlowRateOutput = PneumaticValve.calculate();
   //   PneumaticValve.delete();
   //   return output;
   // }
 
   // pneumaticValve(input: PneumaticValve): PneumaticValveFlowCoefficient {
-  //   let PneumaticValve = new Module.PneumaticValve(input.inletPressure, input.outletPressure, input.flowRate);
+  //   let PneumaticValve = new this.toolsSuiteApiService.ToolsSuiteModule.PneumaticValve(input.inletPressure, input.outletPressure, input.flowRate);
   //   let output: PneumaticValveFlowCoefficient = PneumaticValve.calculate();
   //   PneumaticValve.delete();
   //   return output;
@@ -256,7 +258,7 @@ export class StandaloneSuiteApiService {
   bagMethod(input: BagMethodInput): BagMethodOutput {
     input.bagFillTime = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.bagFillTime);
     input.bagVolume = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.bagVolume);
-    let BagMethod = new Module.BagMethod(input.operatingTime, input.bagFillTime, input.bagVolume, input.numberOfUnits);
+    let BagMethod = new this.toolsSuiteApiService.ToolsSuiteModule.BagMethod(input.operatingTime, input.bagFillTime, input.bagVolume, input.numberOfUnits);
     let rawOutput = BagMethod.calculate();
     let output: BagMethodOutput = {
       flowRate: isNaN(rawOutput.flowRate) ? undefined : rawOutput.flowRate,
@@ -281,7 +283,7 @@ export class StandaloneSuiteApiService {
     input.thermalUtilization = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.thermalUtilization);
 
     let chpOption = this.suiteApiHelperService.getCHPOptionEnum(input.option);
-    let CHP = new Module.CHP(
+    let CHP = new this.toolsSuiteApiService.ToolsSuiteModule.CHP(
       input.annualOperatingHours,
       input.annualElectricityConsumption,
       input.annualThermalDemand,
@@ -312,7 +314,7 @@ export class StandaloneSuiteApiService {
   }
 
   usableAirCapacity(input: CalculateUsableCapacity): number {
-    let ReceiverTank = new Module.ReceiverTank();
+    let ReceiverTank = new this.toolsSuiteApiService.ToolsSuiteModule.ReceiverTank();
     input.tankSize = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.tankSize);
     input.airPressureIn = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.airPressureIn);
     input.airPressureOut = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(input.airPressureOut);

--- a/src/app/tools-suite-api/steam-suite-api.service.ts
+++ b/src/app/tools-suite-api/steam-suite-api.service.ts
@@ -3,16 +3,18 @@ import { HeaderNotHighestPressure, HeaderWithHighestPressure, SSMTInputs } from 
 import { BoilerInput, DeaeratorInput, FlashTankInput, HeaderInput, HeaderInputObj, HeatLossInput, PrvInput, SaturatedPropertiesInput, SteamPropertiesInput, TurbineInput } from '../shared/models/steam/steam-inputs';
 import { SteamPropertiesOutput, SaturatedPropertiesOutput, BoilerOutput, DeaeratorOutput, FlashTankOutput, HeaderOutput, HeatLossOutput, PrvOutput, TurbineOutput, SSMTOutput, SSMTOperationsOutput, ProcessSteamUsage } from '../shared/models/steam/steam-outputs';
 import { SuiteApiHelperService } from './suite-api-helper.service';
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
-declare var Module: any;
 @Injectable()
 export class SteamSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   steamProperties(input: SteamPropertiesInput): SteamPropertiesOutput {
     let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.thermodynamicQuantity)
-    let SteamProperties = new Module.SteamProperties(
+    let SteamProperties = new this.toolsSuiteApiService.ToolsSuiteModule.SteamProperties(
       input.pressure,
       thermodynamicQuantityType,
       input.quantityValue
@@ -35,9 +37,9 @@ export class SteamSuiteApiService {
 
   saturatedPropertiesGivenPressure(saturatedPropertiesInput: SaturatedPropertiesInput): SaturatedPropertiesOutput {
 
-    let SaturatedTemperature = new Module.SaturatedTemperature(saturatedPropertiesInput.saturatedPressure);
+    let SaturatedTemperature = new this.toolsSuiteApiService.ToolsSuiteModule.SaturatedTemperature(saturatedPropertiesInput.saturatedPressure);
     let temperature = SaturatedTemperature.calculate();
-    let SaturatedProperties = new Module.SaturatedProperties(saturatedPropertiesInput.saturatedPressure, temperature);
+    let SaturatedProperties = new this.toolsSuiteApiService.ToolsSuiteModule.SaturatedProperties(saturatedPropertiesInput.saturatedPressure, temperature);
     let saturatedPropertiesOutput = SaturatedProperties.calculate();
     let results: SaturatedPropertiesOutput = {
       saturatedPressure: saturatedPropertiesOutput.saturatedPressure,
@@ -60,9 +62,9 @@ export class SteamSuiteApiService {
 
   saturatedPropertiesGivenTemperature(saturatedPropertiesInput: SaturatedPropertiesInput): SaturatedPropertiesOutput {
 
-    let SaturatedPressure = new Module.SaturatedPressure(saturatedPropertiesInput.saturatedTemperature);
+    let SaturatedPressure = new this.toolsSuiteApiService.ToolsSuiteModule.SaturatedPressure(saturatedPropertiesInput.saturatedTemperature);
     let pressure = SaturatedPressure.calculate();
-    let SaturatedProperties = new Module.SaturatedProperties(pressure, saturatedPropertiesInput.saturatedTemperature);
+    let SaturatedProperties = new this.toolsSuiteApiService.ToolsSuiteModule.SaturatedProperties(pressure, saturatedPropertiesInput.saturatedTemperature);
     let saturatedPropertiesOutput = SaturatedProperties.calculate();
     let results: SaturatedPropertiesOutput = {
       saturatedPressure: saturatedPropertiesOutput.saturatedPressure,
@@ -87,7 +89,7 @@ export class SteamSuiteApiService {
   boiler(input: BoilerInput): BoilerOutput {
     let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.thermodynamicQuantity)
 
-    let Boiler = new Module.Boiler(
+    let Boiler = new this.toolsSuiteApiService.ToolsSuiteModule.Boiler(
       input.deaeratorPressure,
       input.combustionEfficiency,
       input.blowdownRate,
@@ -108,7 +110,7 @@ export class SteamSuiteApiService {
     let steamThermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.steamThermodynamicQuantity)
 
 
-    let Deaerator = new Module.Deaerator(
+    let Deaerator = new this.toolsSuiteApiService.ToolsSuiteModule.Deaerator(
       input.deaeratorPressure,
       input.ventRate,
       input.feedwaterMassFlow,
@@ -128,7 +130,7 @@ export class SteamSuiteApiService {
   flashTank(input: FlashTankInput): FlashTankOutput {
     let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.thermodynamicQuantity)
 
-    let FlashTank = new Module.FlashTank(
+    let FlashTank = new this.toolsSuiteApiService.ToolsSuiteModule.FlashTank(
       input.inletWaterPressure,
       thermodynamicQuantityType,
       input.quantityValue,
@@ -144,7 +146,7 @@ export class SteamSuiteApiService {
   header(input: HeaderInput): HeaderOutput {
     let inletVector = this.getInletVector(input.inlets);
 
-    let Header = new Module.Header(input.headerPressure, inletVector);
+    let Header = new this.toolsSuiteApiService.ToolsSuiteModule.Header(input.headerPressure, inletVector);
     let HeaderProps = Header.getHeaderProperties();
     HeaderProps.energyFlow = Header.getInletEnergyFlow();
     HeaderProps.massFlow = Header.getInletMassFlow();
@@ -186,7 +188,7 @@ export class SteamSuiteApiService {
   heatLoss(input: HeatLossInput): HeatLossOutput {
     let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.thermodynamicQuantity)
 
-    let HeatLoss = new Module.HeatLoss(
+    let HeatLoss = new this.toolsSuiteApiService.ToolsSuiteModule.HeatLoss(
       input.inletPressure,
       thermodynamicQuantityType,
       input.quantityValue,
@@ -223,7 +225,7 @@ export class SteamSuiteApiService {
   prvWithoutDesuperheating(input: PrvInput): PrvOutput {
     let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.thermodynamicQuantity)
 
-    let prvWithoutDesuperheating = new Module.PrvWithoutDesuperheating(
+    let prvWithoutDesuperheating = new this.toolsSuiteApiService.ToolsSuiteModule.PrvWithoutDesuperheating(
       input.inletPressure,
       thermodynamicQuantityType,
       input.quantityValue,
@@ -242,7 +244,7 @@ export class SteamSuiteApiService {
     let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.thermodynamicQuantity);
     let feedwaterThermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.feedwaterThermodynamicQuantity);
 
-    let prvWithDesuperheating = new Module.PrvWithDesuperheating(
+    let prvWithDesuperheating = new this.toolsSuiteApiService.ToolsSuiteModule.PrvWithDesuperheating(
       input.inletPressure,
       thermodynamicQuantityType,
       input.quantityValue,
@@ -267,7 +269,7 @@ export class SteamSuiteApiService {
 
     let Turbine;
     if (input.solveFor == 0) {
-      Turbine = new Module.Turbine(
+      Turbine = new this.toolsSuiteApiService.ToolsSuiteModule.Turbine(
         solveForMethod,
         input.inletPressure,
         inletThermodynamicQuantityType,
@@ -280,7 +282,7 @@ export class SteamSuiteApiService {
       );
     } else {
       let outletThermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(input.outletQuantity);
-      Turbine = new Module.Turbine(
+      Turbine = new this.toolsSuiteApiService.ToolsSuiteModule.Turbine(
         solveForMethod,
         input.inletPressure,
         inletThermodynamicQuantityType,
@@ -305,7 +307,7 @@ export class SteamSuiteApiService {
 
 
     this.suiteApiHelperService.convertNullInputsForObjectConstructor(inputData.boilerInput);
-    let boilerInputObj = new Module.BoilerInput(
+    let boilerInputObj = new this.toolsSuiteApiService.ToolsSuiteModule.BoilerInput(
       inputData.boilerInput.fuelType,
       inputData.boilerInput.fuel,
       inputData.boilerInput.combustionEfficiency,
@@ -328,7 +330,7 @@ export class SteamSuiteApiService {
       highPressureHeaderObj = this.getHighPressureHeaderObject(inputData.headerInput.highPressure);
     }
 
-    let operationsInputObj = new Module.OperationsInput(
+    let operationsInputObj = new this.toolsSuiteApiService.ToolsSuiteModule.OperationsInput(
       inputData.operationsInput.sitePowerImport,
       inputData.operationsInput.makeUpWaterTemperature,
       inputData.operationsInput.operatingHoursPerYear,
@@ -360,7 +362,7 @@ export class SteamSuiteApiService {
       lowPressureHeaderObj = this.getNotHighPressureHeaderObject(inputData.headerInput.lowPressure);
     }
 
-    let headerInputObj = new Module.HeaderInput(highPressureHeaderObj, mediumPressureHeaderObj, lowPressureHeaderObj);
+    let headerInputObj = new this.toolsSuiteApiService.ToolsSuiteModule.HeaderInput(highPressureHeaderObj, mediumPressureHeaderObj, lowPressureHeaderObj);
     if (mediumPressureHeaderObj) {
       mediumPressureHeaderObj.delete();
     }
@@ -369,7 +371,7 @@ export class SteamSuiteApiService {
     }
 
     this.suiteApiHelperService.convertNullInputsForObjectConstructor(inputData.turbineInput.condensingTurbine);
-    let condensingTurbineObj = new Module.CondensingTurbine(
+    let condensingTurbineObj = new this.toolsSuiteApiService.ToolsSuiteModule.CondensingTurbine(
       inputData.turbineInput.condensingTurbine.isentropicEfficiency,
       inputData.turbineInput.condensingTurbine.generationEfficiency,
       inputData.turbineInput.condensingTurbine.condenserPressure,
@@ -378,7 +380,7 @@ export class SteamSuiteApiService {
       inputData.turbineInput.condensingTurbine.useTurbine
     );
     this.suiteApiHelperService.convertNullInputsForObjectConstructor(inputData.turbineInput.highToLowTurbine);
-    let highToLowTurbineObj = new Module.PressureTurbine(
+    let highToLowTurbineObj = new this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbine(
       inputData.turbineInput.highToLowTurbine.isentropicEfficiency,
       inputData.turbineInput.highToLowTurbine.generationEfficiency,
       inputData.turbineInput.highToLowTurbine.operationType,
@@ -387,7 +389,7 @@ export class SteamSuiteApiService {
       inputData.turbineInput.highToLowTurbine.useTurbine
     );
     this.suiteApiHelperService.convertNullInputsForObjectConstructor(inputData.turbineInput.highToMediumTurbine);
-    let highToMediumTurbineObj = new Module.PressureTurbine(
+    let highToMediumTurbineObj = new this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbine(
       inputData.turbineInput.highToMediumTurbine.isentropicEfficiency,
       inputData.turbineInput.highToMediumTurbine.generationEfficiency,
       inputData.turbineInput.highToMediumTurbine.operationType,
@@ -396,7 +398,7 @@ export class SteamSuiteApiService {
       inputData.turbineInput.highToMediumTurbine.useTurbine
     );
     this.suiteApiHelperService.convertNullInputsForObjectConstructor(inputData.turbineInput.mediumToLowTurbine);
-    let mediumToLowTurbineObj = new Module.PressureTurbine(
+    let mediumToLowTurbineObj = new this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbine(
       inputData.turbineInput.mediumToLowTurbine.isentropicEfficiency,
       inputData.turbineInput.mediumToLowTurbine.generationEfficiency,
       inputData.turbineInput.mediumToLowTurbine.operationType,
@@ -405,14 +407,14 @@ export class SteamSuiteApiService {
       inputData.turbineInput.mediumToLowTurbine.useTurbine
     );
 
-    let turbineInputObj = new Module.TurbineInput(
+    let turbineInputObj = new this.toolsSuiteApiService.ToolsSuiteModule.TurbineInput(
       condensingTurbineObj,
       highToLowTurbineObj,
       highToMediumTurbineObj,
       mediumToLowTurbineObj
     );
 
-    let steamModelerInput = new Module.SteamModelerInput(
+    let steamModelerInput = new this.toolsSuiteApiService.ToolsSuiteModule.SteamModelerInput(
       inputData.isBaselineCalc,
       inputData.baselinePowerDemand,
       boilerInputObj,
@@ -421,7 +423,7 @@ export class SteamSuiteApiService {
       turbineInputObj
     );
 
-    let modeler = new Module.SteamModeler();
+    let modeler = new this.toolsSuiteApiService.ToolsSuiteModule.SteamModeler();
     let wasmOutput = modeler.model(steamModelerInput);
     ssmtOutput = this.getSSMTOutputFromWASMOutput(wasmOutput);
 
@@ -939,7 +941,7 @@ export class SteamSuiteApiService {
 
 
   getHighPressureHeaderObject(header: HeaderWithHighestPressure) {
-    return new Module.HeaderWithHighestPressure(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.HeaderWithHighestPressure(
       header.pressure,
       header.processSteamUsage,
       header.condensationRecoveryRate,
@@ -954,7 +956,7 @@ export class SteamSuiteApiService {
       // Adding property for modification where user has not selected calculated from baseline
       header.processSteamUsage = 0;
     }
-    return new Module.HeaderNotHighestPressure(
+    return new this.toolsSuiteApiService.ToolsSuiteModule.HeaderNotHighestPressure(
       header.pressure,
       header.processSteamUsage,
       header.condensationRecoveryRate,
@@ -1066,7 +1068,7 @@ export class SteamSuiteApiService {
       outletProperties.delete();
 
       if (prv.isWithDesuperheating() && !inCalculator) {
-        let castDesuperheating = new Module.PrvCastDesuperheating();
+        let castDesuperheating = new this.toolsSuiteApiService.ToolsSuiteModule.PrvCastDesuperheating();
         let prvWith = castDesuperheating.Cast(prv);
         if (prvWith != null) {
           let feedwaterProperties = prvWith.getFeedwaterProperties();
@@ -1251,10 +1253,10 @@ export class SteamSuiteApiService {
 
 
   getInletVector(inletsArray: Array<HeaderInputObj>) {
-    let inletVector = new Module.InletVector();
+    let inletVector = new this.toolsSuiteApiService.ToolsSuiteModule.InletVector();
     inletsArray.forEach(inlet => {
       let thermodynamicQuantityType = this.suiteApiHelperService.getThermodynamicQuantityType(inlet.thermodynamicQuantity);
-      let inletPointer = new Module.Inlet(
+      let inletPointer = new this.toolsSuiteApiService.ToolsSuiteModule.Inlet(
         inlet.pressure,
         thermodynamicQuantityType,
         inlet.quantityValue,

--- a/src/app/tools-suite-api/suite-api-helper.service.ts
+++ b/src/app/tools-suite-api/suite-api-helper.service.ts
@@ -1,54 +1,53 @@
 import { Injectable } from '@angular/core';
 import * as _ from 'lodash';
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
-//wasm module
-declare var Module: any;
 @Injectable()
 export class SuiteApiHelperService {
 
-  constructor() {}
+  constructor(private toolsSuiteApiService: ToolsSuiteApiService) {}
   getPumpStyleEnum(pumpStyle: number): any {
     switch (pumpStyle) {
       case 0:
-        return Module.PumpStyle.END_SUCTION_SLURRY;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.END_SUCTION_SLURRY;
       case 1:
-        return Module.PumpStyle.END_SUCTION_SEWAGE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.END_SUCTION_SEWAGE;
       case 2:
-        return Module.PumpStyle.END_SUCTION_STOCK;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.END_SUCTION_STOCK;
       case 3:
-        return Module.PumpStyle.END_SUCTION_SUBMERSIBLE_SEWAGE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.END_SUCTION_SUBMERSIBLE_SEWAGE;
       case 4:
-        return Module.PumpStyle.API_DOUBLE_SUCTION;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.API_DOUBLE_SUCTION;
       case 5:
-        return Module.PumpStyle.MULTISTAGE_BOILER_FEED;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.MULTISTAGE_BOILER_FEED;
       case 6:
-        return Module.PumpStyle.END_SUCTION_ANSI_API;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.END_SUCTION_ANSI_API;
       case 7:
-        return Module.PumpStyle.AXIAL_FLOW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.AXIAL_FLOW;
       case 8:
-        return Module.PumpStyle.DOUBLE_SUCTION;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.DOUBLE_SUCTION;
       case 9:
-        return Module.PumpStyle.VERTICAL_TURBINE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.VERTICAL_TURBINE;
       case 10:
-        return Module.PumpStyle.LARGE_END_SUCTION;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.LARGE_END_SUCTION;
       case 11:
-        return Module.PumpStyle.SPECIFIED_OPTIMAL_EFFICIENCY;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PumpStyle.SPECIFIED_OPTIMAL_EFFICIENCY;
     }
   }
 
   getPistonTypeEnum(pistonType: number): any {
     switch (pistonType) {
       case 0:
-        return Module.PistonType.SingleActing;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PistonType.SingleActing;
       case 1:
-        return Module.PistonType.DoubleActing;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PistonType.DoubleActing;
     }
   }
 
   getLineFrequencyEnum(lineFreq: number) {
-    let lineFrequency = Module.LineFrequency.FREQ50;
+    let lineFrequency = this.toolsSuiteApiService.ToolsSuiteModule.LineFrequency.FREQ50;
     if (lineFreq == 60) {
-      lineFrequency = Module.LineFrequency.FREQ60;
+      lineFrequency = this.toolsSuiteApiService.ToolsSuiteModule.LineFrequency.FREQ60;
     }
 
     return lineFrequency;
@@ -67,167 +66,167 @@ export class SuiteApiHelperService {
   getMotorEfficiencyEnum(motorEffVal: number): any {
     switch (motorEffVal) {
       case 0:
-        return Module.MotorEfficiencyClass.STANDARD;
+        return this.toolsSuiteApiService.ToolsSuiteModule.MotorEfficiencyClass.STANDARD;
       case 1:
-        return Module.MotorEfficiencyClass.ENERGY_EFFICIENT;
+        return this.toolsSuiteApiService.ToolsSuiteModule.MotorEfficiencyClass.ENERGY_EFFICIENT;
       case 2:
-        return Module.MotorEfficiencyClass.PREMIUM;
+        return this.toolsSuiteApiService.ToolsSuiteModule.MotorEfficiencyClass.PREMIUM;
       case 3:
-        return Module.MotorEfficiencyClass.SPECIFIED;
+        return this.toolsSuiteApiService.ToolsSuiteModule.MotorEfficiencyClass.SPECIFIED;
     }
   }
 
   getDriveEnum(drive: number) {
     switch (drive) {
       case 0:
-        return Module.Drive.DIRECT_DRIVE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Drive.DIRECT_DRIVE;
       case 1:
-        return Module.Drive.V_BELT_DRIVE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Drive.V_BELT_DRIVE;
       case 2:
-        return Module.Drive.N_V_BELT_DRIVE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Drive.N_V_BELT_DRIVE;
       case 3:
-        return Module.Drive.S_BELT_DRIVE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Drive.S_BELT_DRIVE;
       case 4:
-        return Module.Drive.SPECIFIED;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Drive.SPECIFIED;
     }
   }
 
   getFixedSpeedEnum(fixedSpeed: number) {
     if (fixedSpeed == 0) {
-      return Module.SpecificSpeed.FIXED_SPEED;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SpecificSpeed.FIXED_SPEED;
     } else {
-      return Module.SpecificSpeed.NOT_FIXED_SPEED;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SpecificSpeed.NOT_FIXED_SPEED;
     }
   }
 
   getLoadEstimationMethod(method: number) {
     if (method == 0) {
-      return Module.LoadEstimationMethod.POWER;
+      return this.toolsSuiteApiService.ToolsSuiteModule.LoadEstimationMethod.POWER;
     } else {
-      return Module.LoadEstimationMethod.CURRENT;
+      return this.toolsSuiteApiService.ToolsSuiteModule.LoadEstimationMethod.CURRENT;
     }
   }
 
   getBasGensityInputTypeEnum(type: string) {
     if (type == 'relativeHumidity') {
-      return Module.BaseGasDensityInputType.RelativeHumidity;
+      return this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensityInputType.RelativeHumidity;
     } else if (type == 'wetBulb') {
-      return Module.BaseGasDensityInputType.WetBulbTemp;
+      return this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensityInputType.WetBulbTemp;
     } else if (type == 'dewPoint') {
-      return Module.BaseGasDensityInputType.DewPoint;
+      return this.toolsSuiteApiService.ToolsSuiteModule.BaseGasDensityInputType.DewPoint;
     } else if (type == 'custom') {
       return;
     }
   }
   getGasTypeEnum(type: string) {
     if (type == 'AIR') {
-      return Module.GasType.AIR;
+      return this.toolsSuiteApiService.ToolsSuiteModule.GasType.AIR;
     } else if (type == 'OTHER') {
-      return Module.GasType.OTHER;
+      return this.toolsSuiteApiService.ToolsSuiteModule.GasType.OTHER;
     }
   }
 
   getCHPOptionEnum(option: number) {
     if (option === 0) {
-      return Module.CHPOption.PercentAvgkWhElectricCostAvoided;
+      return this.toolsSuiteApiService.ToolsSuiteModule.CHPOption.PercentAvgkWhElectricCostAvoided;
     } else if (option === 1) {
-      return Module.CHPOption.StandbyRate;
+      return this.toolsSuiteApiService.ToolsSuiteModule.CHPOption.StandbyRate;
     }
   }
 
   getFanTypeEnum(fanType: number) {
     switch (fanType) {
       case 0:
-        return Module.FanType.AirfoilSISW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.AirfoilSISW;
       case 1:
-        return Module.FanType.BackwardCurvedSISW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.BackwardCurvedSISW;
       case 2:
-        return Module.FanType.RadialSISW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.RadialSISW;
       case 3:
-        return Module.FanType.RadialTipSISW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.RadialTipSISW;
       case 4:
-        return Module.FanType.BackwardInclinedSISW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.BackwardInclinedSISW;
       case 5:
-        return Module.FanType.AirfoilDIDW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.AirfoilDIDW;
       case 6:
-        return Module.FanType.BackwardCurvedDIDW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.BackwardCurvedDIDW;
       case 7:
-        return Module.FanType.BackwardInclinedDIDW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.BackwardInclinedDIDW;
       case 8:
-        return Module.FanType.VaneAxial;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanType.VaneAxial;
     }
   }
 
   getFlowCalculationGasTypeEnum(gasType: number) {
     switch (gasType) {
       case 0:
-        return Module.Gas.AIR;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.AIR;
       case 1:
-        return Module.Gas.AMMONIA_DISSOCIATED;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.AMMONIA_DISSOCIATED;
       case 2:
-        return Module.Gas.ARGON;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.ARGON;
       case 3:
-        return Module.Gas.BUTANE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.BUTANE;
       case 4:
-        return Module.Gas.ENDOTHERMIC_AMMONIA;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.ENDOTHERMIC_AMMONIA;
       case 5:
-        return Module.Gas.EXOTHERMIC_CRACKED_LEAN;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.EXOTHERMIC_CRACKED_LEAN;
       case 6:
-        return Module.Gas.EXOTHERMIC_CRACKED_RICH;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.EXOTHERMIC_CRACKED_RICH;
       case 7:
-        return Module.Gas.HELIUM;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.HELIUM;
       case 8:
-        return Module.Gas.NATURAL_GAS;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.NATURAL_GAS;
       case 9:
-        return Module.Gas.NITROGEN;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.NITROGEN;
       case 10:
-        return Module.Gas.OXYGEN;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.OXYGEN;
       case 11:
-        return Module.Gas.PROPANE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.PROPANE;
       case 12:
-        return Module.Gas.OTHER;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Gas.OTHER;
     }
   }
 
   getOpeningShapeEnum(openingShape: number) {
     switch (openingShape) {
       case 0:
-        return Module.OpeningShape.CIRCULAR;
+        return this.toolsSuiteApiService.ToolsSuiteModule.OpeningShape.CIRCULAR;
       case 1:
-        return Module.OpeningShape.SQUARE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.OpeningShape.SQUARE;
     }
   }
 
   getFlowCalculationSectionEnum(section: number) {
     switch (section) {
       case 0:
-        return Module.Section.SQUARE_EDGE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Section.SQUARE_EDGE;
       case 1:
-        return Module.Section.SHARP_EDGE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Section.SHARP_EDGE;
       case 2:
-        return Module.Section.VENTURI;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Section.VENTURI;
     }
   }
 
   getMaterialThermicReactionType(thermicReactionType: number) {
     switch (thermicReactionType) {
       case 0:
-        return Module.ThermicReactionType.ENDOTHERMIC;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermicReactionType.ENDOTHERMIC;
       case 1:
-        return Module.ThermicReactionType.EXOTHERMIC;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermicReactionType.EXOTHERMIC;
       case 2:
-        return Module.ThermicReactionType.NONE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermicReactionType.NONE;
     }
   }
 
   getCoolingTowerFanControlSpeedType(speedType: number) {
     switch (speedType) {
       case 0:
-        return Module.FanControlSpeedType.One;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanControlSpeedType.One;
       case 1:
-        return Module.FanControlSpeedType.Two;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanControlSpeedType.Two;
       case 2:
-        return Module.FanControlSpeedType.Variable;
+        return this.toolsSuiteApiService.ToolsSuiteModule.FanControlSpeedType.Variable;
 
     }
   }
@@ -235,9 +234,9 @@ export class SuiteApiHelperService {
   getCoolingTowerChillerType(chillerType: number) {
     switch (chillerType) {
       case 0:
-        return Module.ChillerType.Centrifugal;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ChillerType.Centrifugal;
       case 1:
-        return Module.ChillerType.Screw;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ChillerType.Screw;
 
     }
   }
@@ -245,9 +244,9 @@ export class SuiteApiHelperService {
   getCoolingTowerCondenserCoolingType(condenserType: number) {
     switch (condenserType) {
       case 0:
-        return Module.CondenserCoolingType.Water;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CondenserCoolingType.Water;
       case 1:
-        return Module.CondenserCoolingType.Air;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CondenserCoolingType.Air;
 
     }
   }
@@ -255,33 +254,33 @@ export class SuiteApiHelperService {
   getCoolingTowerCompressorConfigType(configType: number) {
     switch (configType) {
       case 0:
-        return Module.CompressorConfigType.NoVFD;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CompressorConfigType.NoVFD;
       case 1:
-        return Module.CompressorConfigType.VFD;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CompressorConfigType.VFD;
       case 2:
-        return Module.CompressorConfigType.MagneticBearing;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CompressorConfigType.MagneticBearing;
     }
   }
 
   getThermodynamicQuantityType(thermodynamicQuantity: number) {
     switch (thermodynamicQuantity) {
       case 0:
-        return Module.ThermodynamicQuantity.TEMPERATURE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermodynamicQuantity.TEMPERATURE;
       case 1:
-        return Module.ThermodynamicQuantity.ENTHALPY;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermodynamicQuantity.ENTHALPY;
       case 2:
-        return Module.ThermodynamicQuantity.ENTROPY;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermodynamicQuantity.ENTROPY;
       case 3:
-        return Module.ThermodynamicQuantity.QUALITY;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ThermodynamicQuantity.QUALITY;
     }
   }
 
   getCondensingTurbineOperation(option: number) {
     switch (option) {
       case 0:
-        return Module.CondensingTurbineOperation.STEAM_FLOW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CondensingTurbineOperation.STEAM_FLOW;
       case 1:
-        return Module.CondensingTurbineOperation.POWER_GENERATION;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CondensingTurbineOperation.POWER_GENERATION;
 
     }
   }
@@ -289,33 +288,33 @@ export class SuiteApiHelperService {
   getPressureTurbineOperation(option: number) {
     switch (option) {
       case 0:
-        return Module.PressureTurbineOperation.STEAM_FLOW;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbineOperation.STEAM_FLOW;
       case 1:
-        return Module.PressureTurbineOperation.POWER_GENERATION;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbineOperation.POWER_GENERATION;
       case 2:
-        return Module.PressureTurbineOperation.BALANCE_HEADER;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbineOperation.BALANCE_HEADER;
       case 3:
-        return Module.PressureTurbineOperation.POWER_RANGE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbineOperation.POWER_RANGE;
       case 4:
-        return Module.PressureTurbineOperation.FLOW_RANGE;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PressureTurbineOperation.FLOW_RANGE;
     }
   }
 
   getTurbineProperty(turbineProperty: number) {
     switch (turbineProperty) {
       case 0:
-        return Module.TurbineProperty.MassFlow;
+        return this.toolsSuiteApiService.ToolsSuiteModule.TurbineProperty.MassFlow;
       case 1:
-        return Module.TurbineProperty.PowerOut;
+        return this.toolsSuiteApiService.ToolsSuiteModule.TurbineProperty.PowerOut;
     }
   }
 
   getSolveForMethod(solve: number) {
     switch (solve) {
       case 0:
-        return Module.Solve.OutletProperties;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Solve.OutletProperties;
       case 1:
-        return Module.Solve.IsentropicEfficiency;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Solve.IsentropicEfficiency;
     }
   }
 
@@ -323,75 +322,75 @@ export class SuiteApiHelperService {
   getCompressorTypeEnum(compressorType: number) {
     switch (compressorType) {
       case 0:
-        return Module.CompressorType.Centrifugal;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CompressorType.Centrifugal;
       case 1:
-        return Module.CompressorType.Screw;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CompressorType.Screw;
       case 2:
-        return Module.CompressorType.Reciprocating;
+        return this.toolsSuiteApiService.ToolsSuiteModule.CompressorType.Reciprocating;
     }
   }
 
   getControlTypeEnum(controlType: number) {
     switch (controlType) {
       case 0:
-        return Module.ControlType.LoadUnload;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.LoadUnload;
       case 1:
-        return Module.ControlType.ModulationUnload;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.ModulationUnload;
       case 2:
-        return Module.ControlType.BlowOff;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.BlowOff;
       case 3:
-        return Module.ControlType.ModulationWOUnload;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.ModulationWOUnload;
       case 4:
-        return Module.ControlType.StartStop;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.StartStop;
       case 5:
-        return Module.ControlType.VariableDisplacementUnload;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.VariableDisplacementUnload;
       case 6:
-        return Module.ControlType.MultiStepUnloading;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.MultiStepUnloading;
       case 7:
-        return Module.ControlType.VFD;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ControlType.VFD;
     }
   }
 
   getLubricantEnum(lubricant: number) {
     switch (lubricant) {
       case 0:
-        return Module.Lubricant.Injected;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Lubricant.Injected;
       case 1:
-        return Module.Lubricant.Free;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Lubricant.Free;
       case 2:
-        return Module.Lubricant.None;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Lubricant.None;
     }
   }
 
   getStageEnum(stage: number) {
     switch (stage) {
       case 0:
-        return Module.Stage.Single;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Stage.Single;
       case 1:
-        return Module.Stage.Two;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Stage.Two;
       case 2:
-        return Module.Stage.Multiple;
+        return this.toolsSuiteApiService.ToolsSuiteModule.Stage.Multiple;
     }
   }
 
   getComputeFromEnum(computeFrom: number) {
     switch (computeFrom) {
       case 0:
-        return Module.ComputeFrom.PercentagePower;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentagePower;
       case 1:
-        return Module.ComputeFrom.PercentageCapacity;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PercentageCapacity;
       case 2:
-        return Module.ComputeFrom.PowerMeasured;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerMeasured;
       case 3:
-        return Module.ComputeFrom.CapacityMeasured;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.CapacityMeasured;
       case 4:
-        return Module.ComputeFrom.PowerFactor;
+        return this.toolsSuiteApiService.ToolsSuiteModule.ComputeFrom.PowerFactor;
     }
   }
 
 
   returnDoubleVector(doublesArray: Array<number>) {
-    let doubleVector = new Module.DoubleVector();
+    let doubleVector = new this.toolsSuiteApiService.ToolsSuiteModule.DoubleVector();
     doublesArray.forEach(x => {
       doubleVector.push_back(x);
     });
@@ -424,32 +423,32 @@ export class SuiteApiHelperService {
   getSteamCondition(steamCondition: number) {
     switch (steamCondition) {
       case 0:
-        return Module.SteamConditionType.Superheated;
+        return this.toolsSuiteApiService.ToolsSuiteModule.SteamConditionType.Superheated;
       case 1:
-        return Module.SteamConditionType.Saturated;
+        return this.toolsSuiteApiService.ToolsSuiteModule.SteamConditionType.Saturated;
     }
   }
 
   getPowerFactorModeEnum(mode: number): any {
     switch (mode) {
       case 1:
-        return Module.PowerFactorModeType.ApparentPower_RealPower;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.ApparentPower_RealPower;
       case 2:
-        return Module.PowerFactorModeType.ApparentPower_ReactivePower;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.ApparentPower_ReactivePower;
       case 3:
-        return Module.PowerFactorModeType.ApparentPower_PhaseAngle;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.ApparentPower_PhaseAngle;
       case 4:
-        return Module.PowerFactorModeType.ApparentPower_PowerFactor;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.ApparentPower_PowerFactor;
       case 5:
-        return Module.PowerFactorModeType.RealPower_ReactivePower;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.RealPower_ReactivePower;
       case 6:
-        return Module.PowerFactorModeType.RealPower_PhaseAngle;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.RealPower_PhaseAngle;
       case 7:
-        return Module.PowerFactorModeType.RealPower_PowerFactor;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.RealPower_PowerFactor;
       case 8:
-        return Module.PowerFactorModeType.ReactivePower_PhaseAngle;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.ReactivePower_PhaseAngle;
       case 9:
-        return Module.PowerFactorModeType.ReactivePower_PowerFactor;
+        return this.toolsSuiteApiService.ToolsSuiteModule.PowerFactorModeType.ReactivePower_PowerFactor;
     }
   }
 

--- a/src/app/tools-suite-api/svi-suite-api.service.ts
+++ b/src/app/tools-suite-api/svi-suite-api.service.ts
@@ -1,17 +1,17 @@
 import { Injectable } from '@angular/core';
 import { StatePointAnalysisInput, StatePointAnalysisResults } from '../shared/models/waste-water';
-declare var Module: any;
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SviSuiteApiService {
 
-  constructor() { }
+  constructor(private toolsSuiteApiService: ToolsSuiteApiService) { }
 
   svi(inputs: StatePointAnalysisInput): StatePointAnalysisResults {
     let sviParamEnum = this.getParameter(inputs.sviParameter);
-    let instance = new Module.SludgeVolumeIndex(sviParamEnum, inputs.sviValue, inputs.numberOfClarifiers, inputs.areaOfClarifier, inputs.MLSS, inputs.influentFlow, inputs.rasFlow, inputs.sludgeSettlingVelocity);
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.SludgeVolumeIndex(sviParamEnum, inputs.sviValue, inputs.numberOfClarifiers, inputs.areaOfClarifier, inputs.MLSS, inputs.influentFlow, inputs.rasFlow, inputs.sludgeSettlingVelocity);
     let results = instance.calculate();
     let graphData: Array<Array<number>> = new Array();
     for (let i = 0; i < results.GraphData.size(); i++) {
@@ -41,15 +41,15 @@ export class SviSuiteApiService {
 
   getParameter(sviParameter: number) {
     if (sviParameter == 0) {
-      return Module.SVIParameter.SVISN;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SVIParameter.SVISN;
     } else if (sviParameter == 1) {
-      return Module.SVIParameter.SVIGN;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SVIParameter.SVIGN;
     } else if (sviParameter == 2) {
-      return Module.SVIParameter.SVIGS;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SVIParameter.SVIGS;
     } else if (sviParameter == 3) {
-      return Module.SVIParameter.SVISS;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SVIParameter.SVISS;
     } else if (sviParameter == 4) {
-      return Module.SVIParameter.VoK;
+      return this.toolsSuiteApiService.ToolsSuiteModule.SVIParameter.VoK;
     }
   }
 }

--- a/src/app/tools-suite-api/tools-suite-api.service.ts
+++ b/src/app/tools-suite-api/tools-suite-api.service.ts
@@ -1,11 +1,30 @@
 import { Injectable } from '@angular/core';
+import { SettingsDbService } from '../indexedDb/settings-db.service';
+import { Settings } from '../shared/models/settings';
+import { AtmosphereSpecificHeat, FlueGasMaterial, GasLoadChargeMaterial, LiquidLoadChargeMaterial, SolidLiquidFlueGasMaterial, SolidLoadChargeMaterial, WallLossesSurface } from '../shared/models/materials';
+import { AtmosphereDbService } from '../indexedDb/atmosphere-db.service';
+import { firstValueFrom } from 'rxjs';
+import { FlueGasMaterialDbService } from '../indexedDb/flue-gas-material-db.service';
+import { GasLoadMaterialDbService } from '../indexedDb/gas-load-material-db.service';
+import { LiquidLoadMaterialDbService } from '../indexedDb/liquid-load-material-db.service';
+import { SolidLoadMaterialDbService } from '../indexedDb/solid-load-material-db.service';
+import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
+import { WallLossesSurfaceDbService } from '../indexedDb/wall-losses-surface-db.service';
 
 @Injectable({
     providedIn: 'root'
 })
 export class ToolsSuiteApiService {
     ToolsSuiteModule: any = null;
-    constructor() { }
+    constructor(private settingsDbService: SettingsDbService,
+        private atmosphereDbService: AtmosphereDbService,
+        private flueGasMaterialDbService: FlueGasMaterialDbService,
+        private gasLoadMaterialDbService: GasLoadMaterialDbService,
+        private liquidLoadMaterialDbService: LiquidLoadMaterialDbService,
+        private solidLiquidMaterialDbService: SolidLiquidMaterialDbService,
+        private solidLoadMaterialDbService: SolidLoadMaterialDbService,
+        private wallLossesSurfaceDbService: WallLossesSurfaceDbService
+    ) { }
 
     async initializeModule(): Promise<any> {
         // Dynamically import the Emscripten modularized JS glue code
@@ -15,14 +34,182 @@ export class ToolsSuiteApiService {
             locateFile: (path: string) => `/${path}`
         });
         console.log('=== Tools Suite Module initialized');
-        // var inletTemperature = 100.0
-        // var outletTemperature = 1400.0;
-        // var flowRate = 1200.0;
-        // var correctionFactor = 1.0;
-        // var specificHeat = 0.02;
-
-        // let atmosphere = new this.ToolsSuiteModule.Atmosphere(inletTemperature, outletTemperature, flowRate, correctionFactor, specificHeat);
-        // let heatLoss = atmosphere.getTotalHeat();
+        await this.initializeDefaultDbData();
         return;
     }
+
+    async initializeDefaultDbData() {
+        let globalSettings: Settings = this.settingsDbService.globalSettings;
+        if (!globalSettings.suiteDbItemsInitialized) {
+            console.log('==== Initializing default database items');
+            // Initialize default data here
+            let DefaultData = new this.ToolsSuiteModule.DefaultData();
+            await this.insertAtmosphereData(DefaultData);
+            await this.insertFlueGasMaterials(DefaultData);
+            await this.insertGasLoadMaterials(DefaultData);
+            await this.insertLiquidLoadMaterials(DefaultData);
+            await this.insertSolidLiquidFlueGasMaterials(DefaultData);
+            await this.insertSolidLoadMaterials(DefaultData);
+            await this.insertWallLossSurfaces(DefaultData);
+            DefaultData.delete();
+            globalSettings.suiteDbItemsInitialized = true;
+            this.settingsDbService.globalSettings = await firstValueFrom(this.settingsDbService.updateWithObservable(globalSettings));
+            let updatedSettings: Settings[] = await firstValueFrom(this.settingsDbService.getAllSettings());
+            this.settingsDbService.setAll(updatedSettings);
+        }
+    }
+
+    async insertAtmosphereData(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getAtmosphereSpecificHeat();
+        let defaultMaterials: Array<AtmosphereSpecificHeat> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                substance: wasmClass.getSubstance(),
+                specificHeat: wasmClass.getSpecificHeat(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        suiteDefaultMaterials.delete();
+        await firstValueFrom(this.atmosphereDbService.insertDefaultMaterials(defaultMaterials));
+    }
+
+    async insertFlueGasMaterials(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getGasFlueGasMaterials();
+        let defaultMaterials: Array<FlueGasMaterial> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            //GasComposition
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                substance: wasmClass.getSubstance(),
+                C2H6: wasmClass.getGasByVol("C2H6"),
+                C3H8: wasmClass.getGasByVol("C3H8"),
+                C4H10_CnH2n: wasmClass.getGasByVol("C4H10_CnH2n"),
+                CH4: wasmClass.getGasByVol("CH4"),
+                CO: wasmClass.getGasByVol("CO"),
+                CO2: wasmClass.getGasByVol("CO2"),
+                H2: wasmClass.getGasByVol("H2"),
+                H2O: wasmClass.getGasByVol("H2O"),
+                N2: wasmClass.getGasByVol("N2"),
+                O2: wasmClass.getGasByVol("O2"),
+                SO2: wasmClass.getGasByVol("SO2"),
+                heatingValue: wasmClass.getHeatingValue(),
+                heatingValueVolume: wasmClass.getHeatingValueVolume(),
+                specificGravity: wasmClass.getSpecificGravity(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        suiteDefaultMaterials.delete();
+        await this.flueGasMaterialDbService.insertDefaultMaterials(defaultMaterials);
+    }
+
+    async insertGasLoadMaterials(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getGasLoadChargeMaterials();
+        let defaultMaterials: Array<GasLoadChargeMaterial> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                specificHeatVapor: wasmClass.getSpecificHeatVapor(),
+                substance: wasmClass.getSubstance(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        await this.gasLoadMaterialDbService.insertDefaultMaterials(defaultMaterials);
+    }
+
+    async insertLiquidLoadMaterials(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getLiquidLoadChargeMaterials();
+
+        let defaultMaterials: Array<LiquidLoadChargeMaterial> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                latentHeat: wasmClass.getLatentHeat(),
+                specificHeatLiquid: wasmClass.getSpecificHeatLiquid(),
+                specificHeatVapor: wasmClass.getSpecificHeatVapor(),
+                vaporizationTemperature: wasmClass.getVaporizingTemperature(),
+                substance: wasmClass.getSubstance(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        suiteDefaultMaterials.delete();
+        await this.liquidLoadMaterialDbService.insertDefaultMaterials(defaultMaterials);
+    }
+
+    async insertSolidLiquidFlueGasMaterials(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getSolidLiquidFlueGasMaterials();
+        let defaultMaterials: Array<SolidLiquidFlueGasMaterial> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            //GasComposition
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                substance: wasmClass.getSubstance(),
+                carbon: wasmClass.getCarbon(),
+                hydrogen: wasmClass.getHydrogen(),
+                inertAsh: wasmClass.getInertAsh(),
+                moisture: wasmClass.getMoisture(),
+                nitrogen: wasmClass.getNitrogen(),
+                o2: wasmClass.getO2(),
+                sulphur: wasmClass.getSulphur(),
+                heatingValue: wasmClass.getHeatingValueFuel(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        suiteDefaultMaterials.delete();
+        await this.solidLiquidMaterialDbService.insertDefaultMaterials(defaultMaterials);
+    }
+
+    async insertSolidLoadMaterials(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getSolidLoadChargeMaterials();
+
+        let defaultMaterials: Array<SolidLoadChargeMaterial> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                latentHeat: wasmClass.getLatentHeat(),
+                meltingPoint: wasmClass.getMeltingPoint(),
+                specificHeatLiquid: wasmClass.getSpecificHeatLiquid(),
+                specificHeatSolid: wasmClass.getSpecificHeatSolid(),
+                substance: wasmClass.getSubstance(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        suiteDefaultMaterials.delete();
+        await this.solidLoadMaterialDbService.insertDefaultMaterials(defaultMaterials);
+    }
+
+    async insertWallLossSurfaces(DefaultData: any) {
+        let suiteDefaultMaterials = DefaultData.getWallLossesSurface();
+
+        let defaultMaterials: Array<WallLossesSurface> = [];
+        for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
+            let wasmClass = suiteDefaultMaterials.get(i);
+            defaultMaterials.push({
+                surface: wasmClass.getSurface(),
+                conditionFactor: wasmClass.getConditionFactor(),
+                isDefault: true
+            });
+            wasmClass.delete();
+        }
+        suiteDefaultMaterials.delete();
+        await this.wallLossesSurfaceDbService.insertDefaultMaterials(defaultMaterials);
+    }
+
+    //quick test module works
+    // testModule() {
+    //     var inletTemperature = 100.0
+    //     var outletTemperature = 1400.0;
+    //     var flowRate = 1200.0;
+    //     var correctionFactor = 1.0;
+    //     var specificHeat = 0.02;
+
+    //     let atmosphere = new this.ToolsSuiteModule.Atmosphere(inletTemperature, outletTemperature, flowRate, correctionFactor, specificHeat);
+    //     let heatLoss = atmosphere.getTotalHeat();
+    // }
 }

--- a/src/app/tools-suite-api/tools-suite-api.service.ts
+++ b/src/app/tools-suite-api/tools-suite-api.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ToolsSuiteApiService {
+    ToolsSuiteModule: any = null;
+    constructor() { }
+
+    async initializeModule(): Promise<any> {
+        // Dynamically import the Emscripten modularized JS glue code
+        const moduleFactory = await import('measur-tools-suite/bin/client.js');
+        // Initialize the module, specifying where to find the WASM file
+        this.ToolsSuiteModule = await moduleFactory.default({
+            locateFile: (path: string) => `/${path}`
+        });
+        console.log('=== Tools Suite Module initialized');
+        // var inletTemperature = 100.0
+        // var outletTemperature = 1400.0;
+        // var flowRate = 1200.0;
+        // var correctionFactor = 1.0;
+        // var specificHeat = 0.02;
+
+        // let atmosphere = new this.ToolsSuiteModule.Atmosphere(inletTemperature, outletTemperature, flowRate, correctionFactor, specificHeat);
+        // let heatLoss = atmosphere.getTotalHeat();
+        return;
+    }
+}

--- a/src/app/tools-suite-api/tools-suite-api.service.ts
+++ b/src/app/tools-suite-api/tools-suite-api.service.ts
@@ -34,7 +34,6 @@ export class ToolsSuiteApiService {
             locateFile: (path: string) => `/${path}`
         });
         console.log('=== Tools Suite Module initialized');
-        await this.initializeDefaultDbData();
         return;
     }
 
@@ -59,7 +58,7 @@ export class ToolsSuiteApiService {
         }
     }
 
-    async insertAtmosphereData(DefaultData: any) {
+    private async insertAtmosphereData(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getAtmosphereSpecificHeat();
         let defaultMaterials: Array<AtmosphereSpecificHeat> = [];
         for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
@@ -75,7 +74,7 @@ export class ToolsSuiteApiService {
         await firstValueFrom(this.atmosphereDbService.insertDefaultMaterials(defaultMaterials));
     }
 
-    async insertFlueGasMaterials(DefaultData: any) {
+    private async insertFlueGasMaterials(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getGasFlueGasMaterials();
         let defaultMaterials: Array<FlueGasMaterial> = [];
         for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
@@ -105,7 +104,7 @@ export class ToolsSuiteApiService {
         await this.flueGasMaterialDbService.insertDefaultMaterials(defaultMaterials);
     }
 
-    async insertGasLoadMaterials(DefaultData: any) {
+    private async insertGasLoadMaterials(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getGasLoadChargeMaterials();
         let defaultMaterials: Array<GasLoadChargeMaterial> = [];
         for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
@@ -120,7 +119,7 @@ export class ToolsSuiteApiService {
         await this.gasLoadMaterialDbService.insertDefaultMaterials(defaultMaterials);
     }
 
-    async insertLiquidLoadMaterials(DefaultData: any) {
+    private async insertLiquidLoadMaterials(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getLiquidLoadChargeMaterials();
 
         let defaultMaterials: Array<LiquidLoadChargeMaterial> = [];
@@ -140,7 +139,7 @@ export class ToolsSuiteApiService {
         await this.liquidLoadMaterialDbService.insertDefaultMaterials(defaultMaterials);
     }
 
-    async insertSolidLiquidFlueGasMaterials(DefaultData: any) {
+    private async insertSolidLiquidFlueGasMaterials(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getSolidLiquidFlueGasMaterials();
         let defaultMaterials: Array<SolidLiquidFlueGasMaterial> = [];
         for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
@@ -164,7 +163,7 @@ export class ToolsSuiteApiService {
         await this.solidLiquidMaterialDbService.insertDefaultMaterials(defaultMaterials);
     }
 
-    async insertSolidLoadMaterials(DefaultData: any) {
+    private async insertSolidLoadMaterials(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getSolidLoadChargeMaterials();
 
         let defaultMaterials: Array<SolidLoadChargeMaterial> = [];
@@ -184,15 +183,15 @@ export class ToolsSuiteApiService {
         await this.solidLoadMaterialDbService.insertDefaultMaterials(defaultMaterials);
     }
 
-    async insertWallLossSurfaces(DefaultData: any) {
+    private async insertWallLossSurfaces(DefaultData: any) {
         let suiteDefaultMaterials = DefaultData.getWallLossesSurface();
 
         let defaultMaterials: Array<WallLossesSurface> = [];
         for (let i = 0; i < suiteDefaultMaterials.size(); i++) {
             let wasmClass = suiteDefaultMaterials.get(i);
             defaultMaterials.push({
-                surface: wasmClass.getSurface(),
-                conditionFactor: wasmClass.getConditionFactor(),
+                surface: wasmClass.surfaceDescription(),
+                conditionFactor: wasmClass.shapeFactor(),
                 isDefault: true
             });
             wasmClass.delete();
@@ -202,7 +201,7 @@ export class ToolsSuiteApiService {
     }
 
     //quick test module works
-    // testModule() {
+    // private testModule() {
     //     var inletTemperature = 100.0
     //     var outletTemperature = 1400.0;
     //     var flowRate = 1200.0;

--- a/src/app/tools-suite-api/waste-water-suite-api.service.ts
+++ b/src/app/tools-suite-api/waste-water-suite-api.service.ts
@@ -1,17 +1,16 @@
 import { Injectable } from '@angular/core';
 import { WasteWaterResults, WasteWaterTreatmentInputData } from '../shared/models/waste-water';
 import { SuiteApiHelperService } from './suite-api-helper.service';
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
-declare var Module: any;
 @Injectable()
 export class WasteWaterSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
-  
+  constructor(private suiteApiHelperService: SuiteApiHelperService, private toolsSuiteApiService: ToolsSuiteApiService) { }
   wasteWaterTreatment(inputData: WasteWaterTreatmentInputData, hasGivenSRT: boolean = false): WasteWaterResults{
     // null on new assessment?
     inputData.DefinedSRT = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.DefinedSRT);
-    let WasteWaterTreatmentInstance = new Module.WasteWater_Treatment(
+    let WasteWaterTreatmentInstance = new this.toolsSuiteApiService.ToolsSuiteModule.WasteWater_Treatment(
       inputData.Temperature,
       inputData.So,
       inputData.Volume,

--- a/src/app/tools-suite-api/water-suite-api.service.ts
+++ b/src/app/tools-suite-api/water-suite-api.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 import { SuiteApiHelperService } from './suite-api-helper.service';
 import { copyObject } from '../shared/helperFunctions';
 import { HeatEnergy, HeatEnergyResults, MotorEnergy, MotorEnergyResults } from 'process-flow-lib';
-
-declare var Module: any;
+import { ToolsSuiteApiService } from './tools-suite-api.service';
 
 /**
  * Water system estimation methods are defined in shared-process-flow-logic.ts
@@ -11,11 +10,13 @@ declare var Module: any;
 @Injectable()
 export class WaterSuiteApiService {
 
-  constructor(private suiteApiHelperService: SuiteApiHelperService) { }
+  constructor(private suiteApiHelperService: SuiteApiHelperService,
+    private toolsSuiteApiService: ToolsSuiteApiService
+  ) { }
 
   calculateHeatEnergy(inputData: HeatEnergy): HeatEnergyResults {
     inputData = copyObject(inputData)
-    let instance = new Module.WaterAssessment();
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.WaterAssessment();
     inputData.incomingTemp = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.incomingTemp); 
     inputData.outgoingTemp = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.outgoingTemp); 
     inputData.heaterEfficiency = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.heaterEfficiency); 
@@ -37,7 +38,7 @@ export class WaterSuiteApiService {
 
   calculateMotorEnergy(inputData: MotorEnergy): MotorEnergyResults {
     inputData = copyObject(inputData)
-    let instance = new Module.WaterAssessment();
+    let instance = new this.toolsSuiteApiService.ToolsSuiteModule.WaterAssessment();
     inputData.numberUnits = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.numberUnits);
     inputData.hoursPerYear = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.hoursPerYear);
     inputData.ratedPower = this.suiteApiHelperService.convertNullInputValueForObjectConstructor(inputData.ratedPower);


### PR DESCRIPTION
connects #7759 
This pull request refactors how the MEASUR Tools Suite WebAssembly (WASM) module is loaded and accessed throughout the application. The main change is the removal of direct global `Module` references in favor of a centralized `ToolsSuiteApiService`, which now handles module initialization and access. This improves maintainability, testability, and future extensibility. Additionally, the WASM module initialization logic is moved out of the global app initialization flow and into the Angular service layer.

Key changes include:

**WASM Module Initialization and Access Refactor:**

* Removed all direct usages of the global `Module` object from various services and files, replacing them with references to `ToolsSuiteApiService.ToolsSuiteModule`. This ensures all WASM interactions are routed through a single service, improving encapsulation and maintainability. [[1]](diffhunk://#diff-3c2cac287ca91e39ea2439bea6eeef7cadce575e3c011e5ccfd692a72996f411L6-R20) [[2]](diffhunk://#diff-77806c1de5427167dc864bc3a658995b062b98d780054b297e263a4e8c402603L6-R20) [[3]](diffhunk://#diff-f1e67ef4f3f3d72802f73c15d8a28918518e0728fcd040d0bc8a49fa0be616d7L6-R21) [[4]](diffhunk://#diff-25932c14359472abdb21a8aef409a988668532c07e57df66fcf8026953b54027L6-R20) [[5]](diffhunk://#diff-76c6bad2a2dd4231c1af2eb9474d2b054b3069c1d17884da93fa1c75fb8e83adL6-R18) [[6]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffL6-R20) [[7]](diffhunk://#diff-5d15dcb000a20939124cc8a88d31aefe1bfd261aaa95d9fddf161b1cde064814R6-R22) [[8]](diffhunk://#diff-037dab787bf16982c15f38ebd0f2f188dfaf47638f549d1e90ec754403a1f9d1L1-L2) [[9]](diffhunk://#diff-56797221b1245d7011435e364c90e400732d774504fd5ad4548894b9a0cb6bc5R4-R15) [[10]](diffhunk://#diff-56797221b1245d7011435e364c90e400732d774504fd5ad4548894b9a0cb6bc5L35-R47) [[11]](diffhunk://#diff-56797221b1245d7011435e364c90e400732d774504fd5ad4548894b9a0cb6bc5L66-R67) [[12]](diffhunk://#diff-56797221b1245d7011435e364c90e400732d774504fd5ad4548894b9a0cb6bc5L80-R81)

* Updated the application initialization (`AppComponent` and `AppModule`) to call `ToolsSuiteApiService.initializeModule()` during `ngOnInit`, removing the previous script injection and global variable setup. This change centralizes and standardizes WASM module loading. [[1]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR11) [[2]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deL32-R34) [[3]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR103) [[4]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR117-R121) [[5]](diffhunk://#diff-502d295b435b10ba99f5377504ca51149312e3cbebbbaa78ac5d925cb04cbfb0L42-L65) [[6]](diffhunk://#diff-502d295b435b10ba99f5377504ca51149312e3cbebbbaa78ac5d925cb04cbfb0L80-L108) [[7]](diffhunk://#diff-502d295b435b10ba99f5377504ca51149312e3cbebbbaa78ac5d925cb04cbfb0L151-R98)

**Dependency and Version Updates:**

* Upgraded the `measur-tools-suite` npm package from version `1.0.11-beta.44` to `1.0.11-beta.68`, likely bringing in bug fixes and new features from the WASM module.

**Service Injection and Usage:**

* Modified constructors of all affected database and calculation services to inject `ToolsSuiteApiService`, ensuring consistent access to the WASM module. [[1]](diffhunk://#diff-3c2cac287ca91e39ea2439bea6eeef7cadce575e3c011e5ccfd692a72996f411L6-R20) [[2]](diffhunk://#diff-77806c1de5427167dc864bc3a658995b062b98d780054b297e263a4e8c402603L6-R20) [[3]](diffhunk://#diff-f1e67ef4f3f3d72802f73c15d8a28918518e0728fcd040d0bc8a49fa0be616d7L6-R21) [[4]](diffhunk://#diff-25932c14359472abdb21a8aef409a988668532c07e57df66fcf8026953b54027L6-R20) [[5]](diffhunk://#diff-76c6bad2a2dd4231c1af2eb9474d2b054b3069c1d17884da93fa1c75fb8e83adL6-R18) [[6]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffL6-R20) [[7]](diffhunk://#diff-5d15dcb000a20939124cc8a88d31aefe1bfd261aaa95d9fddf161b1cde064814R6-R22) [[8]](diffhunk://#diff-56797221b1245d7011435e364c90e400732d774504fd5ad4548894b9a0cb6bc5R4-R15)
