### PR TITLE
8165 - Change kJ to kLb

### DIFF
--- a/src/app/calculator/steam/steam-reduction/steam-reduction.service.ts
+++ b/src/app/calculator/steam/steam-reduction/steam-reduction.service.ts
@@ -393,7 +393,7 @@ export class SteamReductionService {
   convertMetricInput(input: SteamReductionData, settings: Settings): SteamReductionData {
     let utilityCostConversionHelper: number = 0;
     if(input.utilityType == 0){
-      utilityCostConversionHelper = this.convertUnitsService.value(1).from('tonne').to('kJ');
+      utilityCostConversionHelper = this.convertUnitsService.value(1).from('tonne').to('klb');
     } else if(input.utilityType == 1 || input.utilityType == 2 ){
       utilityCostConversionHelper = this.convertUnitsService.value(1).from('GJ').to('kJ');
     }


### PR DESCRIPTION
The issue is with converting from mass to energy. It is not supposed to be done, so the metric to convert TO is changed from kj to klb, which is now mass to mass.

The mathematics must be ran to see if the helpers have successfully converted the results correctly between metric and imperial.