### PR TITLE
8134 - Adding Custom Email Attachment Name

### DIFF
--- a/src/app/shared/email-measur-data/email-measur-data.component.html
+++ b/src/app/shared/email-measur-data/email-measur-data.component.html
@@ -29,6 +29,19 @@
       </div>
     </div>
 
+    <div class="form-group d-flex flex-column w-100 mb-3">
+      <label class="bold mr-2 w-25" for="emailAttachmentName">Attachment Name</label>
+      <div class="input-group">
+        <input type="text" formControlName="emailAttachmentName" class="form-control" (input)="save()" id="emailAttachmentName" />
+      </div>
+      <div class="input-group">
+        <span class="alert-danger w-100 pull-right small py-1 px-2"
+          *ngIf="emailDataForm.controls.emailAttachmentName.invalid && !emailDataForm.controls.emailAttachmentName.pristine">
+          <span *ngIf="emailDataForm.controls.emailAttachmentName.errors.required">Email is required</span>
+        </span>
+      </div>
+    </div>
+
   </form>
 </ng-container>
 

--- a/src/app/shared/email-measur-data/email-measur-data.component.ts
+++ b/src/app/shared/email-measur-data/email-measur-data.component.ts
@@ -25,7 +25,8 @@ export class EmailMeasurDataComponent {
   ngOnInit() {
     this.emailDataForm = this.fb.group({
       emailTo: ['', [Validators.required, Validators.email]],
-      emailSender: ['', [Validators.email]]
+      emailSender: ['', [Validators.email]],
+      emailAttachmentName: [this.emailMeasurDataService.measurItemAttachment.itemName, Validators.required]
     });
 
     this.emailSentStatusSubscription = this.emailMeasurDataService.emailSentStatus.subscribe(sentStatus => {

--- a/src/app/shared/email-measur-data/email-measur-data.service.ts
+++ b/src/app/shared/email-measur-data/email-measur-data.service.ts
@@ -37,7 +37,6 @@ export class EmailMeasurDataService {
   }
 
   setEmailData(measurEmailForm: FormGroup) {
-
     if (measurEmailForm.valid && this.measurItemAttachment) {
       let attachmentExportData: ImportExportData | LogToolDbData | ImportExportOpportunities;
       if (this.measurItemAttachment.itemType === 'assessment') {
@@ -56,7 +55,7 @@ export class EmailMeasurDataService {
       this.measurEmailData = {
         emailTo: measurEmailForm.controls.emailTo.value,
         emailSender: measurEmailForm.controls.emailSender.value,
-        fileName: this.measurItemAttachment.itemName,
+        fileName: measurEmailForm.controls.emailAttachmentName.value,
         attachment: attachmentExportData,
         isProduction: environment.production
       }


### PR DESCRIPTION
#8134 
- Added additional field on the Share Data for Attachment Name. Auto populates to current Email attachment names that are statically provided.
- Changing the field updates the file name for only the specific instance.
- Validation as a Required Field.