### PR TITLE
Restore schematics to NG 19 configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -207,25 +207,6 @@
     },
     "@schematics/angular:directive": {
       "prefix": "app",
-      "type": "directive"
-    },
-    "@schematics/angular:service": {
-      "type": "service"
-    },
-    "@schematics/angular:guard": {
-      "typeSeparator": "."
-    },
-    "@schematics/angular:interceptor": {
-      "typeSeparator": "."
-    },
-    "@schematics/angular:module": {
-      "typeSeparator": "."
-    },
-    "@schematics/angular:pipe": {
-      "typeSeparator": "."
-    },
-    "@schematics/angular:resolver": {
-      "typeSeparator": "."
     }
   },
   "cli": {


### PR DESCRIPTION
This is needed to perform some angular cli functions successfully. It was missed in the rollback from ng 20 to ng 19 #7919