### PR TITLE
ci/patch-qa-workflow - Separate QA workflows from main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  qa:
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/release_qa.yml
-
-  qa2:
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/release_qa2.yml
-
   web:
     if: github.ref_name == 'develop' || github.ref_name == 'master'
     uses: ./.github/workflows/release_web.yml

--- a/.github/workflows/release_qa.yml
+++ b/.github/workflows/release_qa.yml
@@ -1,7 +1,7 @@
 name: "Release: QA"
 
 on:
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   call_build:

--- a/.github/workflows/release_qa2.yml
+++ b/.github/workflows/release_qa2.yml
@@ -1,7 +1,7 @@
 name: "Release: QA 2"
 
 on:
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   call_build:


### PR DESCRIPTION
### Changes
  - Remove qa functionality from main workflow
  - Add separate workflow dispatch configurations for release_qa, release_qa2 to run qa workflows separately from main workflow
  
### Notes
The above changes will change the workflow for deployment of branches to QA environments to separate workflows in the Actions page - "Release: QA" and "Release: QA 2" will run separately going forward, as opposed to running the "CI/CD" workflow on a feature branch to deploy to QA.