### PR TITLE
Issue 7876 – Preserve manual performance points when using pressure-reduction EEM

### DIFF
--- a/src/app/compressed-air-assessment/compressed-air-assessment-results.service.ts
+++ b/src/app/compressed-air-assessment/compressed-air-assessment-results.service.ts
@@ -717,6 +717,9 @@ export class CompressedAirAssessmentResultsService {
       }
     });
     selectedDayTypeSummary = this.getProfileSummaryDataAverages(selectedDayTypeSummary);
+    // Include flow reallocation in baseline for optimization
+    let totals = this.calculateProfileSummaryTotals(inventoryItems, dayType, selectedDayTypeSummary, compressedAirAssessment.systemProfile.systemProfileSetup.dataInterval);
+    selectedDayTypeSummary = this.reallocateFlow(dayType, settings, selectedDayTypeSummary, inventoryItems, 0, totals, compressedAirAssessment.systemInformation.atmosphericPressure, compressedAirAssessment.systemInformation.totalAirStorage, compressedAirAssessment.systemInformation);
     return selectedDayTypeSummary;
   }
 
@@ -1259,7 +1262,10 @@ export class CompressedAirAssessmentResultsService {
       compressor.performancePoints.blowoff.isDefaultAirFlow = true;
       compressor.performancePoints.blowoff.isDefaultPressure = true;
       compressor.performancePoints.blowoff.isDefaultPower = true;
-      compressor.performancePoints = this.performancePointCalculationsService.updatePerformancePoints(compressor, atmosphericPressure, settings);
+      // Only recalculate performance points if there is actual pressure reduction to avoid unnecessary changes
+      if (reduceSystemAirPressure.averageSystemPressureReduction > 0) {
+        compressor.performancePoints = this.performancePointCalculationsService.updatePerformancePoints(compressor, atmosphericPressure, settings);
+      }
     });
     return adjustedCompressors;
   }

--- a/src/app/compressed-air-assessment/inventory/performance-points/calculations/performance-point-calculations.service.ts
+++ b/src/app/compressed-air-assessment/inventory/performance-points/calculations/performance-point-calculations.service.ts
@@ -18,6 +18,24 @@ export class PerformancePointCalculationsService {
     private blowoffCalculationsService: BlowoffCalculationsService, private unloadPointCalculationsService: UnloadPointCalculationsService) { }
 
   updatePerformancePoints(selectedCompressor: CompressorInventoryItem, atmosphericPressure: number, settings: Settings): PerformancePoints {
+    // Skip recalculation if all performance points are manually set (non-default)
+    if (!selectedCompressor.performancePoints.fullLoad.isDefaultPressure &&
+        !selectedCompressor.performancePoints.fullLoad.isDefaultAirFlow &&
+        !selectedCompressor.performancePoints.fullLoad.isDefaultPower &&
+        !selectedCompressor.performancePoints.maxFullFlow.isDefaultPressure &&
+        !selectedCompressor.performancePoints.maxFullFlow.isDefaultAirFlow &&
+        !selectedCompressor.performancePoints.maxFullFlow.isDefaultPower &&
+        !selectedCompressor.performancePoints.noLoad.isDefaultPressure &&
+        !selectedCompressor.performancePoints.noLoad.isDefaultAirFlow &&
+        !selectedCompressor.performancePoints.noLoad.isDefaultPower &&
+        !selectedCompressor.performancePoints.blowoff.isDefaultPressure &&
+        !selectedCompressor.performancePoints.blowoff.isDefaultAirFlow &&
+        !selectedCompressor.performancePoints.blowoff.isDefaultPower &&
+        !selectedCompressor.performancePoints.unloadPoint.isDefaultPressure &&
+        !selectedCompressor.performancePoints.unloadPoint.isDefaultAirFlow &&
+        !selectedCompressor.performancePoints.unloadPoint.isDefaultPower) {
+      return selectedCompressor.performancePoints;
+    }
     selectedCompressor.performancePoints = this.setPerformancePoints(selectedCompressor, atmosphericPressure, settings);
     return selectedCompressor.performancePoints;
   }


### PR DESCRIPTION
When “Reduce System Pressure” or “Adjust Cascading Setpoints” is toggled, 
`performancePointUpdateNeeded` forces every compressor to rebuild its performance 
curve, overwriting user-edited points with defaults, even when ΔP = 0 psig. 

The fix:
* Keeps manual performance points intact when the pressure reduction is 0.
* Restores correct savings calculations (fixes negative savings bug).

Fixes #7876