### PR TITLE
Documentation updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic-next.md
+++ b/.github/ISSUE_TEMPLATE/epic-next.md
@@ -1,0 +1,9 @@
+---
+name: Epic Next
+about: Represents a grouping of issues ready for the next initiative
+title: '[MEASUR <FEATURE OR MODULE> NEXT]:'
+labels: 'Epic'
+assignees: ''
+
+---
+

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,9 @@
+---
+name: Epic  
+about: Represents a container grouping of issues
+title: '[MEASUR EPIC]:'
+labels: 'Epic'
+assignees: ''
+
+---
+

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,19 @@
+---
+name: Release Epic
+about: Represents next release group
+title: '[MEASUR NEXT]: vx.x.x'
+labels: 'Epic'
+
+---
+
+
+## Release Checklist
+- [ ] Requires a suite release
+
+**Overview and Notes**
+Context related to release, dependencies, blockers, etc
+
+**Events, In-plants, and Trainings**
+Events and dates where requested features will be used 
+
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,45 +2,56 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at measur-help@ornl.gov. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [rootrm@ornl.gov](mailto:rootrm@ornl.gov).
+All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction
+2. Warning
+3. Temporary Ban
+4. Permanent Ban
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing to MEASUR (AMO-Tools-Desktop)
 
-We would love for you to contribute to MEASUR (AMO-Tools-Desktop) and help make it even better than it is today!
-
-Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the product team as well as the developers managing and developing this open source projects. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
-
 ## Quicklinks
 
 * [Code of Conduct](#code-of-conduct)
 * [Getting Started](#getting-started)
     * [Issues](#issues)
+    * [Branching Conventions](#issues)
     * [Pull Requests](#pull-requests)
+* [Coding Style](#coding-style)
+* [Release Process](#release-process)
+* [Versioning](#versioning)
 * [Getting Help](#getting-help)
 
 ## Code of Conduct
@@ -17,6 +17,11 @@ Reading and following these guidelines will help us make the contribution proces
 We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Getting Started
+
+We would love for you to contribute to MEASUR (AMO-Tools-Desktop) and help make it even better than it is today!
+
+Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the product team as well as the developers managing and developing this open source projects. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
+
 
 Contributions are made to this repo via Issues and Pull Requests (PRs).
 
@@ -39,6 +44,15 @@ Please do not add information or comments to existing issues other than those re
 If you encounter a bug or have reproduction information related to an existing issue, please contact [measur-help@ornl.gov](measur-help@ornl.gov).
 
 
+### Branching Conventions
+
+This repository uses the following branch conventions:
+
+- master: Stable release version
+- develop: Development branch which contains the newest features and issues will be tracked in the latest release milestone. Code may be unstable as issues work through the QA phase.
+- issue-xxx[-description]: Feature or bug fix branch from develop, should reference a github issue number. You may provide an optional short description in the branch name.
+- fix-xxx[-description]: Bug fix branch from develop, should reference a github issue number. You may provide an optional short description in the branch name.
+- epic-xxx[-description]: In some cases, a large feature will be broken down into a subset of issues. Will the large feature is developed, the small issues can't be added to develop without the totality of the epic being finished. Use an epic branch to create incremental pull requests of smaller issues into the larger epic feature.
 
 ### Pull Requests
 
@@ -53,6 +67,44 @@ PRs should:
     - Contributors should do their best to follow the conventions of modern Angular, React, Typescript, and Javascript versions.
     - A project code and style conventions document is in progress. Maintainers acknowledge that legacy portions of the repository may not follow best practices for code styling conventions. 
 
+#### Please follow the "fork-and-pull" Git workflow
+
+Fork and pull process for contributors:
+
+1. Fork the repository to your own Github account
+2. Clone the project to your machine
+3. Create a branch locally with a succinct but descriptive name
+4. Commit changes to the branch
+5. Following any formatting and testing guidelines specific to this repo
+6. Push changes to your fork
+7. Open a PR in our repository and follow the PR template so that we can efficiently review the changes.
+
+
+#### More Information:
+[Git Hub - Creating a pull request from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+[Atlassian - Forking Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow).
+
+## Coding Style
+
+The team is working on a coding style document. Contributors should do their best to follow the conventions of modern Angular, React, Typescript, and Javascript versions.
+
+## Release Process
+
+Releases are managed by the core development team. An "Epic" issue and a Milestone are used to track the issues going into the next release of MEASUR. Our QA team will test issues via the project board. When QA has been completed on the full set of "Epic" issues develop is merged into main and a release will be drafted by the CI system. Release notes are compiled from the changelog entries in PRs. Version numbers follow semantic versioning. Only core maintainers should publish releases.
+
+## Versioning
+
+MEASUR uses [semantic verisoning 2.0.0](https://semver.org/spec/v2.0.0.html). An example version specification for MEASUR looks like `0.0.1-alpha`. Core developers will be responsible for version numbers and releases.
+
+The following is reproduced from semver.org:
+```
+Given a version number MAJOR.MINOR.PATCH, increment the:
+
+MAJOR version when you make incompatible API changes
+MINOR version when you add functionality in a backward compatible manner
+PATCH version when you make backward compatible bug fixes
+Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+```
 
 ## Getting Help
 The MEASUR development team cannot provide technical guidance beyond PR review


### PR DESCRIPTION
Adding some issue templates to reduce human error on titles. 'Epic Next' was discussed with Kristina and Tom. Allows us the distinction between epic containers that group ALL of our TH issues for example, and an epic grouping that is actually ready for the roadmap