### PR TITLE
Checkbox accessibility / Pointer hover #6544

### DIFF
--- a/src/assets/styles/forms.css
+++ b/src/assets/styles/forms.css
@@ -22,3 +22,7 @@
     padding-top: 0px;
     padding-bottom: 0px;
 }
+
+input[type="checkbox"]:hover {
+  cursor: pointer;
+}


### PR DESCRIPTION
#6544 Checkbox accessibility / Pointer hover 

- Applied an override to one of the existing base style sheets(Forms) to add cursor: pointer to all checkboxes. 
- This can be overwritten by MaterialUI or Bootstrap if !important is used or if they use specific classes closer to the checkbox instances.