### PR TITLE
System settings fixes and custom database reset logic

### DIFF
--- a/src/app/core/core.service.ts
+++ b/src/app/core/core.service.ts
@@ -93,7 +93,7 @@ export class CoreService {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const text = await response.text();
-      const backupData: ImportExportData = JSON.parse(text);
+      let backupData: ImportExportData = JSON.parse(text);
       await this.importService.importData(backupData, 1)
     } catch (err) {
       console.log(err);
@@ -108,5 +108,7 @@ export class CoreService {
       parentDirectoryId: null,
     };
     let allDirectory: Directory = await firstValueFrom(this.directoryDbService.addWithObservable(allAssessmentsDir));
+    let defaultSettings = this.getDefaultSettingsObject();
+    await firstValueFrom(this.settingsDbService.addWithObservable(defaultSettings));
   }
 }

--- a/src/app/indexedDb/atmosphere-db.service.ts
+++ b/src/app/indexedDb/atmosphere-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, Observable, map } from 'rxjs';
+import { BehaviorSubject, Observable, firstValueFrom, map } from 'rxjs';
 import { AtmosphereSpecificHeat } from '../shared/models/materials';
 import { AtmosphereStoreMeta } from './dbConfig';
 
@@ -45,7 +45,16 @@ export class AtmosphereDbService {
   }
 
   clearAtmosphereSpecificHeat(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
+  }
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<AtmosphereSpecificHeat> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<AtmosphereSpecificHeat> = materials.filter((material: AtmosphereSpecificHeat) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    return true;
   }
 
 }

--- a/src/app/indexedDb/flue-gas-material-db.service.ts
+++ b/src/app/indexedDb/flue-gas-material-db.service.ts
@@ -41,9 +41,10 @@ export class FlueGasMaterialDbService {
   }
 
   clearFlueGasMaterials(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
   }
-  
+
   getById(id: number): FlueGasMaterial {
     let allMaterials: Array<FlueGasMaterial> = this.dbFlueGasMaterials.getValue();
     return allMaterials.find(material => material.id === id);
@@ -79,4 +80,13 @@ export class FlueGasMaterialDbService {
     return material.id;
   }
 
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<FlueGasMaterial> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<FlueGasMaterial> = materials.filter((material: FlueGasMaterial) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    await this.setAllMaterialsFromDb();
+    return true;
+  }
 }

--- a/src/app/indexedDb/gas-load-material-db.service.ts
+++ b/src/app/indexedDb/gas-load-material-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { GasLoadChargeMaterial } from '../shared/models/materials';
 import { GasLoadMaterialStoreMeta } from './dbConfig';
 
@@ -45,7 +45,19 @@ export class GasLoadMaterialDbService {
   }
 
   clearGasLoadChargeMaterial(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
   }
+
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<GasLoadChargeMaterial> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<GasLoadChargeMaterial> = materials.filter((material: GasLoadChargeMaterial) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    return true;
+  }
+
+
 
 }

--- a/src/app/indexedDb/liquid-load-material-db.service.ts
+++ b/src/app/indexedDb/liquid-load-material-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { LiquidLoadChargeMaterial } from '../shared/models/materials';
 import { LiquidLoadMaterialStoreMeta } from './dbConfig';
 
@@ -44,7 +44,17 @@ export class LiquidLoadMaterialDbService {
   }
 
   clearLiquidLoadChargeMaterial(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
+  }
+
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<LiquidLoadChargeMaterial> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<LiquidLoadChargeMaterial> = materials.filter((material: LiquidLoadChargeMaterial) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    return true;
   }
 
 }

--- a/src/app/indexedDb/solid-liquid-material-db.service.ts
+++ b/src/app/indexedDb/solid-liquid-material-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { SolidLiquidFlueGasMaterial } from '../shared/models/materials';
 import { SolidLiquidFlueGasMaterialStoreMeta } from './dbConfig';
 
@@ -16,7 +16,7 @@ export class SolidLiquidMaterialDbService {
     await firstValueFrom(this.dbService.bulkAdd(this.storeName, defaultMaterials));
     await this.setAllMaterialsFromDb();
   }
-  
+
   private getAllWithObservable(): Observable<Array<SolidLiquidFlueGasMaterial>> {
     return this.dbService.getAll(this.storeName);
   }
@@ -38,6 +38,7 @@ export class SolidLiquidMaterialDbService {
   }
 
   clearSolidLiquidFlueGasMaterials(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
   }
 
@@ -46,7 +47,7 @@ export class SolidLiquidMaterialDbService {
     return allMaterials.find(material => material.id === id);
   }
 
-  getAllMaterials(): Array<SolidLiquidFlueGasMaterial>{
+  getAllMaterials(): Array<SolidLiquidFlueGasMaterial> {
     return this.dbSolidLiquidFlueGasMaterials.getValue();
   }
 
@@ -74,5 +75,15 @@ export class SolidLiquidMaterialDbService {
     material = await firstValueFrom(this.addWithObservable(material));
     await this.setAllMaterialsFromDb();
     return material.id;
+  }
+
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<SolidLiquidFlueGasMaterial> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<SolidLiquidFlueGasMaterial> = materials.filter((material: SolidLiquidFlueGasMaterial) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    await this.setAllMaterialsFromDb();
+    return true;
   }
 }

--- a/src/app/indexedDb/solid-load-material-db.service.ts
+++ b/src/app/indexedDb/solid-load-material-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { SolidLoadChargeMaterial } from '../shared/models/materials';
 import { SolidLoadMaterialStoreMeta } from './dbConfig';
 
@@ -44,7 +44,16 @@ export class SolidLoadMaterialDbService {
   }
 
   clearSolidLoadChargeMaterial(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
   }
 
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<SolidLoadChargeMaterial> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<SolidLoadChargeMaterial> = materials.filter((material: SolidLoadChargeMaterial) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    return true;
+  }
 }

--- a/src/app/indexedDb/wall-losses-surface-db.service.ts
+++ b/src/app/indexedDb/wall-losses-surface-db.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, map, Observable } from 'rxjs';
 import { WallLossesSurface } from '../shared/models/materials';
 import { WallLossesSurfaceStoreMeta } from './dbConfig';
 
@@ -46,6 +46,16 @@ export class WallLossesSurfaceDbService {
   }
 
   clearWallLossesSurface(): Observable<boolean> {
+    //this clears the suite db items as well
     return this.dbService.clear(this.storeName);
+  }
+
+  async deleteAllCustomMaterials(): Promise<boolean> {
+    const materials: Array<WallLossesSurface> = await firstValueFrom(this.dbService.getAll(this.storeName));
+    const customMaterials: Array<WallLossesSurface>  = materials.filter((material: WallLossesSurface) => !material.isDefault);
+    for (const material of customMaterials) {
+      await firstValueFrom(this.deleteByIdWithObservable(material.id));
+    }
+    return true;
   }
 }

--- a/src/app/settings/assessment-settings/reset-data-modal/reset-data-modal.component.ts
+++ b/src/app/settings/assessment-settings/reset-data-modal/reset-data-modal.component.ts
@@ -157,6 +157,7 @@ export class ResetDataModalComponent implements OnInit {
     defaultSettings.disableDataExplorerTutorial = this.settingsDbService.globalSettings.disableDataExplorerTutorial;
     defaultSettings.disableTutorial = this.settingsDbService.globalSettings.disableTutorial;
     defaultSettings.printAll = this.settingsDbService.globalSettings.printAll;
+    defaultSettings.suiteDbItemsInitialized = true;
     delete defaultSettings.facilityInfo;
     await firstValueFrom(this.settingsDbService.updateWithObservable(defaultSettings));
     let settings: Settings[] = await firstValueFrom(this.settingsDbService.getAllSettings());
@@ -262,13 +263,13 @@ export class ResetDataModalComponent implements OnInit {
   }
 
   async resetFactoryCustomMaterials() {
-    await firstValueFrom(this.gasLoadDbService.clearGasLoadChargeMaterial());
-    await firstValueFrom(this.atmosphereDbService.clearAtmosphereSpecificHeat());
-    await firstValueFrom(this.flueGasMaterialDbService.clearFlueGasMaterials());
-    await firstValueFrom(this.liquidLoadMaterialDbService.clearLiquidLoadChargeMaterial());
-    await firstValueFrom(this.solidLiquidMaterialDbService.clearSolidLiquidFlueGasMaterials());
-    await firstValueFrom(this.solidLoadMaterialDbService.clearSolidLoadChargeMaterial());
-    await firstValueFrom(this.wallLossesSurfaceDbService.clearWallLossesSurface());
+    await this.gasLoadDbService.deleteAllCustomMaterials();
+    await this.atmosphereDbService.deleteAllCustomMaterials();
+    await this.flueGasMaterialDbService.deleteAllCustomMaterials();
+    await this.liquidLoadMaterialDbService.deleteAllCustomMaterials();
+    await this.solidLiquidMaterialDbService.deleteAllCustomMaterials();
+    await this.solidLoadMaterialDbService.deleteAllCustomMaterials();
+    await this.wallLossesSurfaceDbService.deleteAllCustomMaterials();
     this.hideResetSystemSettingsModal();
   }
 

--- a/src/app/shared/models/settings.ts
+++ b/src/app/shared/models/settings.ts
@@ -232,6 +232,7 @@ export function getDefaultSettings(): Settings {
         steamRollupUnit: "MMBtu",
         wasteWaterRollupUnit: "MWh",
         compressedAirRollupUnit: "MWh",
-        flowDecimalPrecision: 2
+        flowDecimalPrecision: 2,
+        suiteDbItemsInitialized: false
     }
 };

--- a/src/app/tools-suite-api/tools-suite-api.service.ts
+++ b/src/app/tools-suite-api/tools-suite-api.service.ts
@@ -47,6 +47,7 @@ export class ToolsSuiteApiService {
 
     async initializeDefaultDbData() {
         let globalSettings: Settings = this.settingsDbService.globalSettings;
+        // suiteDbItemsInitialized - flag is just continuing to support current app init logic - settings doesn't really need to be coupled to init logic. 
         if (!globalSettings.suiteDbItemsInitialized) {
             console.log('==== Initializing default database items');
             // Initialize default data here


### PR DESCRIPTION
Quick fix to data initialization and reset data settings workflow.

This pull request introduces a new approach for resetting custom materials in the app's IndexedDB services, replacing the previous method of clearing entire stores with targeted deletion of only custom materials. Additionally, it ensures proper initialization of default settings and suite database items. The changes improve data integrity and user experience by preserving default materials while allowing users to reset custom entries.

**Improvements to custom material management:**

* Added `deleteAllCustomMaterials` methods to all material-related IndexedDB services (`AtmosphereDbService`, `FlueGasMaterialDbService`, `GasLoadMaterialDbService`, `LiquidLoadMaterialDbService`, `SolidLiquidMaterialDbService`, `SolidLoadMaterialDbService`, `WallLossesSurfaceDbService`). These methods selectively delete only custom materials, leaving default materials intact. [[1]](diffhunk://#diff-3c2cac287ca91e39ea2439bea6eeef7cadce575e3c011e5ccfd692a72996f411R48-R58) [[2]](diffhunk://#diff-77806c1de5427167dc864bc3a658995b062b98d780054b297e263a4e8c402603R83-R91) [[3]](diffhunk://#diff-f1e67ef4f3f3d72802f73c15d8a28918518e0728fcd040d0bc8a49fa0be616d7R48-R62) [[4]](diffhunk://#diff-25932c14359472abdb21a8aef409a988668532c07e57df66fcf8026953b54027R47-R59) [[5]](diffhunk://#diff-76c6bad2a2dd4231c1af2eb9474d2b054b3069c1d17884da93fa1c75fb8e83adR79-R88) [[6]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffR47-R58) [[7]](diffhunk://#diff-5d15dcb000a20939124cc8a88d31aefe1bfd261aaa95d9fddf161b1cde064814R49-R60)
* Updated the `resetFactoryCustomMaterials` method in `reset-data-modal.component.ts` to use the new `deleteAllCustomMaterials` methods instead of clearing the entire store.

**Enhancements to settings initialization:**

* Added initialization of default settings and suite database items in `core.service.ts` during data import and app setup.
* Modified the reset logic in `reset-data-modal.component.ts` to set `suiteDbItemsInitialized` to `true` in default settings, ensuring proper tracking of initialization state.
* Introduced `suiteDbItemsInitialized` property to the default settings object in `settings.ts`.

**Codebase improvements:**

* Updated imports across multiple services to include `firstValueFrom`, enabling the use of async/await patterns for database operations. [[1]](diffhunk://#diff-3c2cac287ca91e39ea2439bea6eeef7cadce575e3c011e5ccfd692a72996f411L3-R3) [[2]](diffhunk://#diff-f1e67ef4f3f3d72802f73c15d8a28918518e0728fcd040d0bc8a49fa0be616d7L3-R3) [[3]](diffhunk://#diff-25932c14359472abdb21a8aef409a988668532c07e57df66fcf8026953b54027L3-R3) [[4]](diffhunk://#diff-76c6bad2a2dd4231c1af2eb9474d2b054b3069c1d17884da93fa1c75fb8e83adL3-R3) [[5]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffL3-R3) [[6]](diffhunk://#diff-5d15dcb000a20939124cc8a88d31aefe1bfd261aaa95d9fddf161b1cde064814L3-R3)
* Added clarifying comments in `clear*` methods to indicate that suite database items are also cleared. [[1]](diffhunk://#diff-3c2cac287ca91e39ea2439bea6eeef7cadce575e3c011e5ccfd692a72996f411R48-R58) [[2]](diffhunk://#diff-77806c1de5427167dc864bc3a658995b062b98d780054b297e263a4e8c402603R44) [[3]](diffhunk://#diff-f1e67ef4f3f3d72802f73c15d8a28918518e0728fcd040d0bc8a49fa0be616d7R48-R62) [[4]](diffhunk://#diff-25932c14359472abdb21a8aef409a988668532c07e57df66fcf8026953b54027R47-R59) [[5]](diffhunk://#diff-76c6bad2a2dd4231c1af2eb9474d2b054b3069c1d17884da93fa1c75fb8e83adR41) [[6]](diffhunk://#diff-ccaad74ffee71e78dc1fdcfc6de65f3d9a0a556137c191ddc08fba13d051c3ffR47-R58) [[7]](diffhunk://#diff-5d15dcb000a20939124cc8a88d31aefe1bfd261aaa95d9fddf161b1cde064814R49-R60)

**Minor bug fix:**

* Changed a variable declaration in `core.service.ts` from `const` to `let` to allow reassignment after parsing JSON data.