### PR TITLE
8295 - Excel to .json in export description

### DIFF
--- a/src/app/shared/share-data-modal/share-data-modal.component.html
+++ b/src/app/shared/share-data-modal/share-data-modal.component.html
@@ -48,7 +48,7 @@
                             Export Locally
                         </button>
                         <p class="small text-center">
-                            Export your Treasure Hunt Opportunities data to an excel file for local use.
+                            Export your Treasure Hunt Opportunities data to a .json file for local use.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
#8295 

- Changing the Treasure Hunt Export window's "Export Locally" descriptive check from saying "Export" to ".json"
- No other checks needed.
