### PR TITLE
chore: added help text to pipe sizing and air velocity calculators

### DIFF
--- a/src/app/calculator/compressed-air/air-velocity/air-velocity-help/air-velocity-help.component.html
+++ b/src/app/calculator/compressed-air/air-velocity/air-velocity-help/air-velocity-help.component.html
@@ -2,7 +2,8 @@
   <h5>
     Velocity in the Piping Help
     <br>
-    <small class="text-muted">This calculator helps in finding the velocity of compressed air through all the different piping involved in the system.
+    <small class="text-muted">This calculator helps in finding the velocity of compressed air through all the different
+      piping involved in the system.
     </small>
   </h5>
   <hr class="my-1 hr-spacer">
@@ -35,9 +36,30 @@
       <br>
       <small class="text-muted">
 
-        General value is 14.7 psi. In case the receiver tank is at higher altitude location, the respective atmospheric pressure
+        General value is 14.7 psi. In case the receiver tank is at higher altitude location, the respective atmospheric
+        pressure
         at that location can be given.
         <hr>
+      </small>
+    </h6>
+  </div>
+  <div class="my-2">
+    <h6>
+      Heuristics recommend that velocity in the compressed air piping is no more than:
+      <small class="text-muted">
+        @if(settings.unitsOfMeasure == 'Metric'){
+        <ul>
+          <li>6 m/s in the compressed air room</li>
+          <li>9 m/s in the plant header</li>
+          <li>15 m/s in the final drop to an end use</li>
+        </ul>
+        }@else {
+        <ul>
+          <li>20 ft/s in the compressed air room</li>
+          <li>30 ft/s in the plant header</li>
+          <li>50 ft/s in the final drop to an end use</li>
+        </ul>
+        }
       </small>
     </h6>
   </div>

--- a/src/app/calculator/compressed-air/air-velocity/air-velocity-help/air-velocity-help.component.ts
+++ b/src/app/calculator/compressed-air/air-velocity/air-velocity-help/air-velocity-help.component.ts
@@ -1,15 +1,18 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { Settings } from '../../../../shared/models/settings';
 
 @Component({
-    selector: 'app-air-velocity-help',
-    templateUrl: './air-velocity-help.component.html',
-    styleUrls: ['./air-velocity-help.component.css'],
-    standalone: false
+  selector: 'app-air-velocity-help',
+  templateUrl: './air-velocity-help.component.html',
+  styleUrls: ['./air-velocity-help.component.css'],
+  standalone: false
 })
 export class AirVelocityHelpComponent implements OnInit {
   @Input()
   currentField: string;
-  
+  @Input()
+  settings: Settings;
+
   constructor() { }
 
   ngOnInit() {

--- a/src/app/calculator/compressed-air/air-velocity/air-velocity.component.html
+++ b/src/app/calculator/compressed-air/air-velocity/air-velocity.component.html
@@ -45,7 +45,7 @@
         </div>
       </div>
       <div class="d-flex">
-        <app-air-velocity-help [currentField]="currentField"></app-air-velocity-help>
+        <app-air-velocity-help [currentField]="currentField" [settings]="settings"></app-air-velocity-help>
       </div>
     </div>
   </div>

--- a/src/app/calculator/compressed-air/pipe-sizing/pipe-sizing.component.html
+++ b/src/app/calculator/compressed-air/pipe-sizing/pipe-sizing.component.html
@@ -105,6 +105,27 @@
               </small>
             </h6>
           </div>
+
+          <div class="my-2">
+            <h6>
+              Heuristics recommend that velocity in the compressed air piping is no more than:
+              <small class="text-muted">
+                @if(settings.unitsOfMeasure == 'Metric'){
+                <ul>
+                  <li>6 m/s in the compressed air room</li>
+                  <li>9 m/s in the plant header</li>
+                  <li>15 m/s in the final drop to an end use</li>
+                </ul>
+                }@else {
+                <ul>
+                  <li>20 ft/s in the compressed air room</li>
+                  <li>30 ft/s in the plant header</li>
+                  <li>50 ft/s in the final drop to an end use</li>
+                </ul>
+                }
+              </small>
+            </h6>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
connects #7982 
This pull request introduces improvements to the help sections of the compressed air calculators, specifically by adding recommended velocity heuristics for compressed air piping. It also updates the `AirVelocityHelpComponent` to accept and use `settings` as an input, enabling dynamic display of recommendations based on the selected unit of measure. The changes enhance user guidance and contextual information across both the air velocity and pipe sizing calculators.

Enhancements to help content and user guidance:

* Added a section to both `air-velocity-help.component.html` and `pipe-sizing.component.html` displaying recommended maximum velocities for compressed air piping, with values shown conditionally based on whether the units are metric or imperial. [[1]](diffhunk://#diff-7df8d110388a54d7d4686e0673a8efd8fad8505647f9e37688ee528ec08f8d22L38-R65) [[2]](diffhunk://#diff-7424ca2c723db02ecaa668f93ba86743d2983ac18dd430a9af44dd02ecc921ddR108-R128)
* Improved formatting and readability of existing help text in `air-velocity-help.component.html`.

Component and data flow updates:

* Updated `AirVelocityHelpComponent` to accept a `settings` input, allowing the component to access unit preferences and display the relevant velocity recommendations. [[1]](diffhunk://#diff-bede761ef976f2f2f414bbc9a2a9fac7c59cd80abe988d903407d1e1a44cec24R2) [[2]](diffhunk://#diff-bede761ef976f2f2f414bbc9a2a9fac7c59cd80abe988d903407d1e1a44cec24R13-R14)
* Modified `air-velocity.component.html` to pass the `settings` input to `AirVelocityHelpComponent`.
