### PR TITLE
chore: move egrid intialization logic to startup

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { UpdateApplicationService } from './shared/update-application/update-app
 import { MeasurAppError } from './shared/errors/errors';
 import { ToolsSuiteApiService } from './tools-suite-api/tools-suite-api.service';
 import { CoreService } from './core/core.service';
+import { EGridService } from './shared/helper-services/e-grid.service';
 // declare ga as a function to access the JS code in TS
 declare let gtag: Function;
 
@@ -32,7 +33,8 @@ export class AppComponent {
     private appErrorService: AppErrorService,
     private router: Router,
     private toolsSuiteApiService: ToolsSuiteApiService,
-    private coreService: CoreService) {
+    private coreService: CoreService,
+    private eGridService: EGridService) {
 
     if (environment.production) {
       // analytics handled through gatg() automatically manages sessions, visits, clicks, etc
@@ -117,6 +119,7 @@ export class AppComponent {
 
   async initializeToolsSuiteApi(){
     await this.toolsSuiteApiService.initializeModule();
+    await this.eGridService.processCSVData();
     this.coreService.initializedToolsSuiteModule.next(true);
   }
 

--- a/src/app/calculator/utilities/co2-savings/co2-savings.component.ts
+++ b/src/app/calculator/utilities/co2-savings/co2-savings.component.ts
@@ -1,9 +1,8 @@
-import { Component, OnInit, ViewChild, HostListener, ElementRef, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, ViewChild, HostListener, ElementRef } from '@angular/core';
 import { Settings } from '../../../shared/models/settings';
 import { SettingsDbService } from '../../../indexedDb/settings-db.service';
 import { Co2SavingsService, Co2SavingsData } from './co2-savings.service';
 import * as _ from 'lodash';
-import { EGridService } from '../../../shared/helper-services/e-grid.service';
 import { AnalyticsService } from '../../../shared/analytics/analytics.service';
 
 @Component({
@@ -47,13 +46,11 @@ export class Co2SavingsComponent implements OnInit {
   smallScreenTab: string = 'baseline';
 
   constructor(private settingsDbService: SettingsDbService,
-    private egridService: EGridService,
     private co2SavingsService: Co2SavingsService,
     private analyticsService: AnalyticsService) { }
 
   ngOnInit() {
     this.analyticsService.sendEvent('calculator-UTIL-co2-savings');
-    this.egridService.getAllSubRegions();
     this.settings = this.settingsDbService.globalSettings;
     this.co2SavingsService.setEmissionsUnit(this.settings);
     if (this.settingsDbService.globalSettings.defaultPanelTab) {

--- a/src/app/compressed-air-assessment/compressed-air-assessment.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-assessment.component.ts
@@ -5,7 +5,6 @@ import { AssessmentService } from '../dashboard/assessment.service';
 import { AssessmentDbService } from '../indexedDb/assessment-db.service';
  
 import { SettingsDbService } from '../indexedDb/settings-db.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import { AirPropertiesCsvService } from '../shared/helper-services/air-properties-csv.service';
 import { Assessment } from '../shared/models/assessment';
 import { CompressedAirAssessment } from '../shared/models/compressed-air-assessment';
@@ -78,7 +77,6 @@ export class CompressedAirAssessmentComponent implements OnInit {
     private settingsDbService: SettingsDbService, 
     private compressedAirAssessmentService: CompressedAirAssessmentService,  
     private dayTypeService: DayTypeService,
-    private egridService: EGridService,
     private endUseService: EndUsesService,
     private genericCompressorDbService: GenericCompressorDbService, private inventoryService: InventoryService,
     private exploreOpportunitiesService: ExploreOpportunitiesService, private assessmentService: AssessmentService,
@@ -89,7 +87,6 @@ export class CompressedAirAssessmentComponent implements OnInit {
 
   ngOnInit() {
     this.analyticsService.sendEvent('view-compressed-air-assessment', undefined);
-    this.egridService.getAllSubRegions();
     this.activatedRoute.params.subscribe(params => {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']));
       let settings: Settings = this.settingsDbService.getByAssessmentId(this.assessment, true);

--- a/src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.html
+++ b/src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.html
@@ -2,7 +2,7 @@
     <div class="small-tab-select nav-pills nav-fill" #smallTabSelect>
         <div class="nav-item" (click)="setSmallScreenTab('form')"
             [ngClass]="{'small-screen-active': smallScreenTab === 'form'}">
-            <a class="nav-link" *ngIf="setupTab == 'plant-setup' && initPlantSetup">Plant Setup</a>
+            <a class="nav-link" *ngIf="setupTab == 'plant-setup'">Plant Setup</a>
             <a class="nav-link" *ngIf="setupTab == 'system-setup'">System Setup</a>
             <a class="nav-link" *ngIf="setupTab == 'compressor-properties'">Compressed Air Properties</a>
             <a class="nav-link" *ngIf="setupTab == 'compressed-air-catalog'">Catalog</a>
@@ -18,7 +18,7 @@
         <div class="assessment-panel-container lookup-form modification scroll-item"
             [ngClass]="{'modal-open': isModalOpen == true, 'small-screen-tab': smallScreenTab === 'form'}"
             [ngStyle]="{'height.px': containerHeight}">
-            <app-plant-setup *ngIf="setupTab == 'plant-setup' && initPlantSetup"></app-plant-setup>
+            <app-plant-setup *ngIf="setupTab == 'plant-setup'"></app-plant-setup>
             <app-system-setup *ngIf="setupTab == 'system-setup'"></app-system-setup>
             <app-compressed-air-properties *ngIf="setupTab == 'compressor-properties'"></app-compressed-air-properties>
             <app-compressed-air-catalog *ngIf="setupTab == 'compressed-air-catalog'"></app-compressed-air-catalog>

--- a/src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.ts
+++ b/src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { CompressedAirInventoryService } from '../compressed-air-inventory.service';
-import { EGridService } from '../../shared/helper-services/e-grid.service';
 import { SettingsDbService } from '../../indexedDb/settings-db.service';
 import { Subscription } from 'rxjs';
 
@@ -20,18 +19,12 @@ export class CompressedAirInventorySetupComponent implements OnInit {
   modalOpenSub: Subscription;
   isModalOpen: boolean;
   helpPanelTabSub: Subscription;
-  initPlantSetup: boolean = false;
   smallScreenTab: string = 'form';
 
-  constructor(private compressedAirInventoryService: CompressedAirInventoryService, private egridService: EGridService,
+  constructor(private compressedAirInventoryService: CompressedAirInventoryService,
     private cd: ChangeDetectorRef, private settingsDbService: SettingsDbService) { }
 
   ngOnInit(): void {
-    this.egridService.processCSVData().then(result => {
-      this.initPlantSetup = true;
-    }).catch(err => {
-      this.initPlantSetup = false;
-    });
     this.helpPanelTabSub = this.compressedAirInventoryService.helpPanelTab.subscribe(val => {
       if (val) {
         this.tabSelect = val;

--- a/src/app/fsat/fsat.component.ts
+++ b/src/app/fsat/fsat.component.ts
@@ -17,11 +17,9 @@ import { FanFieldDataService } from './fan-field-data/fan-field-data.service';
 import { FanSetupService } from './fan-setup/fan-setup.service';
 import { FanImperialDefaults, SettingsService } from '../settings/settings.service';
 import { ConvertFsatService } from './convert-fsat.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import * as _ from 'lodash';
 import { OperationsService } from './operations/operations.service';
 import { AnalyticsService } from '../shared/analytics/analytics.service';
-import { copyObject } from '../shared/helperFunctions';
 
 @Component({
     selector: 'app-fsat',
@@ -98,7 +96,6 @@ export class FsatComponent implements OnInit {
     private fanSetupService: FanSetupService,
     private cd: ChangeDetectorRef,
     private settingsService: SettingsService,
-    private egridService: EGridService,
     private convertFsatService: ConvertFsatService,
     private fsatOperationsService: OperationsService,
     private analyticsService: AnalyticsService) {
@@ -106,7 +103,6 @@ export class FsatComponent implements OnInit {
 
   ngOnInit() {
     this.analyticsService.sendEvent('view-fan-assessment');
-    this.egridService.getAllSubRegions();
     this.activatedRoute.params.subscribe(params => {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']))
       if (!this.assessment || (this.assessment && this.assessment.type !== 'FSAT')) {

--- a/src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.html
+++ b/src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.html
@@ -2,7 +2,7 @@
     <div class="small-tab-select nav-pills nav-fill" #smallTabSelect>
         <div class="nav-item" (click)="setSmallScreenTab('form')"
             [ngClass]="{'small-screen-active': smallScreenTab === 'form'}">
-            <a class="nav-link" *ngIf="setupTab == 'plant-setup' && initPlantSetup">Plant Setup</a>
+            <a class="nav-link" *ngIf="setupTab == 'plant-setup'">Plant Setup</a>
             <a class="nav-link" *ngIf="setupTab == 'department-setup'">Departments</a>
             <a class="nav-link" *ngIf="setupTab == 'motor-properties'">Motor Properties</a>
             <a class="nav-link" *ngIf="setupTab == 'motor-catalog'">Catalog</a>
@@ -16,7 +16,7 @@
     <div class="assessment-container tab-content">
         <div class="assessment-panel-container lookup-form modification scroll-item"
             [ngClass]="{'modal-open': isModalOpen == true, 'small-screen-tab': smallScreenTab === 'form'}" [ngStyle]="{'height.px': containerHeight}">
-            <app-plant-setup *ngIf="setupTab == 'plant-setup' && initPlantSetup"></app-plant-setup>
+            <app-plant-setup *ngIf="setupTab == 'plant-setup'"></app-plant-setup>
             <app-motor-properties *ngIf="setupTab == 'motor-properties'"></app-motor-properties>
             <app-motor-catalog *ngIf="setupTab == 'motor-catalog'"></app-motor-catalog>
             <app-department-setup *ngIf="setupTab == 'department-setup'"></app-department-setup>

--- a/src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.ts
+++ b/src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, ChangeDetectorRef, Input } from '@angular/core';
 import { MotorInventoryService } from '../motor-inventory.service';
 import { Subscription } from 'rxjs';
 import { SettingsDbService } from '../../indexedDb/settings-db.service';
-import { EGridService } from '../../shared/helper-services/e-grid.service';
 
 @Component({
     selector: 'app-motor-inventory-setup',
@@ -20,17 +19,11 @@ export class MotorInventorySetupComponent implements OnInit {
   modalOpenSub: Subscription;
   isModalOpen: boolean;
   helpPanelTabSub: Subscription;
-  initPlantSetup: boolean = false;
   smallScreenTab: string = 'form';
-  constructor(private motorInventoryService: MotorInventoryService, private egridService: EGridService,
+  constructor(private motorInventoryService: MotorInventoryService,
     private cd: ChangeDetectorRef, private settingsDbService: SettingsDbService) { }
 
   ngOnInit(): void {
-    this.egridService.processCSVData().then(result => {
-      this.initPlantSetup = true;
-    }).catch(err => {
-      this.initPlantSetup = false;
-    });
     this.helpPanelTabSub = this.motorInventoryService.helpPanelTab.subscribe(val => {
       if (val) {
         this.tabSelect = val;

--- a/src/app/phast/phast.component.html
+++ b/src/app/phast/phast.component.html
@@ -40,7 +40,7 @@
   </div>
   <div *ngIf="mainTab == 'baseline' && stepTab.step != 1" class="assessment-tab-container tab-content">
     <!--Step: 4 Heat Balance-->
-    <app-losses *ngIf="stepTab.step  == 2 && hasEgridDataInit" [(phast)]="_phast" (saved)="saveDb()" [settings]="settings" [inSetup]="true"
+    <app-losses *ngIf="stepTab.step  == 2" [(phast)]="_phast" (saved)="saveDb()" [settings]="settings" [inSetup]="true"
       [containerHeight]="containerHeight"></app-losses>
     <!--Step: 5 Aux Equipment-->
     <app-aux-equipment *ngIf="stepTab.step  == 3" [(phast)]="_phast" (save)="saveDb()"
@@ -60,7 +60,7 @@
         [assessment]="assessment" (save)="saveDb()" [exploreModIndex]="modificationIndex" (emitAddNewMod)="addNewMod()">
       </app-explore-phast-opportunities>
     </div>
-    <div *ngIf="assessmentTab == 'modify-conditions' && hasEgridDataInit">
+    <div *ngIf="assessmentTab == 'modify-conditions'">
       <app-losses [containerHeight]="containerHeight" [(phast)]="_phast" (saved)="saveDb()" [settings]="settings"
         [inSetup]="false" [modificationIndex]="modificationIndex"></app-losses>
     </div>

--- a/src/app/phast/phast.component.ts
+++ b/src/app/phast/phast.component.ts
@@ -17,7 +17,6 @@ import { SettingsService } from '../settings/settings.service';
 import { PhastValidService } from './phast-valid.service';
 import { SavingsOpportunity } from '../shared/models/explore-opps';
 import { ConvertPhastService } from './convert-phast.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import { AnalyticsService } from '../shared/analytics/analytics.service';
 import { getNewIdString } from '../shared/helperFunctions';
 
@@ -64,7 +63,6 @@ export class PhastComponent implements OnInit {
   isModalOpen: boolean = false;
   selectedLossTab: LossTab;
   calcTab: string;
-  hasEgridDataInit: boolean;
   assessmentTab: string = 'explore-opportunities';
   sankeyPhast: PHAST;
   modificationIndex: number;
@@ -99,17 +97,11 @@ export class PhastComponent implements OnInit {
     private settingsDbService: SettingsDbService,
     private assessmentDbService: AssessmentDbService,
     private settingsService: SettingsService,
-    private egridService: EGridService,
     private analyticsService: AnalyticsService) {
   }
 
   ngOnInit() {
     this.analyticsService.sendEvent('view-process-heating-assessment');
-    this.egridService.processCSVData().then(result => {
-      this.hasEgridDataInit = true;
-    }).catch(err => {
-      this.hasEgridDataInit = false;
-    });
     this.tab1Status = '';
     this.tab2Status = '';
 

--- a/src/app/psat/psat.component.ts
+++ b/src/app/psat/psat.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild, ElementRef, HostListener, ChangeDetectorRef } from '@angular/core';
 import { Assessment } from '../shared/models/assessment';
 import { AssessmentService } from '../dashboard/assessment.service';
-import { PSAT, Modification, PsatOutputs, PsatInputs } from '../shared/models/psat';
+import { PSAT, Modification, PsatOutputs } from '../shared/models/psat';
 import { PsatService } from './psat.service';
 import * as _ from 'lodash';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -17,7 +17,6 @@ import { UntypedFormGroup } from '@angular/forms';
 import { MotorService } from './motor/motor.service';
 import { FieldDataService } from './field-data/field-data.service';
 import { SettingsService } from '../settings/settings.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import { PumpOperationsService } from './pump-operations/pump-operations.service';
 import { PsatIntegrationService } from '../shared/connected-inventory/psat-integration.service';
 import { IntegrationStateService } from '../shared/connected-inventory/integration-state.service';
@@ -103,14 +102,12 @@ export class PsatComponent implements OnInit {
     private motorService: MotorService,
     private fieldDataService: FieldDataService,
     private cd: ChangeDetectorRef,
-    private egridService: EGridService,
     private settingsService: SettingsService,
     private analyticsService: AnalyticsService) {
   }
 
   ngOnInit() {
     this.analyticsService.sendEvent('view-pump-assessment');
-    this.egridService.getAllSubRegions();
     this.activatedRoute.params.subscribe(params => {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']));
       this.getSettings();

--- a/src/app/pump-inventory/pump-inventory-setup/pump-inventory-setup.component.html
+++ b/src/app/pump-inventory/pump-inventory-setup/pump-inventory-setup.component.html
@@ -2,7 +2,7 @@
     <div class="small-tab-select nav-pills nav-fill" #smallTabSelect>
         <div class="nav-item" (click)="setSmallScreenTab('form')"
             [ngClass]="{'small-screen-active': smallScreenTab === 'form'}">
-            <a class="nav-link" *ngIf="setupTab == 'plant-setup' && initPlantSetup">Plant Setup</a>
+            <a class="nav-link" *ngIf="setupTab == 'plant-setup'">Plant Setup</a>
             <a class="nav-link" *ngIf="setupTab == 'department-setup'">Departments</a>
             <a class="nav-link" *ngIf="setupTab == 'pump-properties'">Pump Properties</a>
             <a class="nav-link" *ngIf="setupTab == 'pump-catalog'">Catalog</a>
@@ -16,7 +16,7 @@
     <div class="assessment-container tab-content">
         <div class="assessment-panel-container lookup-form modification scroll-item"
             [ngClass]="{'modal-open': isModalOpen == true, 'small-screen-tab': smallScreenTab === 'form'}" [ngStyle]="{'height.px': containerHeight}">
-            <app-plant-setup *ngIf="setupTab == 'plant-setup' && initPlantSetup"></app-plant-setup>
+            <app-plant-setup *ngIf="setupTab == 'plant-setup'"></app-plant-setup>
             <app-pump-properties *ngIf="setupTab == 'pump-properties'"></app-pump-properties>
             <app-pump-catalog *ngIf="setupTab == 'pump-catalog'"></app-pump-catalog>
             <app-department-setup *ngIf="setupTab == 'department-setup'"></app-department-setup>

--- a/src/app/pump-inventory/pump-inventory-setup/pump-inventory-setup.component.ts
+++ b/src/app/pump-inventory/pump-inventory-setup/pump-inventory-setup.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SettingsDbService } from '../../indexedDb/settings-db.service';
-import { EGridService } from '../../shared/helper-services/e-grid.service';
 import { PumpInventoryService } from '../pump-inventory.service';
 
 @Component({
@@ -20,17 +19,11 @@ export class PumpInventorySetupComponent implements OnInit {
   modalOpenSub: Subscription;
   isModalOpen: boolean;
   helpPanelTabSub: Subscription;
-  initPlantSetup: boolean = false;
   smallScreenTab: string = 'form';
-  constructor(private pumpInventoryService: PumpInventoryService, private egridService: EGridService,
+  constructor(private pumpInventoryService: PumpInventoryService,
     private cd: ChangeDetectorRef, private settingsDbService: SettingsDbService) { }
 
   ngOnInit(): void {
-    this.egridService.processCSVData().then(result => {
-      this.initPlantSetup = true;
-    }).catch(err => {
-      this.initPlantSetup = false;
-    });
     this.helpPanelTabSub = this.pumpInventoryService.helpPanelTab.subscribe(val => {
       if (val) {
         this.tabSelect = val;

--- a/src/app/settings/assessment-settings/assessment-settings.component.ts
+++ b/src/app/settings/assessment-settings/assessment-settings.component.ts
@@ -5,7 +5,6 @@ import { SettingsService } from '../settings.service'
  
 import { SettingsDbService } from '../../indexedDb/settings-db.service';
 import { UntypedFormGroup } from '@angular/forms';
-import { EGridService } from '../../shared/helper-services/e-grid.service';
 import { firstValueFrom } from 'rxjs';
 
 @Component({
@@ -32,13 +31,11 @@ export class AssessmentSettingsComponent implements OnInit {
   showOperationalImpacts: Signal<boolean> = this.featureFlagService.showOperationalImpacts;
 
   constructor(   
-    private egridService: EGridService, 
     private settingsDbService: SettingsDbService, 
     private settingsService: SettingsService) {
   }
 
   ngOnInit() {
-    this.egridService.getAllSubRegions();
     this.initializeSettings();
   }
   

--- a/src/app/shared/helper-services/e-grid.service.ts
+++ b/src/app/shared/helper-services/e-grid.service.ts
@@ -14,25 +14,6 @@ export class EGridService {
 
   constructor() {}
   
-  getAllSubRegions() {
-    Papa.parse("assets/eGRID-co2-emissions.csv", {
-      header: true,
-      download: true,
-      complete: results => {
-        this.setCo2Emissions(results.data);
-      }
-    });
-
-    Papa.parse("assets/eGrid_zipcode_lookup.csv", {
-      header: true,
-      download: true,
-      complete: results => {
-        this.setSubRegionsByZip(results.data);
-      }
-    });
-    
-  }
-
   getEmissionsParsed(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       Papa.parse("assets/eGRID-co2-emissions.csv", {

--- a/src/app/ssmt/ssmt.component.ts
+++ b/src/app/ssmt/ssmt.component.ts
@@ -13,7 +13,6 @@ import * as _ from 'lodash';
 import { AssessmentService } from '../dashboard/assessment.service';
 import { SettingsService, SteamImperialDefaults, SteamMetricDefaults } from '../settings/settings.service';
 import { ConvertSsmtService } from './convert-ssmt.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import { SteamService } from '../calculator/steam/steam.service';
 import { AnalyticsService } from '../shared/analytics/analytics.service';
 import { SnackbarService } from '../shared/snackbar-notification/snackbar.service';
@@ -93,7 +92,6 @@ export class SsmtComponent implements OnInit {
   saturatedPropertiesOutput: SaturatedPropertiesOutput;
 
   constructor(
-    private egridService: EGridService,
     private activatedRoute: ActivatedRoute,
     private boilerService: BoilerService,
     private router: Router,
@@ -112,7 +110,6 @@ export class SsmtComponent implements OnInit {
 
   ngOnInit() {
     this.analyticsService.sendEvent('view-steam-assessment');
-    this.egridService.getAllSubRegions();
     this.activatedRoute.params.subscribe(params => {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']))
       if (!this.assessment || (this.assessment && this.assessment.type !== 'SSMT')) {

--- a/src/app/treasure-hunt/treasure-hunt.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt.component.ts
@@ -15,7 +15,6 @@ import { SortCardsData } from './treasure-chest/opportunity-cards/sort-cards-by.
 import { SettingsService } from '../settings/settings.service';
 import { ConvertInputDataService } from './convert-input-data.service';
 import { ConvertUnitsService } from '../shared/convert-units/convert-units.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import { AnalyticsService } from '../shared/analytics/analytics.service';
 
 @Component({
@@ -70,13 +69,11 @@ export class TreasureHuntComponent implements OnInit {
     private treasureChestMenuService: TreasureChestMenuService,
     private settingsService: SettingsService,
     private convertUnitsService: ConvertUnitsService,
-    private egridService: EGridService,
     private analyticsService: AnalyticsService
   ) { }
 
   ngOnInit() {
     this.analyticsService.sendEvent('view-treasure-hunt-assessment');
-    this.egridService.getAllSubRegions();
     this.activatedRoute.params.subscribe(params => {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']));
       if (this.assessment && this.assessment.type !== 'TreasureHunt') {

--- a/src/app/waste-water/waste-water.component.ts
+++ b/src/app/waste-water/waste-water.component.ts
@@ -15,7 +15,6 @@ import { ConvertWasteWaterService } from './convert-waste-water.service';
 import { CompareService } from './modify-conditions/compare.service';
 import { SystemBasicsService } from './system-basics/system-basics.service';
 import { WasteWaterService } from './waste-water.service';
-import { EGridService } from '../shared/helper-services/e-grid.service';
 import { WasteWaterOperationsService } from './waste-water-operations/waste-water-operations.service';
 import { AnalyticsService } from '../shared/analytics/analytics.service';
 
@@ -69,7 +68,6 @@ export class WasteWaterComponent implements OnInit {
   smallScreenTab: string = 'form';
   constructor(private activatedRoute: ActivatedRoute,   
     private router: Router,
-    private egridService: EGridService,
     private settingsDbService: SettingsDbService, private wasteWaterService: WasteWaterService, private convertWasteWaterService: ConvertWasteWaterService,
     private assessmentDbService: AssessmentDbService, private cd: ChangeDetectorRef, private compareService: CompareService,
     private activatedSludgeFormService: ActivatedSludgeFormService, private aeratorPerformanceFormService: AeratorPerformanceFormService,
@@ -78,7 +76,6 @@ export class WasteWaterComponent implements OnInit {
 
   ngOnInit(): void {
     this.analyticsService.sendEvent('view-waste-water-assessment');
-    this.egridService.getAllSubRegions();
     this.activatedRoute.params.subscribe(params => {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']));
 


### PR DESCRIPTION
connects #8258 

This pull request refactors how the `EGridService` is initialized and used across the application. The core change is to centralize the initialization of EGrid CSV data in the main `AppComponent`, removing redundant or component-level initializations. This simplifies component logic and ensures EGrid data is loaded once at app startup, improving maintainability and reducing the risk of inconsistent state. Additionally, some UI logic related to the initialization state of plant setup tabs is simplified.

**Centralization of EGridService Initialization:**

* The `EGridService` is now injected and its `processCSVData()` method is called only once during app startup in `AppComponent`, rather than in each component that needs EGrid data. (`src/app/app.component.ts`) [[1]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR13) [[2]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deL35-R37) [[3]](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR122)

**Removal of Redundant EGridService Usage from Components:**

* All direct imports and constructor injections of `EGridService` have been removed from components such as `Co2SavingsComponent`, `CompressedAirAssessmentComponent`, `CompressedAirInventorySetupComponent`, `FsatComponent`, `MotorInventorySetupComponent`, `PhastComponent`, and `PsatComponent`. (`src/app/calculator/utilities/co2-savings/co2-savings.component.ts`, `src/app/compressed-air-assessment/compressed-air-assessment.component.ts`, `src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.ts`, `src/app/fsat/fsat.component.ts`, `src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.ts`, `src/app/phast/phast.component.ts`, `src/app/psat/psat.component.ts`) (F02011deL2R2, [[1]](diffhunk://#diff-569d51eec11b096ac99eef532096936819b60122b99857aec5e3751361a948ecL50-L56) [[2]](diffhunk://#diff-0a445d4c90bc25df4626cd23607344b261f4f830f0c49d0041a70e10a5cf74eaL8) [[3]](diffhunk://#diff-0a445d4c90bc25df4626cd23607344b261f4f830f0c49d0041a70e10a5cf74eaL81) [[4]](diffhunk://#diff-0a445d4c90bc25df4626cd23607344b261f4f830f0c49d0041a70e10a5cf74eaL92) [[5]](diffhunk://#diff-286be0132c918f5ba54ba39c6af072c1b13a5101908b564dc7256ce425feb3c6L3) [[6]](diffhunk://#diff-286be0132c918f5ba54ba39c6af072c1b13a5101908b564dc7256ce425feb3c6L23-L34) [[7]](diffhunk://#diff-18929dd2c26205652f1c13cfa9b538c183bbff506515f4a2a332817cc593b8aaL20-L24) [[8]](diffhunk://#diff-18929dd2c26205652f1c13cfa9b538c183bbff506515f4a2a332817cc593b8aaL101-L109) [[9]](diffhunk://#diff-0f1993c1a1b0ac9579f190f4518a483ef20b2325850c37de49af784334abbf98L5) [[10]](diffhunk://#diff-0f1993c1a1b0ac9579f190f4518a483ef20b2325850c37de49af784334abbf98L23-L33) [[11]](diffhunk://#diff-c1b9fea6423feb1cf0f59cecc588cf91ebd0c4fe01a5bd7a85840781434a79deL20) [[12]](diffhunk://#diff-c1b9fea6423feb1cf0f59cecc588cf91ebd0c4fe01a5bd7a85840781434a79deL67) [[13]](diffhunk://#diff-c1b9fea6423feb1cf0f59cecc588cf91ebd0c4fe01a5bd7a85840781434a79deL102-L112) [[14]](diffhunk://#diff-0bd92a5fe0b43c3360b6670136a4c6dd96ffd48a71b3230f79cf69972611bdfeL20) [[15]](diffhunk://#diff-0bd92a5fe0b43c3360b6670136a4c6dd96ffd48a71b3230f79cf69972611bdfeL106-L113)

**Simplification of Plant Setup Tab Initialization Logic:**

* The `initPlantSetup` flag and related checks have been removed from inventory setup components and their templates. The plant setup tab is now shown based solely on the `setupTab` value, no longer waiting for EGrid data initialization. (`src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.html`, `src/app/compressed-air-inventory/compressed-air-inventory-setup/compressed-air-inventory-setup.component.ts`, `src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.html`, `src/app/motor-inventory/motor-inventory-setup/motor-inventory-setup.component.ts`, `src/app/pump-inventory/pump-inventory-setup/pump-inventory-setup.component.html`) [[1]](diffhunk://#diff-807d8ceb683845ece9f30369add147aa48dedcc34e6e71f71c666d4238e827ffL5-R5) [[2]](diffhunk://#diff-807d8ceb683845ece9f30369add147aa48dedcc34e6e71f71c666d4238e827ffL21-R21) [[3]](diffhunk://#diff-286be0132c918f5ba54ba39c6af072c1b13a5101908b564dc7256ce425feb3c6L23-L34) [[4]](diffhunk://#diff-95c835eb824fedcace1f3cc41c6f71ab7d711d01d07e1e63bd21a60cd585704cL5-R5) [[5]](diffhunk://#diff-95c835eb824fedcace1f3cc41c6f71ab7d711d01d07e1e63bd21a60cd585704cL19-R19) [[6]](diffhunk://#diff-0f1993c1a1b0ac9579f190f4518a483ef20b2325850c37de49af784334abbf98L23-L33) [[7]](diffhunk://#diff-6a078c6c81427effee5b616acf0dab72c899e30c05f8fe04c2dffd07fd80071bL5-R5)

**Template and State Cleanup in PHAST:**

* The `hasEgridDataInit` flag and related template checks have been removed from `PhastComponent`, further decoupling UI rendering from EGrid data initialization. (`src/app/phast/phast.component.html`, `src/app/phast/phast.component.ts`) [[1]](diffhunk://#diff-336ad930631bc29def222ae11feaffe8e70c0f6303d8a45b723649217463aabaL43-R43) [[2]](diffhunk://#diff-336ad930631bc29def222ae11feaffe8e70c0f6303d8a45b723649217463aabaL63-R63) [[3]](diffhunk://#diff-c1b9fea6423feb1cf0f59cecc588cf91ebd0c4fe01a5bd7a85840781434a79deL67) [[4]](diffhunk://#diff-c1b9fea6423feb1cf0f59cecc588cf91ebd0c4fe01a5bd7a85840781434a79deL102-L112)

**Minor Cleanup:**

* Removed unused imports and variables related to EGrid and other utilities for improved code clarity. (`src/app/psat/psat.component.ts`)

Let me know if you'd like more details on any of these changes!