### PR TITLE
ci/bump-macos-14 - Update release_desktop bundle_macos job to MacOS 14 runner

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -58,7 +58,7 @@ jobs:
 
   bundle_macos:
     if: github.ref_name == 'master'
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build]
     steps:
       - name: Checkout
@@ -262,7 +262,7 @@ jobs:
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-22.04
-    needs: [build,bundle_macos,bundle_linux,sign_win]
+    needs: [build, bundle_macos, bundle_linux, sign_win]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:


### PR DESCRIPTION
Changes:
  - Bump bundle_macos 'runs_on' target to MacOS 14 as 13 is deprecated. No other changes required for this bundle and signing process
  
Note: Autoformatter inserted spaces in the `needs` property for release job. Not an issue.