### PR TITLE
fix: performance profile avg operating points calc

### DIFF
--- a/src/app/compressed-air-assessment/compressed-air-report/compressed-air-report.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-report/compressed-air-report.component.html
@@ -1,4 +1,4 @@
-<div class="assessment-report report-in-compressed-air compressed-air"
+<div class="assessment-report report-in-compressed-air compressed-air h-100"
     [ngClass]="{'assessment-report-padding': inAssessment, 'report-in-rollup': inRollup}">
     <div *ngIf="inAssessment" class="report-cover">
         <img src="assets/images/Logo_Color_Seal_Blue_Lettering_Horizontal.png" class="doe-logo">

--- a/src/app/compressed-air-assessment/compressed-air-report/performance-profiles/performance-profiles.component.html
+++ b/src/app/compressed-air-assessment/compressed-air-report/performance-profiles/performance-profiles.component.html
@@ -14,7 +14,7 @@
 }
 <div class="row">
     <!--baseline-->
-    <div class="col-sm-12 col-md-6">
+    <div class="col-sm-12 col-md-6" [ngClass]="{'col-md-12': !selectedModificationResults}">
         <app-inventory-performance-profile class="mt-auto" [context]="'report'" [printView]="printView"
             [settings]="settings">
         </app-inventory-performance-profile>

--- a/src/app/compressed-air-assessment/inventory-performance-profile/inventory-performance-profile.component.ts
+++ b/src/app/compressed-air-assessment/inventory-performance-profile/inventory-performance-profile.component.ts
@@ -299,7 +299,7 @@ export class InventoryPerformanceProfileComponent implements OnInit {
                 size: 12,
                 symbol: currentMarkerShape,
               },
-              fillcolor: dataItem.color,
+              fillcolor: undefined,
             }
             traceData.push(trace);
           }
@@ -542,7 +542,7 @@ export class InventoryPerformanceProfileComponent implements OnInit {
     compressorSummary.forEach(compressorSummary => {
       if (dayTypeId === compressorSummary.dayTypeId && compressorSummary.avgPercentCapacity) {
         let compressor: CompressorInventoryItem = this.adjustedCompressors.find(item => { return item.itemId === compressorSummary.compressorId });
-        let results: CompressorCalcResult = this.compressedAirCalculationService.compressorsCalc(compressor, this.settings, 1, compressorSummary.avgAirflow, this.compressedAirAssessment.systemInformation.atmosphericPressure, this.compressedAirAssessment.systemInformation.totalAirStorage, 0, false);
+        let results: CompressorCalcResult = this.compressedAirCalculationService.compressorsCalc(compressor, this.settings, 3, compressorSummary.avgAirflow, this.compressedAirAssessment.systemInformation.atmosphericPressure, this.compressedAirAssessment.systemInformation.totalAirStorage, 0, false);
         compressorData.push(results);
       }
     });


### PR DESCRIPTION
Connects #4841 

Fixed method to calculate avg operating points.
Made report height 100% to fill screen.
Have baseline chart be full with (col-12) if no modification in performance profile in report.
