### PR TITLE
Issue   8282

### DIFF
--- a/src/app/calculator/fans/fan-system-checklist/fan-system-checklist-chart/fan-system-checklist-chart.component.ts
+++ b/src/app/calculator/fans/fan-system-checklist/fan-system-checklist-chart/fan-system-checklist-chart.component.ts
@@ -3,7 +3,7 @@ import { PlotlyService } from 'angular-plotly.js';
 import { FanSystemChecklistOutput } from '../../../../shared/models/fans';
 import { SimpleChart, TraceData } from '../../../../shared/models/plotting';
 import { Settings } from '../../../../shared/models/settings';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-fan-system-checklist-chart',
     templateUrl: './fan-system-checklist-chart.component.html',
@@ -130,14 +130,14 @@ export class FanSystemChecklistChartComponent implements OnInit {
         this.expandedChartDiv.nativeElement,
         traces,
         chartLayout,
-        this.fanChecklistChart.config
+        defaultPlotlyConfig(this.fanChecklistChart.config)
       );
     }else if(!this.expanded && this.panelChartDiv){
       this.plotlyService.newPlot(
         this.panelChartDiv.nativeElement,
         traces,
         chartLayout,
-        this.fanChecklistChart.config
+        defaultPlotlyConfig(this.fanChecklistChart.config)
       );
     }
   }

--- a/src/app/calculator/furnaces/o2-enrichment/enrichment-graph/enrichment-graph.component.ts
+++ b/src/app/calculator/furnaces/o2-enrichment/enrichment-graph/enrichment-graph.component.ts
@@ -7,6 +7,7 @@ import { SimpleChart, TraceCoordinates } from '../../../../shared/models/plottin
 import { O2EnrichmentService, DisplayPoint, Axis } from '../o2-enrichment.service';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 @Component({
     selector: 'app-enrichment-graph',
@@ -117,7 +118,7 @@ export class EnrichmentGraphComponent implements OnInit {
 
     let chartLayout = JSON.parse(JSON.stringify(this.enrichmentChart.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.enrichmentChart.data, chartLayout, this.enrichmentChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.enrichmentChart.data, chartLayout, defaultPlotlyConfig(this.enrichmentChart.config))
         .then(chart => {
           chart.on('plotly_hover', hoverData => {
             this.displayHoverGroupData(hoverData);
@@ -127,7 +128,7 @@ export class EnrichmentGraphComponent implements OnInit {
           });
         });
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.enrichmentChart.data, chartLayout, this.enrichmentChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.enrichmentChart.data, chartLayout, defaultPlotlyConfig(this.enrichmentChart.config))
         .then(chart => {
           chart.on('plotly_hover', hoverData => {
             this.displayHoverGroupData(hoverData);

--- a/src/app/calculator/motors/motor-performance/motor-performance-chart/motor-performance-chart.component.ts
+++ b/src/app/calculator/motors/motor-performance/motor-performance-chart/motor-performance-chart.component.ts
@@ -6,6 +6,7 @@ import { graphColors } from '../../../../shared/graphColors';
 
 import { MotorPerformanceChartService, MotorPoint } from '../motor-performance-chart.service';
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 
 @Component({
@@ -97,18 +98,18 @@ export class MotorPerformanceChartComponent implements OnInit {
     });
     this.dataPointTraces.forEach(trace => {
       traceData.push(trace);
-    })
-
+    });
     let chartLayout = JSON.parse(JSON.stringify(this.performanceChart.layout));
+    const config = defaultPlotlyConfig(this.performanceChart.config);
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, traceData, chartLayout, this.performanceChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, traceData, chartLayout, config)
         .then(chart => {
           chart.on('plotly_click', chartData => {
             this.addSelectedPointTraces(chartData);
           });
         });
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, traceData, chartLayout, this.performanceChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, traceData, chartLayout, config)
         .then(chart => {
           chart.on('plotly_click', chartData => {
             this.addSelectedPointTraces(chartData);

--- a/src/app/calculator/process-cooling/fan-psychrometric/fan-psychrometric-chart/fan-psychrometric-chart.component.ts
+++ b/src/app/calculator/process-cooling/fan-psychrometric/fan-psychrometric-chart/fan-psychrometric-chart.component.ts
@@ -10,7 +10,7 @@ import { Subscription } from 'rxjs';
 import { BaseGasDensity, PsychrometricResults } from '../../../../shared/models/fans';
 import { GasDensityFormService } from '../../../fans/fan-analysis/fan-analysis-form/gas-density-form/gas-density-form.service';
 import { graphColors } from '../../../../shared/graphColors';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-fan-psychrometric-chart',
     templateUrl: './fan-psychrometric-chart.component.html',
@@ -85,7 +85,7 @@ export class FanPsychrometricChartComponent implements OnInit {
     }
     
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.chart.data, this.chart.layout, this.chart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.chart.data, this.chart.layout, defaultPlotlyConfig(this.chart.config))
       .then(chart => {
         chart.on('plotly_click', chartData => {
           this.addSelectedPointTraces(chartData);
@@ -93,7 +93,7 @@ export class FanPsychrometricChartComponent implements OnInit {
       });
 
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.chart.data, this.chart.layout, this.chart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.chart.data, this.chart.layout, defaultPlotlyConfig(this.chart.config))
       .then(chart => {
         chart.on('plotly_click', chartData => {
           this.addSelectedPointTraces(chartData);

--- a/src/app/calculator/pumps/achievable-efficiency/achievable-efficiency-graph/achievable-efficiency-graph.component.ts
+++ b/src/app/calculator/pumps/achievable-efficiency/achievable-efficiency-graph/achievable-efficiency-graph.component.ts
@@ -8,7 +8,7 @@ import { SimpleChart, TraceData, TraceCoordinates } from '../../../../shared/mod
 import { AchievableEfficiencyService, EfficiencyPoint, EfficiencyTrace } from '../achievable-efficiency.service';
 import { pumpTypeRanges } from '../../../../psat/psatConstants';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-achievable-efficiency-graph',
     templateUrl: './achievable-efficiency-graph.component.html',
@@ -115,14 +115,14 @@ export class AchievableEfficiencyGraphComponent implements OnInit {
 
     let chartLayout = JSON.parse(JSON.stringify(this.efficiencyChart.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, traceData, chartLayout, this.efficiencyChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, traceData, chartLayout, defaultPlotlyConfig(this.efficiencyChart.config))
         .then(chart => {
           chart.on('plotly_click', (graphData) => {
             this.createDataPoints(graphData);
           });
         });
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, traceData, chartLayout, this.efficiencyChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, traceData, chartLayout, defaultPlotlyConfig(this.efficiencyChart.config))
         .then(chart => {
           chart.on('plotly_click', (graphData) => {
             this.createDataPoints(graphData);

--- a/src/app/calculator/pumps/specific-speed/specific-speed-graph/specific-speed-graph.component.ts
+++ b/src/app/calculator/pumps/specific-speed/specific-speed-graph/specific-speed-graph.component.ts
@@ -6,7 +6,7 @@ import { SpecificSpeedService } from '../specific-speed.service';
 
 import { DataPoint, SimpleChart, TraceData } from '../../../../shared/models/plotting';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-specific-speed-graph',
     templateUrl: './specific-speed-graph.component.html',
@@ -107,14 +107,14 @@ export class SpecificSpeedGraphComponent implements OnInit {
     })
     let chartLayout = JSON.parse(JSON.stringify(this.specificSpeedChart.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, traceData, chartLayout, this.specificSpeedChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, traceData, chartLayout, defaultPlotlyConfig(this.specificSpeedChart.config))
         .then(chart => {
           chart.on('plotly_click', (graphData) => {
             this.createDataPoint(graphData);
           });
         });
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, traceData, chartLayout, this.specificSpeedChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, traceData, chartLayout, defaultPlotlyConfig(this.specificSpeedChart.config))
         .then(chart => {
           chart.on('plotly_click', (graphData) => {
             this.createDataPoint(graphData);

--- a/src/app/calculator/steam/saturated-properties/saturated-properties-chart/saturated-properties-chart.component.ts
+++ b/src/app/calculator/steam/saturated-properties/saturated-properties-chart/saturated-properties-chart.component.ts
@@ -7,6 +7,7 @@ import { graphColors } from '../../../../shared/graphColors';
 import { SaturatedPropertiesService, IsobarCoordinates } from '../../saturated-properties.service';
 import { SaturatedPropertiesConversionService } from '../../saturated-properties-conversion.service';
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 @Component({
     selector: 'app-saturated-properties-chart',
@@ -92,9 +93,9 @@ export class SaturatedPropertiesChartComponent implements OnChanges {
 
     let chartLayout = JSON.parse(JSON.stringify(this.entropyChart.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.entropyChart.data, chartLayout, this.entropyChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.entropyChart.data, chartLayout, defaultPlotlyConfig(this.entropyChart.config))
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.entropyChart.data, chartLayout, this.entropyChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.entropyChart.data, chartLayout, defaultPlotlyConfig(this.entropyChart.config))
     }
     this.save();
   }

--- a/src/app/calculator/steam/saturated-properties/saturated-properties-ph-chart/saturated-properties-ph-chart.component.ts
+++ b/src/app/calculator/steam/saturated-properties/saturated-properties-ph-chart/saturated-properties-ph-chart.component.ts
@@ -221,6 +221,7 @@ export class SaturatedPropertiesPhChartComponent implements OnInit, OnChanges {
   removePointTrace() {
     this.enthalpyChart.data.splice(this.enthalpyChart.data.length - 1, 1);
     this.enthalpyChart.existingPoint = false;
+    // no need, has its correct config
     let chartLayout = JSON.parse(JSON.stringify(this.enthalpyChart.layout));
     if (this.expanded) {
       this.plotlyService.update(this.expandedChartDiv.nativeElement, this.enthalpyChart.data, chartLayout);

--- a/src/app/calculator/steam/steam-properties/steam-properties-chart/steam-properties-chart.component.ts
+++ b/src/app/calculator/steam/steam-properties/steam-properties-chart/steam-properties-chart.component.ts
@@ -7,7 +7,7 @@ import { graphColors } from '../../../../shared/graphColors';
 import { SaturatedPropertiesService, IsobarCoordinates } from '../../saturated-properties.service';
 import { SaturatedPropertiesConversionService } from '../../saturated-properties-conversion.service';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 
 @Component({
@@ -94,9 +94,9 @@ export class SteamPropertiesChartComponent implements OnChanges {
 
     let chartLayout = JSON.parse(JSON.stringify(this.entropyChart.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.entropyChart.data, chartLayout, this.entropyChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.entropyChart.data, chartLayout, defaultPlotlyConfig(this.entropyChart.config))
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.entropyChart.data, chartLayout, this.entropyChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.entropyChart.data, chartLayout, defaultPlotlyConfig(this.entropyChart.config))
     }
     this.save();
   }

--- a/src/app/calculator/steam/steam-properties/steam-properties-ph-chart/steam-properties-ph-chart.component.ts
+++ b/src/app/calculator/steam/steam-properties/steam-properties-ph-chart/steam-properties-ph-chart.component.ts
@@ -7,7 +7,7 @@ import { graphColors } from '../../../../shared/graphColors';
 import { SaturatedPropertiesService, IsothermCoordinates } from '../../saturated-properties.service';
 import { SaturatedPropertiesConversionService } from '../../saturated-properties-conversion.service';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 
 @Component({
@@ -115,9 +115,9 @@ export class SteamPropertiesPhChartComponent implements OnInit {
 
     let chartLayout = JSON.parse(JSON.stringify(this.enthalpyChart.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.enthalpyChart.data, chartLayout, this.enthalpyChart.config)
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.enthalpyChart.data, chartLayout, defaultPlotlyConfig(this.enthalpyChart.config))
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.enthalpyChart.data, chartLayout, this.enthalpyChart.config)
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.enthalpyChart.data, chartLayout, defaultPlotlyConfig(this.enthalpyChart.config))
     }
     this.save();
   }
@@ -128,9 +128,9 @@ export class SteamPropertiesPhChartComponent implements OnInit {
     }
     let chartLayout = JSON.parse(JSON.stringify(this.enthalpyChart.layout));
     if(this.expanded){
-      this.plotlyService.update(this.expandedChartDiv.nativeElement, this.enthalpyChart.data, chartLayout);
+      this.plotlyService.update(this.expandedChartDiv.nativeElement, this.enthalpyChart.data, chartLayout, defaultPlotlyConfig(this.enthalpyChart.config));
     }else{
-      this.plotlyService.update(this.panelChartDiv.nativeElement, this.enthalpyChart.data, chartLayout);
+      this.plotlyService.update(this.panelChartDiv.nativeElement, this.enthalpyChart.data, chartLayout, defaultPlotlyConfig(this.enthalpyChart.config));
     }
     this.save();
   }

--- a/src/app/calculator/system-and-equipment-curve/system-and-equipment-curve-graph/system-and-equipment-curve-graph.component.ts
+++ b/src/app/calculator/system-and-equipment-curve/system-and-equipment-curve-graph/system-and-equipment-curve-graph.component.ts
@@ -12,7 +12,7 @@ import * as Plotly from 'plotly.js-dist';
 import { copyObject, getNewIdString, roundVal } from '../../../shared/helperFunctions';
 import { FanSystemCurveData, PumpSystemCurveData } from '../../../shared/models/system-and-equipment-curve';
 import { RegressionEquationsService } from '../regression-equations.service';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 
 @Component({
     selector: 'app-system-and-equipment-curve-graph',
@@ -219,7 +219,7 @@ export class SystemAndEquipmentCurveGraphComponent implements OnInit {
       }
     })
     if (this.expanded && this.expandedSystemChartDiv) {
-      this.plotlyService.newPlot(this.expandedSystemChartDiv.nativeElement, traceData, chartLayout, this.curveEquipmentChart.config)
+      this.plotlyService.newPlot(this.expandedSystemChartDiv.nativeElement, traceData, chartLayout, defaultPlotlyConfig(this.curveEquipmentChart.config))
         .then(chart => {
           chart.on('plotly_click', (graphData) => {
             this.createDataPoint(graphData);
@@ -233,7 +233,7 @@ export class SystemAndEquipmentCurveGraphComponent implements OnInit {
         });
 
     } else if (!this.expanded && this.systemPanelDiv) {
-      this.plotlyService.newPlot(this.systemPanelDiv.nativeElement, traceData, chartLayout, this.curveEquipmentChart.config)
+      this.plotlyService.newPlot(this.systemPanelDiv.nativeElement, traceData, chartLayout, defaultPlotlyConfig(this.curveEquipmentChart.config))
         .then(chart => {
           chart.on('plotly_click', (graphData) => {
             this.createDataPoint(graphData);
@@ -251,7 +251,7 @@ export class SystemAndEquipmentCurveGraphComponent implements OnInit {
     if (this.displayPowerChart) {
       let powerChartLayout = copyObject(this.powerChart.layout);
       if (this.powerExpanded && this.expandedPowerChartDiv) {
-        this.plotlyService.newPlot(this.expandedPowerChartDiv.nativeElement, this.powerChart.data, powerChartLayout, this.powerChart.config)
+        this.plotlyService.newPlot(this.expandedPowerChartDiv.nativeElement, this.powerChart.data, powerChartLayout, defaultPlotlyConfig(this.powerChart.config))
           .then(chart => {
             chart.on('plotly_hover', powerHoverData => {
               this.displayHoverData(powerHoverData, true);
@@ -261,7 +261,7 @@ export class SystemAndEquipmentCurveGraphComponent implements OnInit {
             });
           });
       } else if (!this.powerExpanded && this.powerChartPanelDiv) {
-        this.plotlyService.newPlot(this.powerChartPanelDiv.nativeElement, this.powerChart.data, powerChartLayout, this.powerChart.config)
+        this.plotlyService.newPlot(this.powerChartPanelDiv.nativeElement, this.powerChart.data, powerChartLayout, defaultPlotlyConfig(this.powerChart.config))
           .then(chart => {
             chart.on('plotly_hover', powerHoverData => {
               this.displayHoverData(powerHoverData, true);

--- a/src/app/calculator/utilities/cash-flow/cash-flow-diagram/cash-flow-diagram.component.ts
+++ b/src/app/calculator/utilities/cash-flow/cash-flow-diagram/cash-flow-diagram.component.ts
@@ -4,7 +4,7 @@ import { CashFlowForm } from '../cash-flow';
 import { CashFlowService } from '../cash-flow.service';
 import { TraceData, SimpleChart } from '../../../../shared/models/plotting';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 
 @Component({
@@ -61,9 +61,9 @@ export class CashFlowDiagramComponent implements OnInit {
     this.cashFlowChart.data = chartTraces;
     let chartLayout = JSON.parse(JSON.stringify(this.cashFlowChart.layout));
     if(this.expanded && this.expandedChartDiv){
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.cashFlowChart.data, chartLayout, this.cashFlowChart.config);
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.cashFlowChart.data, chartLayout, defaultPlotlyConfig(this.cashFlowChart.config));
     }else if(!this.expanded && this.panelChartDiv){
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.cashFlowChart.data, chartLayout, this.cashFlowChart.config);
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.cashFlowChart.data, chartLayout, defaultPlotlyConfig(this.cashFlowChart.config));
     }
   }
 

--- a/src/app/calculator/utilities/power-factor-triangle/power-factor-triangle-results/power-factor-triangle-results.component.ts
+++ b/src/app/calculator/utilities/power-factor-triangle/power-factor-triangle-results/power-factor-triangle-results.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Input, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { PowerFactorTriangleOutputs } from '../../../../shared/models/standalone';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-power-factor-triangle-results',
     templateUrl: './power-factor-triangle-results.component.html',
@@ -100,11 +100,12 @@ export class PowerFactorTriangleResultsComponent implements OnInit {
     };
 
     var modebarBtns = {
+      modeBarButtonsToRemove: ['select2d', 'lasso2d'],
       displaylogo: false,
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.powerFactorTiangle.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.powerFactorTiangle.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
 

--- a/src/app/calculator/utilities/pre-assessment/pre-assessment-graph/pre-assessment-graph.component.ts
+++ b/src/app/calculator/utilities/pre-assessment/pre-assessment-graph/pre-assessment-graph.component.ts
@@ -113,7 +113,7 @@ export class PreAssessmentGraphComponent implements OnInit, OnChanges {
       };
 
       var modebarBtns = {
-        modeBarButtonsToRemove: ['hoverClosestPie'],
+        modeBarButtonsToRemove: ['hoverClosestPie', 'select2d', 'lasso2d'],
         displaylogo: false,
         displayModeBar: true,
         responsive: true

--- a/src/app/calculator/waste-water/o2-utilization-rate/o2-utilization-rate-graph/o2-utilization-rate-graph.component.ts
+++ b/src/app/calculator/waste-water/o2-utilization-rate/o2-utilization-rate-graph/o2-utilization-rate-graph.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { Subscription } from 'rxjs';
 import { O2UtilizationDataPoints, O2UtilizationRateService } from '../o2-utilization-rate.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-o2-utilization-rate-graph',
     templateUrl: './o2-utilization-rate-graph.component.html',
@@ -78,7 +78,7 @@ export class O2UtilizationRateGraphComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       }
-      this.plotlyService.newPlot(this.o2UtilizationChart.nativeElement, [trace], layout, config);
+      this.plotlyService.newPlot(this.o2UtilizationChart.nativeElement, [trace], layout, defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/calculator/waste-water/state-point-analysis/state-point-analysis-graph/state-point-analysis-graph.component.ts
+++ b/src/app/calculator/waste-water/state-point-analysis/state-point-analysis-graph/state-point-analysis-graph.component.ts
@@ -8,7 +8,7 @@ import { Subscription } from 'rxjs';
 import { StatePointAnalysisGraphService } from '../state-point-analysis-graph.service';
 import { StatePointAnalysisOutput, StatePointAnalysisResults } from '../../../../shared/models/waste-water';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-state-point-analysis-graph',
     templateUrl: './state-point-analysis-graph.component.html',
@@ -87,9 +87,9 @@ export class StatePointAnalysisGraphComponent implements OnInit {
 
     let chartLayout = JSON.parse(JSON.stringify(this.spaGraph.layout));
     if (this.expanded && this.expandedChartDiv) {
-      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.spaGraph.data, chartLayout, this.spaGraph.config);
+      this.plotlyService.newPlot(this.expandedChartDiv.nativeElement, this.spaGraph.data, chartLayout, defaultPlotlyConfig(this.spaGraph.config));
     } else if (!this.expanded && this.panelChartDiv) {
-      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.spaGraph.data, chartLayout, this.spaGraph.config);
+      this.plotlyService.newPlot(this.panelChartDiv.nativeElement, this.spaGraph.data, chartLayout, defaultPlotlyConfig(this.spaGraph.config));
     }
     this.save();
   }

--- a/src/app/compressed-air-assessment/baseline-tab-content/end-uses-setup/end-use-chart/end-use-chart.component.ts
+++ b/src/app/compressed-air-assessment/baseline-tab-content/end-uses-setup/end-use-chart/end-use-chart.component.ts
@@ -11,7 +11,7 @@ import { CompressedAirCalculationService } from '../../../compressed-air-calcula
 import { AssessmentCo2SavingsService } from '../../../../shared/assessment-co2-savings/assessment-co2-savings.service';
 import { DayTypeSetupService } from '../end-uses-form/day-type-setup-form/day-type-setup.service';
 import { EndUseEnergy, EndUseEnergyData, EndUsesFormService } from '../end-uses-form/end-uses-form.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
   selector: 'app-end-use-chart',
   templateUrl: './end-use-chart.component.html',
@@ -216,7 +216,7 @@ export class EndUseChartComponent implements OnInit {
       responsive: true
     };
 
-    this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
   getChunkedArray(array, size) {

--- a/src/app/compressed-air-assessment/centrifugal-graph/centrifugal-graph.component.ts
+++ b/src/app/compressed-air-assessment/centrifugal-graph/centrifugal-graph.component.ts
@@ -7,7 +7,7 @@ import { Settings } from '../../shared/models/settings';
 import { CompressedAirAssessmentService } from '../compressed-air-assessment.service';
 import { InventoryService } from '../baseline-tab-content/inventory-setup/inventory/inventory.service';
 import { CompressedAirAssessmentModificationResults } from '../calculations/modifications/CompressedAirAssessmentModificationResults';
-
+import { defaultPlotlyConfig } from '../../shared/helperFunctions';
 @Component({
   selector: 'app-centrifugal-graph',
   templateUrl: './centrifugal-graph.component.html',
@@ -170,7 +170,7 @@ export class CentrifugalGraphComponent implements OnInit {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.centrifugalGraph.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.centrifugalGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/compressed-air-assessment/compressed-air-report/report-graphs/compressed-air-airflow-savings-graph/compressed-air-airflow-savings-graph.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-report/report-graphs/compressed-air-airflow-savings-graph/compressed-air-airflow-savings-graph.component.ts
@@ -4,7 +4,7 @@ import { CompressedAirAssessment, CompressedAirDayType } from '../../../../share
 import { CompressedAirAssessmentModificationResults } from '../../../calculations/modifications/CompressedAirAssessmentModificationResults';
 import { BaselineResults } from '../../../calculations/caCalculationModels';
 import { Settings } from '../../../../shared/models/settings';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
   selector: 'app-compressed-air-airflow-savings-graph',
   templateUrl: './compressed-air-airflow-savings-graph.component.html',
@@ -79,7 +79,7 @@ export class CompressedAirAirflowSavingsGraphComponent {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/compressed-air-assessment/compressed-air-report/report-graphs/compressed-air-cost-savings-graph/compressed-air-cost-savings-graph.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-report/report-graphs/compressed-air-cost-savings-graph/compressed-air-cost-savings-graph.component.ts
@@ -4,6 +4,7 @@ import { CompressedAirAssessment, CompressedAirDayType, Modification } from '../
 import { CompressedAirAssessmentModificationResults } from '../../../calculations/modifications/CompressedAirAssessmentModificationResults';
 import { BaselineResults, DayTypeModificationResult } from '../../../calculations/caCalculationModels';
 import { CompressedAirModificationValid } from '../../../compressed-air-assessment-validation/CompressedAirAssessmentValidation';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 
 @Component({
   selector: 'app-compressed-air-cost-savings-graph',
@@ -137,7 +138,7 @@ export class CompressedAirCostSavingsGraphComponent {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config));
     }
   }
 
@@ -234,7 +235,7 @@ export class CompressedAirCostSavingsGraphComponent {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/compressed-air-assessment/compressed-air-report/report-graphs/compressed-air-energy-savings-graph/compressed-air-energy-savings-graph.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-report/report-graphs/compressed-air-energy-savings-graph/compressed-air-energy-savings-graph.component.ts
@@ -4,7 +4,7 @@ import { CompressedAirAssessment, CompressedAirDayType, Modification } from '../
 import { CompressedAirAssessmentModificationResults } from '../../../calculations/modifications/CompressedAirAssessmentModificationResults';
 import { BaselineResults, DayTypeModificationResult } from '../../../calculations/caCalculationModels';
 import { CompressedAirModificationValid } from '../../../compressed-air-assessment-validation/CompressedAirAssessmentValidation';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
   selector: 'app-compressed-air-energy-savings-graph',
   templateUrl: './compressed-air-energy-savings-graph.component.html',
@@ -138,7 +138,7 @@ export class CompressedAirEnergySavingsGraphComponent {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config));
     }
   }
 
@@ -236,7 +236,7 @@ export class CompressedAirEnergySavingsGraphComponent {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.modificationGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/compressed-air-assessment/compressed-air-sankey/airflow-sankey/airflow-sankey.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-sankey/airflow-sankey/airflow-sankey.component.ts
@@ -11,7 +11,7 @@ import { CompressedAirAssessmentService } from '../../compressed-air-assessment.
 import { AirflowSankeyService, CompressedAirSankeyNode, AirFlowSankeyResults } from './airflow-sankey.service';
 import { EndUseEnergyData, EndUsesFormService } from '../../baseline-tab-content/end-uses-setup/end-uses-form/end-uses-form.service';
 import { DayTypeSetupService } from '../../baseline-tab-content/end-uses-setup/end-uses-form/day-type-setup-form/day-type-setup.service';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
     selector: 'app-airflow-sankey',
     templateUrl: './airflow-sankey.component.html',
@@ -215,7 +215,7 @@ export class AirflowSankeyComponent implements OnInit {
           config.responsive = false
         }
 
-        this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, config)
+        this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, defaultPlotlyConfig(config))
           .then(chart => {
             this.addGradientElement();
             this.buildSvgArrows();

--- a/src/app/compressed-air-assessment/compressed-air-sankey/power-sankey/power-sankey.component.ts
+++ b/src/app/compressed-air-assessment/compressed-air-sankey/power-sankey/power-sankey.component.ts
@@ -13,7 +13,7 @@ import { CompressedAirAssessmentBaselineResults } from '../../calculations/Compr
 import { CompressedAirCalculationService } from '../../compressed-air-calculation.service';
 import { AssessmentCo2SavingsService } from '../../../shared/assessment-co2-savings/assessment-co2-savings.service';
 import { DayTypeSetupService } from '../../baseline-tab-content/end-uses-setup/end-uses-form/day-type-setup-form/day-type-setup.service';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
   selector: 'app-power-sankey',
   templateUrl: './power-sankey.component.html',
@@ -253,7 +253,7 @@ export class PowerSankeyComponent implements OnInit {
       config.responsive = false
     }
 
-    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, config)
+    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, defaultPlotlyConfig(config))
       .then(chart => {
         this.addGradientElement();
         this.buildSvgArrows();

--- a/src/app/compressed-air-assessment/inventory-performance-profile/inventory-performance-profile.component.ts
+++ b/src/app/compressed-air-assessment/inventory-performance-profile/inventory-performance-profile.component.ts
@@ -12,7 +12,7 @@ import { AssessmentCo2SavingsService } from '../../shared/assessment-co2-savings
 import { CompressedAirAssessmentModificationResults } from '../calculations/modifications/CompressedAirAssessmentModificationResults';
 import { CompressorInventoryValidationService } from '../compressed-air-assessment-validation/compressor-inventory-validation.service';
 import { CompressedAirProfileSummary } from '../calculations/CompressedAirProfileSummary';
-
+import { defaultPlotlyConfig } from '../../shared/helperFunctions';
 @Component({
   selector: 'app-inventory-performance-profile',
   templateUrl: './inventory-performance-profile.component.html',
@@ -343,7 +343,7 @@ export class InventoryPerformanceProfileComponent implements OnInit {
         responsive: true,
         displaylogo: false
       };
-      this.plotlyService.newPlot(this.performanceProfileChart.nativeElement, traceData, layout, config);
+      this.plotlyService.newPlot(this.performanceProfileChart.nativeElement, traceData, layout,defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/compressed-air-assessment/system-profile-graphs/system-profile-graphs.component.ts
+++ b/src/app/compressed-air-assessment/system-profile-graphs/system-profile-graphs.component.ts
@@ -12,7 +12,7 @@ import { AssessmentCo2SavingsService } from '../../shared/assessment-co2-savings
 import { CompressedAirModifiedDayTypeProfileSummary } from '../calculations/modifications/CompressedAirModifiedDayTypeProfileSummary';
 import { ExploreOpportunitiesService } from '../assessment-tab-content/explore-opportunities/explore-opportunities.service';
 import * as Plotly from 'plotly.js-dist';
-
+import { defaultPlotlyConfig } from '../../shared/helperFunctions';
 @Component({
   selector: 'app-system-profile-graphs',
   templateUrl: './system-profile-graphs.component.html',
@@ -374,7 +374,7 @@ export class SystemProfileGraphsComponent implements OnInit {
       let peakTrace = this.getPeakLineTrace(xData, peakAirflow, 'Peak Airflow');
       traceData.push(peakTrace);
 
-      this.plotlyService.newPlot(this.systemCapacityGraph.nativeElement, traceData, layout, config).then(chart => {
+      this.plotlyService.newPlot(this.systemCapacityGraph.nativeElement, traceData, layout, defaultPlotlyConfig(config)).then(chart => {
         this.updateHoverPositionData(chart, 'systemCapacityGraph');
         this.updateLayout(chart, this.systemCapacityGraph);
       });

--- a/src/app/compressed-air-inventory/compressed-air-inventory-setup/end-uses-chart/end-uses-chart.component.ts
+++ b/src/app/compressed-air-inventory/compressed-air-inventory-setup/end-uses-chart/end-uses-chart.component.ts
@@ -7,7 +7,7 @@ import { Settings } from '../../../shared/models/settings';
 import { CompressedAirInventoryData, CompressedAirInventorySystem } from '../../compressed-air-inventory';
 import { Subscription } from 'rxjs';
 import { CompressedAirCatalogService } from '../compressed-air-catalog/compressed-air-catalog.service';
-
+import { defaultPlotlyConfig} from '../../../shared/helperFunctions';
 @Component({
   selector: 'app-end-uses-chart',
   templateUrl: './end-uses-chart.component.html',
@@ -194,7 +194,7 @@ export class EndUsesChartComponent implements OnInit {
       responsive: true
     };
 
-    this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
   getChunkedArray(array, size) {

--- a/src/app/compressed-air-inventory/compressed-air-inventory-summary/compressed-air-inventory-summary-graphs/compressed-air-summary-graph/compressed-air-summary-graph.component.ts
+++ b/src/app/compressed-air-inventory/compressed-air-inventory-summary/compressed-air-inventory-summary-graphs/compressed-air-summary-graph/compressed-air-summary-graph.component.ts
@@ -3,7 +3,7 @@ import { Subscription } from 'rxjs';
 import { CompressedAirInventorySummaryGraphsService } from '../compressed-air-inventory-summary-graphs.service';
 import { PlotlyService } from 'angular-plotly.js';
 import { CompressedAirInventoryService } from '../../../compressed-air-inventory.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
   selector: 'app-compressed-air-summary-graph',
   templateUrl: './compressed-air-summary-graph.component.html',
@@ -110,7 +110,7 @@ export class CompressedAirSummaryGraphComponent {
 
         let config = { responsive: true }
         if (this.visualizeChart) {
-          this.plotlyService.newPlot(this.visualizeChart.nativeElement, data, layout, config);
+          this.plotlyService.newPlot(this.visualizeChart.nativeElement, data, layout, defaultPlotlyConfig(config));
         }
       }
     });

--- a/src/app/compressed-air-inventory/compressed-air-inventory-summary/compressed-air-inventory-summary-overview/compressed-air-inventory-overview-bar-chart/compressed-air-inventory-overview-bar-chart.component.ts
+++ b/src/app/compressed-air-inventory/compressed-air-inventory-summary/compressed-air-inventory-summary-overview/compressed-air-inventory-overview-bar-chart/compressed-air-inventory-overview-bar-chart.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { Subscription } from 'rxjs';
 import { CompressedAirInventorySummaryOverviewService, InventorySummary } from '../compressed-air-inventory-summary-overview.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
   selector: 'app-compressed-air-inventory-overview-bar-chart',
   templateUrl: './compressed-air-inventory-overview-bar-chart.component.html',
@@ -43,12 +43,12 @@ export class CompressedAirInventoryOverviewBarChartComponent implements OnInit {
       };
 
       let configOptions = {
-        modeBarButtonsToRemove: ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'lasso2d', 'pan2d', 'select2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'],
+        modeBarButtonsToRemove: ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'pan2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'],
         displaylogo: false,
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.compressedAirInventoryBarChart.nativeElement, dataArray, layout, configOptions);
+      this.plotlyService.newPlot(this.compressedAirInventoryBarChart.nativeElement, dataArray, layout, defaultPlotlyConfig(configOptions));
     })
   }
 

--- a/src/app/log-tool/day-type-analysis/day-type-analysis.service.ts
+++ b/src/app/log-tool/day-type-analysis/day-type-analysis.service.ts
@@ -212,7 +212,6 @@ export class DayTypeAnalysisService {
       }
     });
     this.dayTypeSummaries.next(dayTypeSummaries);
-    console.log('Day Type Summaries: ', dayTypeSummaries);
     console.timeEnd('setDayTypeSummaries');
   }
 

--- a/src/app/log-tool/day-type-analysis/day-type-graph/day-type-graph.component.ts
+++ b/src/app/log-tool/day-type-analysis/day-type-graph/day-type-graph.component.ts
@@ -79,9 +79,9 @@ export class DayTypeGraphComponent implements OnInit {
     graphData.forEach(entry => {
       this.graph.data.push({ x: entry.xData, y: entry.yData, type: 'scatter', mode: 'lines+markers', marker: { color: entry.color }, name: entry.name })
     });
+    console.log(this.graph.layout, this.dayTypeGraph.nativeElement);
     if (this.dayTypeGraph) {
-      this.plotlyService.newPlot(this.dayTypeGraph.nativeElement, this.graph.data, this.graph.layout, { responsive: true });
-    }
+      this.plotlyService.newPlot(this.dayTypeGraph.nativeElement, this.graph.data, this.graph.layout, { responsive: true,  modeBarButtonsToRemove: ['select2d', 'lasso2d'],  displaylogo: false });    }
   }
 
   getGraphData(): Array<DayTypeGraphItem> {

--- a/src/app/log-tool/day-type-analysis/day-type-graph/day-type-graph.component.ts
+++ b/src/app/log-tool/day-type-analysis/day-type-graph/day-type-graph.component.ts
@@ -7,6 +7,7 @@ import { ConvertUnitsService } from '../../../shared/convert-units/convert-units
 import { PlotlyService } from 'angular-plotly.js';
 import { LogToolDataService } from '../../log-tool-data.service';
 import { truncate } from '../../../shared/helperFunctions';
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
     selector: 'app-day-type-graph',
     templateUrl: './day-type-graph.component.html',
@@ -79,9 +80,9 @@ export class DayTypeGraphComponent implements OnInit {
     graphData.forEach(entry => {
       this.graph.data.push({ x: entry.xData, y: entry.yData, type: 'scatter', mode: 'lines+markers', marker: { color: entry.color }, name: entry.name })
     });
-    console.log(this.graph.layout, this.dayTypeGraph.nativeElement);
     if (this.dayTypeGraph) {
-      this.plotlyService.newPlot(this.dayTypeGraph.nativeElement, this.graph.data, this.graph.layout, { responsive: true,  modeBarButtonsToRemove: ['select2d', 'lasso2d'],  displaylogo: false });    }
+      this.plotlyService.newPlot(this.dayTypeGraph.nativeElement, this.graph.data, this.graph.layout, defaultPlotlyConfig({ responsive: true}));
+    }
   }
 
   getGraphData(): Array<DayTypeGraphItem> {

--- a/src/app/log-tool/visualize/visualize-graph/visualize-graph.component.ts
+++ b/src/app/log-tool/visualize/visualize-graph/visualize-graph.component.ts
@@ -8,7 +8,7 @@ import { LogToolDataService } from '../../log-tool-data.service';
 import * as _ from 'lodash';
 import { Router } from '@angular/router';
 import * as Plotly from 'plotly.js-dist';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 
 @Component({
     selector: 'app-visualize-graph',
@@ -144,7 +144,7 @@ export class VisualizeGraphComponent implements OnInit {
 
   plotGraph(graphObj: GraphObj) {
     this.checkLegendDisplay(graphObj);
-    this.plotlyService.newPlot(this.visualizeGraph.nativeElement, graphObj.data, graphObj.layout, graphObj.mode)
+    this.plotlyService.newPlot(this.visualizeGraph.nativeElement, graphObj.data, graphObj.layout, defaultPlotlyConfig(graphObj.mode))
       .then(chart => {
         graphObj.shouldRenderNewPlot = false;
         this.selectedGraphObj.hasChanges = false;

--- a/src/app/motor-inventory/batch-analysis/batch-analysis-graphs/energy-cost-bar-chart/energy-cost-bar-chart.component.ts
+++ b/src/app/motor-inventory/batch-analysis/batch-analysis-graphs/energy-cost-bar-chart/energy-cost-bar-chart.component.ts
@@ -3,7 +3,7 @@ import { BatchAnalysisService, BatchAnalysisResults, BatchAnalysisSettings } fro
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-energy-cost-bar-chart',
     templateUrl: './energy-cost-bar-chart.component.html',
@@ -85,12 +85,12 @@ export class EnergyCostBarChartComponent implements OnInit {
       };
 
       let configOptions = {
-        modeBarButtonsToRemove: ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'lasso2d', 'pan2d', 'select2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'],
+        modeBarButtonsToRemove: ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'pan2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'],
         displaylogo: false,
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.energyBarChart.nativeElement, dataArray, layout, configOptions);
+      this.plotlyService.newPlot(this.energyBarChart.nativeElement, dataArray, layout, defaultPlotlyConfig(configOptions));
     });
   }
 

--- a/src/app/motor-inventory/batch-analysis/batch-analysis-graphs/energy-cost-pie-chart/energy-cost-pie-chart.component.ts
+++ b/src/app/motor-inventory/batch-analysis/batch-analysis-graphs/energy-cost-pie-chart/energy-cost-pie-chart.component.ts
@@ -3,7 +3,7 @@ import { BatchAnalysisService, BatchAnalysisSettings } from '../../batch-analysi
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-energy-cost-pie-chart',
     templateUrl: './energy-cost-pie-chart.component.html',
@@ -71,7 +71,7 @@ export class EnergyCostPieChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.costPieChart.nativeElement, data, layout, configOptions);
+      this.plotlyService.newPlot(this.costPieChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
     });
   }
 

--- a/src/app/motor-inventory/batch-analysis/batch-analysis-graphs/total-motors-bar-chart/total-motors-bar-chart.component.ts
+++ b/src/app/motor-inventory/batch-analysis/batch-analysis-graphs/total-motors-bar-chart/total-motors-bar-chart.component.ts
@@ -3,7 +3,7 @@ import { BatchAnalysisService, BatchAnalysisSettings, BatchAnalysisResults } fro
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-total-motors-bar-chart',
     templateUrl: './total-motors-bar-chart.component.html',
@@ -52,7 +52,7 @@ export class TotalMotorsBarChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.barChart.nativeElement, [data], layout, configOptions);
+      this.plotlyService.newPlot(this.barChart.nativeElement, [data], layout, defaultPlotlyConfig(configOptions));
     });
   }
 

--- a/src/app/motor-inventory/motor-inventory-summary/inventory-summary-graphs/inventory-summary-graph/inventory-summary-graph.component.ts
+++ b/src/app/motor-inventory/motor-inventory-summary/inventory-summary-graphs/inventory-summary-graph/inventory-summary-graph.component.ts
@@ -3,7 +3,7 @@ import { InventorySummaryGraphsService } from '../inventory-summary-graphs.servi
 import { MotorInventoryService } from '../../../motor-inventory.service';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-inventory-summary-graph',
     templateUrl: './inventory-summary-graph.component.html',
@@ -106,7 +106,7 @@ export class InventorySummaryGraphComponent implements OnInit {
 
         let config = { responsive: true }
         if (this.visualizeChart) {
-          this.plotlyService.newPlot(this.visualizeChart.nativeElement, data, layout, config);
+          this.plotlyService.newPlot(this.visualizeChart.nativeElement, data, layout, defaultPlotlyConfig(config));
         }
       }
     });

--- a/src/app/motor-inventory/motor-inventory-summary/inventory-summary-overview/inventory-overview-bar-chart/inventory-overview-bar-chart.component.ts
+++ b/src/app/motor-inventory/motor-inventory-summary/inventory-summary-overview/inventory-overview-bar-chart/inventory-overview-bar-chart.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { InventorySummary, InventorySummaryOverviewService } from '../inventory-summary-overview.service';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-inventory-overview-bar-chart',
     templateUrl: './inventory-overview-bar-chart.component.html',
@@ -49,7 +49,7 @@ export class InventoryOverviewBarChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.overviewBarChart.nativeElement, dataArray, layout, configOptions);
+      this.plotlyService.newPlot(this.overviewBarChart.nativeElement, dataArray, layout, defaultPlotlyConfig(configOptions));
     })
   }
 

--- a/src/app/motor-inventory/motor-inventory-summary/inventory-summary-overview/inventory-overview-pie-chart/inventory-overview-pie-chart.component.ts
+++ b/src/app/motor-inventory/motor-inventory-summary/inventory-summary-overview/inventory-overview-pie-chart/inventory-overview-pie-chart.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { InventorySummary, InventorySummaryOverviewService } from '../inventory-summary-overview.service';
 import { Subscription } from 'rxjs';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-inventory-overview-pie-chart',
     templateUrl: './inventory-overview-pie-chart.component.html',
@@ -62,7 +62,7 @@ export class InventoryOverviewPieChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, configOptions);
+      this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
     })
   }
 

--- a/src/app/pump-inventory/pump-inventory-summary/inventory-summary-graphs/pump-summary-graph/pump-summary-graph.component.ts
+++ b/src/app/pump-inventory/pump-inventory-summary/inventory-summary-graphs/pump-summary-graph/pump-summary-graph.component.ts
@@ -3,7 +3,7 @@ import { Subscription } from 'rxjs';
 import { PumpSummaryGraphsService } from '../pump-summary-graphs.service';
 import { PlotlyService } from 'angular-plotly.js';
 import { PumpInventoryService } from '../../../pump-inventory.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-pump-summary-graph',
     templateUrl: './pump-summary-graph.component.html',
@@ -107,7 +107,7 @@ export class PumpSummaryGraphComponent {
 
         let config = { responsive: true }
         if (this.visualizeChart) {
-          this.plotlyService.newPlot(this.visualizeChart.nativeElement, data, layout, config);
+          this.plotlyService.newPlot(this.visualizeChart.nativeElement, data, layout,defaultPlotlyConfig(config));
         }
       }
     });

--- a/src/app/pump-inventory/pump-inventory-summary/inventory-summary-overview/inventory-overview-bar-chart/inventory-overview-bar-chart.component.ts
+++ b/src/app/pump-inventory/pump-inventory-summary/inventory-summary-overview/inventory-overview-bar-chart/inventory-overview-bar-chart.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { Subscription } from 'rxjs';
 import { InventorySummaryOverviewService, InventorySummary } from '../inventory-summary-overview.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-inventory-overview-bar-chart',
     templateUrl: './inventory-overview-bar-chart.component.html',
@@ -48,7 +48,7 @@ export class PumpInventoryOverviewBarChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.pumpInventoryBarChart.nativeElement, dataArray, layout, configOptions);
+      this.plotlyService.newPlot(this.pumpInventoryBarChart.nativeElement, dataArray, layout, defaultPlotlyConfig(configOptions));
     })
   }
 

--- a/src/app/pump-inventory/pump-inventory-summary/inventory-summary-overview/inventory-overview-pie-chart/inventory-overview-pie-chart.component.ts
+++ b/src/app/pump-inventory/pump-inventory-summary/inventory-summary-overview/inventory-overview-pie-chart/inventory-overview-pie-chart.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { Subscription } from 'rxjs';
 import { InventorySummaryOverviewService, InventorySummary } from '../inventory-summary-overview.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-inventory-overview-pie-chart',
     templateUrl: './inventory-overview-pie-chart.component.html',
@@ -60,7 +60,7 @@ export class InventoryOverviewPieChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, configOptions);
+      this.plotlyService.newPlot(this.overviewPieChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
     })
   }
 

--- a/src/app/report-rollup/report-summary-graphs/report-summary-bar-chart/report-summary-bar-chart.component.ts
+++ b/src/app/report-rollup/report-summary-graphs/report-summary-bar-chart/report-summary-bar-chart.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { BarChartDataItem } from '../../rollup-summary-bar-chart/rollup-summary-bar-chart.component';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
     selector: 'app-report-summary-bar-chart',
     templateUrl: './report-summary-bar-chart.component.html',
@@ -64,13 +64,13 @@ export class ReportSummaryBarChartComponent implements OnInit {
       }
     };
     let configOptions = {
-      modeBarButtonsToRemove: ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'lasso2d', 'pan2d', 'select2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'],
+      modeBarButtonsToRemove: ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'pan2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'],
       displaylogo: false,
       displayModeBar: true,
       responsive: true
     };
 
-    this.plotlyService.newPlot(this.reportBarChart.nativeElement, this.barChartData, layout, configOptions);
+    this.plotlyService.newPlot(this.reportBarChart.nativeElement, this.barChartData, layout, defaultPlotlyConfig(configOptions));
   }
 
   createPrintChart() {
@@ -101,7 +101,7 @@ export class ReportSummaryBarChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false,
     };
-    this.plotlyService.newPlot(this.reportBarChart.nativeElement, this.barChartData, layout, configOptions);
+    this.plotlyService.newPlot(this.reportBarChart.nativeElement, this.barChartData, layout, defaultPlotlyConfig(configOptions));
   }
 
 

--- a/src/app/report-rollup/report-summary-graphs/report-summary-pie-chart/report-summary-pie-chart.component.ts
+++ b/src/app/report-rollup/report-summary-graphs/report-summary-pie-chart/report-summary-pie-chart.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit, Input, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, Input, ElementRef, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { PieChartDataItem } from '../../rollup-summary-pie-chart/rollup-summary-pie-chart.component';
-import { Settings } from '../../../shared/models/settings';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
     selector: 'app-report-summary-pie-chart',
     templateUrl: './report-summary-pie-chart.component.html',
@@ -116,7 +115,7 @@ export class ReportSummaryPieChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.reportSummaryPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.reportSummaryPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
   drawPrintPlot() {
@@ -180,7 +179,7 @@ export class ReportSummaryPieChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false
     };
-    this.plotlyService.newPlot(this.reportSummaryPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.reportSummaryPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
 

--- a/src/app/report-rollup/rollup-summary-bar-chart/rollup-summary-bar-chart.component.ts
+++ b/src/app/report-rollup/rollup-summary-bar-chart/rollup-summary-bar-chart.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ElementRef, ViewChild, Input } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../shared/helperFunctions';
 @Component({
     selector: 'app-rollup-summary-bar-chart',
     templateUrl: './rollup-summary-bar-chart.component.html',
@@ -75,7 +75,7 @@ export class RollupSummaryBarChartComponent implements OnInit {
       responsive: true
     };
 
-    this.plotlyService.newPlot(this.rollupBarChart.nativeElement, this.barChartData, layout, configOptions);
+    this.plotlyService.newPlot(this.rollupBarChart.nativeElement, this.barChartData, layout, defaultPlotlyConfig(configOptions));
   }
 
   createPrintChart() {
@@ -110,7 +110,7 @@ export class RollupSummaryBarChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false,
     };
-    this.plotlyService.newPlot(this.rollupBarChart.nativeElement, this.barChartData, layout, configOptions);
+    this.plotlyService.newPlot(this.rollupBarChart.nativeElement, this.barChartData, layout, defaultPlotlyConfig(configOptions));
   }
 }
 

--- a/src/app/report-rollup/rollup-summary-pie-chart/rollup-summary-pie-chart.component.ts
+++ b/src/app/report-rollup/rollup-summary-pie-chart/rollup-summary-pie-chart.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit, Input, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, Input, ElementRef, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../shared/helperFunctions';
 @Component({
     selector: 'app-rollup-summary-pie-chart',
     templateUrl: './rollup-summary-pie-chart.component.html',
@@ -101,7 +101,7 @@ export class RollupSummaryPieChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.rollupSummaryPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.rollupSummaryPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
   drawPrintPlot() {
@@ -158,7 +158,7 @@ export class RollupSummaryPieChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false
     };
-    this.plotlyService.newPlot(this.rollupSummaryPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.rollupSummaryPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 }
 

--- a/src/app/shared/fsat-sankey/fsat-sankey.component.ts
+++ b/src/app/shared/fsat-sankey/fsat-sankey.component.ts
@@ -6,7 +6,7 @@ import { FsatService } from '../../fsat/fsat.service';
 import { DecimalPipe } from '@angular/common';
 import { PlotlyService } from 'angular-plotly.js';
 import { SankeyNode } from '../models/sankey';
-
+import { defaultPlotlyConfig } from '../helperFunctions';
 
 @Component({
     selector: 'app-fsat-sankey',
@@ -226,7 +226,7 @@ export class FsatSankeyComponent implements OnInit {
       };
     }
 
-    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, config).then(() =>{
+    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, defaultPlotlyConfig(config)).then(() =>{
       this.addGradientElement();
       this.buildSvgArrows();
     });

--- a/src/app/shared/helperFunctions.ts
+++ b/src/app/shared/helperFunctions.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { FlatColors, graphColors } from './graphColors';
+import { SimpleChart } from './models/plotting';
 
 export function copyObject(object) {
     return cloneDeep(object);
@@ -43,4 +44,17 @@ export const getGraphColors = (): Array<string> => {
 export function getRandomFlatColor(): string {
     let randomIndex = Math.floor(Math.random() * FlatColors.length);
     return FlatColors[randomIndex];
+}
+
+
+// Returns a Plotly config object with base options, merging any provided config
+export function defaultPlotlyConfig(config?: Partial<SimpleChart['config']>): Partial<SimpleChart['config']> {
+    const mergedConfig = {
+        modeBarButtonsToRemove: ['select2d', 'lasso2d'],
+        displaylogo: false,
+        displayModeBar: true,
+        responsive: true,
+        ...config
+    };
+    return mergedConfig;
 }

--- a/src/app/shared/modules/weather-data/annual-station-data/annual-station-graph/annual-station-graph.component.ts
+++ b/src/app/shared/modules/weather-data/annual-station-data/annual-station-graph/annual-station-graph.component.ts
@@ -1,8 +1,7 @@
-import { Component, Input, ViewChild, ElementRef, SimpleChanges, inject } from '@angular/core';
+import { Component, Input, ViewChild, ElementRef, inject } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
-import { AnnualStationDataSummary } from '../annual-station-data.component';
 import { WeatherDataPoint } from '../../../../weather-api.service';
-
+import { defaultPlotlyConfig } from '../../../../../shared/helperFunctions';
 @Component({
     selector: 'app-annual-station-graph',
     templateUrl: './annual-station-graph.component.html',
@@ -92,7 +91,7 @@ export class AnnualStationGraphComponent {
                 displaylogo: false,
                 responsive: true,
             };
-            this.plotlyService.newPlot(this.annualDataChart.nativeElement, traceData, layout, config);
+            this.plotlyService.newPlot(this.annualDataChart.nativeElement, traceData, layout, defaultPlotlyConfig(config));
         }
     }
 

--- a/src/app/shared/modules/weather-data/weather-stations/weather-stations-map/weather-stations-map.component.ts
+++ b/src/app/shared/modules/weather-data/weather-stations/weather-stations-map/weather-stations-map.component.ts
@@ -2,7 +2,7 @@ import { Component, SimpleChanges, ElementRef, ViewChild, Input } from '@angular
 import { PlotlyService } from 'angular-plotly.js';
 import * as _ from 'lodash';
 import { WeatherStation } from '../../../../weather-api.service';
-
+import { defaultPlotlyConfig } from '../../../../helperFunctions';
 @Component({
   selector: 'app-weather-stations-map',
   templateUrl: './weather-stations-map.component.html',
@@ -123,7 +123,7 @@ export class WeatherStationsMapComponent {
       const allData = [this.stateLines, ...data];
 
       // Create the plot
-      this.plotlyService.newPlot(this.weatherStationMap.nativeElement, allData, layout, config);
+      this.plotlyService.newPlot(this.weatherStationMap.nativeElement, allData, layout, defaultPlotlyConfig(config));
     }
   }
 

--- a/src/app/shared/phast-sankey/phast-sankey.component.ts
+++ b/src/app/shared/phast-sankey/phast-sankey.component.ts
@@ -7,7 +7,7 @@ import { DecimalPipe } from "@angular/common";
 import { PlotlyService } from 'angular-plotly.js';
 import { FuelResults, SankeyService } from './sankey.service';
 import { SankeyNode } from '../models/sankey';
-
+import { defaultPlotlyConfig } from '../helperFunctions';
 
 @Component({
     selector: 'app-phast-sankey',
@@ -204,7 +204,7 @@ export class PhastSankeyComponent implements OnInit, OnChanges {
       responsive: true,
     };
 
-    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, config)
+    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, defaultPlotlyConfig(config))
       .then(chart => {
         this.addGradientElement();
         this.buildSvgArrows();

--- a/src/app/shared/plotly-bar-chart/plotly-bar-chart.component.ts
+++ b/src/app/shared/plotly-bar-chart/plotly-bar-chart.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, ElementRef, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../helperFunctions';
 @Component({
     selector: 'app-plotly-bar-chart',
     templateUrl: './plotly-bar-chart.component.html',
@@ -79,7 +80,7 @@ export class PlotlyBarChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.barChart.nativeElement, traces, layout, configOptions);
+    this.plotlyService.newPlot(this.barChart.nativeElement, traces, layout, defaultPlotlyConfig(configOptions));
   }
 
   drawPrintChart(){
@@ -115,7 +116,7 @@ export class PlotlyBarChartComponent implements OnInit {
       displayModeBar: false,
       responsive: false
     };
-    this.plotlyService.newPlot(this.barChart.nativeElement, traces, layout, configOptions);
+    this.plotlyService.newPlot(this.barChart.nativeElement, traces, layout, defaultPlotlyConfig(configOptions));
 
   }
 

--- a/src/app/shared/plotly-pie-chart/plotly-pie-chart.component.ts
+++ b/src/app/shared/plotly-pie-chart/plotly-pie-chart.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit, ElementRef, ViewChild, Input, HostListener } from '@angular/core';
+import { Component, OnInit, ElementRef, ViewChild, Input } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { graphColors } from '../graphColors';
-
+import { defaultPlotlyConfig } from '../helperFunctions';
 @Component({
     selector: 'app-plotly-pie-chart',
     templateUrl: './plotly-pie-chart.component.html',
@@ -76,7 +76,7 @@ export class PlotlyPieChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, [data], layout, modebarBtns);
+    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, [data], layout, defaultPlotlyConfig(modebarBtns));
   }
 
   drawPrintPlot() {
@@ -110,6 +110,6 @@ export class PlotlyPieChartComponent implements OnInit {
       displayModeBar: false
     };
 
-    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, [data], layout, modebarBtns);
+    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, [data], layout, defaultPlotlyConfig(modebarBtns));
   }
 }

--- a/src/app/shared/psat-sankey/psat-sankey.component.ts
+++ b/src/app/shared/psat-sankey/psat-sankey.component.ts
@@ -15,7 +15,7 @@ import { PsatService } from "../../psat/psat.service";
 import { DecimalPipe } from "@angular/common";
 import { PlotlyService } from "angular-plotly.js";
 import { SankeyNode } from "../models/sankey";
-
+import { defaultPlotlyConfig } from "../helperFunctions";
 @Component({
     selector: 'app-psat-sankey',
     templateUrl: './psat-sankey.component.html',
@@ -256,7 +256,7 @@ export class PsatSankeyComponent implements OnInit {
       };
     }
 
-    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, config).then(() => {
+    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, defaultPlotlyConfig(config)).then(() => {
       this.addGradientElement();
       this.buildSvgArrows();
     });

--- a/src/app/shared/ssmt-sankey/ssmt-sankey.component.ts
+++ b/src/app/shared/ssmt-sankey/ssmt-sankey.component.ts
@@ -8,7 +8,7 @@ import { SsmtService } from "../../ssmt/ssmt.service";
 import { DecimalPipe } from "@angular/common";
 import { PlotlyService } from "angular-plotly.js";
 import { SankeyNode } from "../models/sankey";
-
+import { defaultPlotlyConfig } from "../../shared/helperFunctions";
 
 @Component({
     selector: 'app-ssmt-sankey',
@@ -213,7 +213,7 @@ export class SsmtSankeyComponent implements OnInit, AfterViewInit, OnChanges {
       responsive: true,
     };
 
-    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, config)
+    this.plotlyService.newPlot(this.ngChart.nativeElement, [sankeyData], layout, defaultPlotlyConfig(config))
     .then(chart => {
       this.addGradientElement();
       this.buildSvgArrows();

--- a/src/app/ssmt/ssmt-report/report-graphs/ssmt-pie-chart/ssmt-pie-chart.component.ts
+++ b/src/app/ssmt/ssmt-report/report-graphs/ssmt-pie-chart/ssmt-pie-chart.component.ts
@@ -4,7 +4,7 @@ import { ReportGraphsService } from '../report-graphs.service';
 import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from '../../../../shared/models/settings';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-ssmt-pie-chart',
     templateUrl: './ssmt-pie-chart.component.html',
@@ -94,7 +94,7 @@ export class SsmtPieChartComponent implements OnInit {
         displayModeBar: true,
         responsive: true
       };
-      this.plotlyService.newPlot(this.ssmtPieChart.nativeElement, data, layout, modebarBtns);
+      this.plotlyService.newPlot(this.ssmtPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
     } else {
       this.noData = true;
       this.cd.detectChanges();
@@ -147,7 +147,7 @@ export class SsmtPieChartComponent implements OnInit {
         displaylogo: false,
         displayModeBar: false
       };
-      this.plotlyService.newPlot(this.ssmtPieChart.nativeElement, data, layout, modebarBtns);
+      this.plotlyService.newPlot(this.ssmtPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
     } else {
       this.noData = true;
       this.cd.detectChanges();

--- a/src/app/ssmt/ssmt-report/report-graphs/ssmt-waterfall/ssmt-waterfall.component.ts
+++ b/src/app/ssmt/ssmt-report/report-graphs/ssmt-waterfall/ssmt-waterfall.component.ts
@@ -2,10 +2,9 @@ import { Component, OnInit, Input, ElementRef, ViewChild } from '@angular/core';
 import { SSMT, SsmtValid } from '../../../../shared/models/steam/ssmt';
 import { SSMTLosses } from '../../../../shared/models/steam/steam-outputs';
 import { ReportGraphsService } from '../report-graphs.service';
-import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from '../../../../shared/models/settings';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-ssmt-waterfall',
     templateUrl: './ssmt-waterfall.component.html',
@@ -116,7 +115,7 @@ export class SsmtWaterfallComponent implements OnInit {
       responsive: true
     };
 
-    this.plotlyService.newPlot(this.ssmtWaterfall.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.ssmtWaterfall.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
   getSsmtWatefallData(ssmt: SSMT): Array<{ value: number, label: string, stackTraceValue: number, color: string }> {
@@ -189,7 +188,7 @@ export class SsmtWaterfallComponent implements OnInit {
       displayModeBar: false
     };
 
-    this.plotlyService.newPlot(this.ssmtWaterfall.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.ssmtWaterfall.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
 }

--- a/src/app/treasure-hunt/treasure-hunt-report/executive-summary/carbon-emissions-summary-pie-chart/carbon-emissions-summary-pie-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/executive-summary/carbon-emissions-summary-pie-chart/carbon-emissions-summary-pie-chart.component.ts
@@ -2,8 +2,8 @@ import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from '../../../../shared/models/settings';
-import { TreasureHuntCo2EmissionsResults, TreasureHuntResults } from '../../../../shared/models/treasure-hunt';
-
+import { TreasureHuntCo2EmissionsResults } from '../../../../shared/models/treasure-hunt';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-carbon-emissions-summary-pie-chart',
     templateUrl: './carbon-emissions-summary-pie-chart.component.html',
@@ -118,7 +118,7 @@ export class CarbonEmissionsSummaryPieChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
   drawPrintPlot() {
@@ -151,7 +151,7 @@ export class CarbonEmissionsSummaryPieChartComponent implements OnInit {
       displayModeBar: false,
       responsive: true
     };
-    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
 
 
   }

--- a/src/app/treasure-hunt/treasure-hunt-report/executive-summary/team-summary-pie-chart/team-summary-pie-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/executive-summary/team-summary-pie-chart/team-summary-pie-chart.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
 import { graphColors } from '../../../../shared/graphColors';
 import * as _ from 'lodash';
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-team-summary-pie-chart',
     templateUrl: './team-summary-pie-chart.component.html',
@@ -80,7 +81,7 @@ export class TeamSummaryPieChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
   drawPrintPlot() {
@@ -113,6 +114,6 @@ export class TeamSummaryPieChartComponent implements OnInit {
       displayModeBar: false,
       responsive: true
     };
-    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, modebarBtns);    
+    this.plotlyService.newPlot(this.plotlyPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));    
   }
 }

--- a/src/app/treasure-hunt/treasure-hunt-report/executive-summary/utility-bar-chart/utility-bar-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/executive-summary/utility-bar-chart/utility-bar-chart.component.ts
@@ -3,7 +3,7 @@ import { TreasureHuntResults } from '../../../../shared/models/treasure-hunt';
 import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from '../../../../shared/models/settings';
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-utility-bar-chart',
     templateUrl: './utility-bar-chart.component.html',
@@ -79,7 +79,7 @@ export class UtilityBarChartComponent implements OnInit {
       responsive: true
     };
 
-    this.plotlyService.newPlot(this.utilityBarChart.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.utilityBarChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
   createPrintBarChart() {
@@ -114,7 +114,7 @@ export class UtilityBarChartComponent implements OnInit {
       displayModeBar: false
     };
 
-    this.plotlyService.newPlot(this.utilityBarChart.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.utilityBarChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
   createRollupPrintBarChart() {
@@ -149,7 +149,7 @@ export class UtilityBarChartComponent implements OnInit {
       displayModeBar: false
     };
 
-    this.plotlyService.newPlot(this.utilityBarChart.nativeElement, data, layout, configOptions);
+    this.plotlyService.newPlot(this.utilityBarChart.nativeElement, data, layout, defaultPlotlyConfig(configOptions));
   }
 
   getDataObject(){

--- a/src/app/treasure-hunt/treasure-hunt-report/opportunity-payback/opportunity-payback-bar-chart/opportunity-payback-bar-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/opportunity-payback/opportunity-payback-bar-chart/opportunity-payback-bar-chart.component.ts
@@ -3,7 +3,7 @@ import { OpportunitiesPaybackDetails } from "../../../../shared/models/treasure-
 import { graphColors } from "../../../../shared/graphColors";
 import { Settings } from '../../../../shared/models/settings';
 import { PlotlyService } from "angular-plotly.js";
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: "app-opportunity-payback-bar-chart",
     templateUrl: "./opportunity-payback-bar-chart.component.html",
@@ -89,7 +89,7 @@ export class OpportunityPaybackBarChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.paybackBarChart.nativeElement, traces, layout, configOptions);
+    this.plotlyService.newPlot(this.paybackBarChart.nativeElement, traces, layout, defaultPlotlyConfig(configOptions));
 
   }
 
@@ -142,7 +142,7 @@ export class OpportunityPaybackBarChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false
     };
-    this.plotlyService.newPlot(this.paybackBarChart.nativeElement, traces, layout, configOptions);
+    this.plotlyService.newPlot(this.paybackBarChart.nativeElement, traces, layout, defaultPlotlyConfig(configOptions));
   }
 
   getLabelsAndData(): Array<{ label: string, data: number }> {

--- a/src/app/treasure-hunt/treasure-hunt-report/opportunity-payback/opportunity-payback-donut/opportunity-payback-donut.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/opportunity-payback/opportunity-payback-donut/opportunity-payback-donut.component.ts
@@ -3,6 +3,7 @@ import { OpportunitiesPaybackDetails } from '../../../../shared/models/treasure-
 import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from '../../../../shared/models/settings';
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-opportunity-payback-donut',
     templateUrl: './opportunity-payback-donut.component.html',
@@ -67,7 +68,7 @@ export class OpportunityPaybackDonutComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.paybackDonutChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.paybackDonutChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
   createPrintChart(){
@@ -102,7 +103,7 @@ export class OpportunityPaybackDonutComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false
     };
-    this.plotlyService.newPlot(this.paybackDonutChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.paybackDonutChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
 

--- a/src/app/treasure-hunt/treasure-hunt-report/report-graphs/cost-pie-chart/cost-pie-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/report-graphs/cost-pie-chart/cost-pie-chart.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
-import { TreasureHuntCo2EmissionsResults, TreasureHuntResults, UtilityUsageData } from '../../../../shared/models/treasure-hunt';
+import { TreasureHuntResults, UtilityUsageData } from '../../../../shared/models/treasure-hunt';
 import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from '../../../../shared/models/settings';
 import { PlotlyService } from 'angular-plotly.js';
 import { ConvertUnitsService } from '../../../../shared/convert-units/convert-units.service';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-cost-pie-chart',
     templateUrl: './cost-pie-chart.component.html',
@@ -81,7 +81,7 @@ export class CostPieChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.costPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.costPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
 
@@ -119,7 +119,7 @@ export class CostPieChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false,
     };
-    this.plotlyService.newPlot(this.costPieChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.costPieChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
 

--- a/src/app/treasure-hunt/treasure-hunt-report/report-graphs/effort-savings-chart/effort-savings-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/report-graphs/effort-savings-chart/effort-savings-chart.component.ts
@@ -6,7 +6,7 @@ import { SimpleChart, TraceData } from '../../../../shared/models/plotting';
 import { graphColors } from '../../../../shared/graphColors';
 import { Settings } from "../../../../shared/models/settings";
 import { PlotlyService } from 'angular-plotly.js';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 export interface ChartOpportunity {
   curveNumber: number,
   pointNumber: number,
@@ -131,7 +131,7 @@ export class EffortSavingsChartComponent implements OnInit {
 
   newPlot() {
     let chartLayout = JSON.parse(JSON.stringify(this.effortChart.layout));
-    this.plotlyService.newPlot(this.effortChartDiv.nativeElement, this.effortChart.data, chartLayout, this.effortChart.config)
+    this.plotlyService.newPlot(this.effortChartDiv.nativeElement, this.effortChart.data, chartLayout, defaultPlotlyConfig(this.effortChart.config))
       .then(chart => {
         chart.on('plotly_beforehover', () => {
           if (this.showingHoverLabels) {
@@ -192,7 +192,7 @@ export class EffortSavingsChartComponent implements OnInit {
 
     this.buildTrace();
     let chartLayout = JSON.parse(JSON.stringify(this.effortChart.layout));
-    this.plotlyService.newPlot(this.effortChartDiv.nativeElement, this.effortChart.data, chartLayout, this.effortChart.config);
+    this.plotlyService.newPlot(this.effortChartDiv.nativeElement, this.effortChart.data, chartLayout, defaultPlotlyConfig(this.effortChart.config));
   }
 
   updateVisibleLabels(legendClick) {

--- a/src/app/treasure-hunt/treasure-hunt-report/report-graphs/utility-donut-chart/utility-donut-chart.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-report/report-graphs/utility-donut-chart/utility-donut-chart.component.ts
@@ -1,9 +1,9 @@
-import { CurrencyPipe, DecimalPipe } from '@angular/common';
+import { CurrencyPipe } from '@angular/common';
 import { Component, OnInit, ViewChild, ElementRef, Input } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { graphColors } from '../../../../shared/graphColors';
 import { SavingsItem } from '../../../../shared/models/treasure-hunt';
-
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-utility-donut-chart',
     templateUrl: './utility-donut-chart.component.html',
@@ -95,7 +95,7 @@ export class UtilityDonutChartComponent implements OnInit {
       displayModeBar: true,
       responsive: true
     };
-    this.plotlyService.newPlot(this.utilityDonutChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.utilityDonutChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 
   createPrintChart() {
@@ -152,6 +152,6 @@ export class UtilityDonutChartComponent implements OnInit {
       displaylogo: false,
       displayModeBar: false
     };
-    this.plotlyService.newPlot(this.utilityDonutChart.nativeElement, data, layout, modebarBtns);
+    this.plotlyService.newPlot(this.utilityDonutChart.nativeElement, data, layout, defaultPlotlyConfig(modebarBtns));
   }
 }

--- a/src/app/waste-water/waste-water-analysis/energy-analysis/energy-analysis-bar-chart/energy-analysis-bar-chart.component.ts
+++ b/src/app/waste-water/waste-water-analysis/energy-analysis/energy-analysis-bar-chart/energy-analysis-bar-chart.component.ts
@@ -3,6 +3,7 @@ import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { WasteWaterAnalysisService } from '../../waste-water-analysis.service';
 import { Settings } from '../../../../shared/models/settings'; 
 import { PlotlyService } from 'angular-plotly.js';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-energy-analysis-bar-chart',
     templateUrl: './energy-analysis-bar-chart.component.html',
@@ -62,7 +63,7 @@ export class EnergyAnalysisBarChartComponent implements OnInit {
       displayModeBar: !this.printView,
       responsive: true,
     };
-    this.plotlyService.newPlot(this.analysisBarChart.nativeElement, traceData, layout, configOptions);
+    this.plotlyService.newPlot(this.analysisBarChart.nativeElement, traceData, layout, defaultPlotlyConfig(configOptions));
   }
 
   getEnergyCostData() {

--- a/src/app/waste-water/waste-water-analysis/waste-water-graphs/srt-graph/srt-graph.component.ts
+++ b/src/app/waste-water/waste-water-analysis/waste-water-graphs/srt-graph/srt-graph.component.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 import { DataTableVariable } from '../../dataTableVariables';
 import { PlotlyService } from 'angular-plotly.js';
 import * as Plotly from 'plotly.js-dist';
+import { defaultPlotlyConfig } from '../../../../shared/helperFunctions';
 @Component({
     selector: 'app-srt-graph',
     templateUrl: './srt-graph.component.html',
@@ -89,7 +90,7 @@ export class SrtGraphComponent implements OnInit {
       configOptions.modeBarButtonsToRemove = ['toggleHover', 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d', 'zoom2d', 'lasso2d', 'pan2d', 'select2d', 'toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'];
     }
 
-    this.plotlyService.newPlot(this.srtGraphItem.nativeElement, this.analysisGraphItem.traces, layout, configOptions).then(chart => {
+    this.plotlyService.newPlot(this.srtGraphItem.nativeElement, this.analysisGraphItem.traces, layout, defaultPlotlyConfig(configOptions)).then(chart => {
       chart.on('plotly_hover', (data) => {
         this.wasteWaterAnalysisService.xAxisHover.next(data.points);
       });

--- a/src/app/water/results-panel/monthly-flow-chart/monthly-flow-chart.component.ts
+++ b/src/app/water/results-panel/monthly-flow-chart/monthly-flow-chart.component.ts
@@ -4,7 +4,7 @@ import { PlotlyService } from 'angular-plotly.js';
 import { WaterAssessmentService } from '../../water-assessment.service';
 import { Subscription } from 'rxjs';
 import { DischargeOutlet, IntakeSource, WaterAssessment, WaterProcessComponentType } from 'process-flow-lib';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
   selector: 'app-monthly-flow-chart',
   standalone: false,
@@ -113,6 +113,6 @@ export class MonthlyFlowChartComponent {
       displaylogo: false
     }
 
-    this.plotlyService.newPlot(this.monthlyFlowChart.nativeElement, this.plantMonthlyFlowTraces, layout, config)
+    this.plotlyService.newPlot(this.monthlyFlowChart.nativeElement, this.plantMonthlyFlowTraces, layout, defaultPlotlyConfig(config))
   }
 }

--- a/src/app/water/water-report/stacked-bar-intake-costs/stacked-bar-intake-costs.component.ts
+++ b/src/app/water/water-report/stacked-bar-intake-costs/stacked-bar-intake-costs.component.ts
@@ -6,7 +6,7 @@ import { getGraphColors } from '../../../shared/helperFunctions';
 import { WaterAssessmentResultsService } from '../../water-assessment-results.service';
 import { PlantSystemSummaryResults } from 'process-flow-lib';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
   selector: 'app-stacked-bar-intake-costs',
   standalone: false,
@@ -147,7 +147,7 @@ export class StackedBarIntakeCostsComponent {
       responsive: this.printView ? false : true
     };
 
-    this.plotlyService.newPlot(this.intakeCostsChart.nativeElement, chartData, layout, configOptions)
+    this.plotlyService.newPlot(this.intakeCostsChart.nativeElement, chartData, layout, defaultPlotlyConfig(configOptions))
     .then(chart => {
           chart.on('plotly_legendclick', event => false);
           chart.on('plotly_legenddoubleclick', event => false);

--- a/src/app/water/water-report/stacked-bar-intake-flow/stacked-bar-intake-flow.component.ts
+++ b/src/app/water/water-report/stacked-bar-intake-flow/stacked-bar-intake-flow.component.ts
@@ -7,7 +7,7 @@ import { WaterAssessmentService } from '../../water-assessment.service';
 import { getGraphColors } from '../../../shared/helperFunctions';
 import { WaterAssessmentResultsService } from '../../water-assessment-results.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
   selector: 'app-stacked-bar-intake-flow',
   standalone: false,
@@ -128,7 +128,7 @@ export class StackedBarIntakeFlowComponent {
       responsive: this.printView ? false : true
     };
 
-    this.plotlyService.newPlot(this.intakeFlowsChart.nativeElement, chartData, layout, configOptions);
+    this.plotlyService.newPlot(this.intakeFlowsChart.nativeElement, chartData, layout, defaultPlotlyConfig(configOptions));
   }
 
 

--- a/src/app/water/water-report/system-true-cost-bar/system-true-cost-bar.component.ts
+++ b/src/app/water/water-report/system-true-cost-bar/system-true-cost-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, ElementRef, inject, Input, ViewChild } from '@angular/core';
+import { Component, DestroyRef, ElementRef, inject, ViewChild } from '@angular/core';
 import { PlotlyService } from 'angular-plotly.js';
 import { Subscription } from 'rxjs';
 import * as _ from 'lodash';
@@ -6,7 +6,7 @@ import { PrintOptionsMenuService } from '../../../shared/print-options-menu/prin
 import { WaterAssessmentResultsService } from '../../water-assessment-results.service';
 import { sortTrueCostReport, SystemTrueCostData } from 'process-flow-lib';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
+import { defaultPlotlyConfig } from '../../../shared/helperFunctions';
 @Component({
   selector: 'app-system-true-cost-bar',
   standalone: false,
@@ -118,7 +118,7 @@ export class SystemTrueCostBarComponent {
         displayModeBar: true,
         responsive: this.printView? false : true
       };
-      this.plotlyService.newPlot(this.systemTrueCostBarChart.nativeElement, chartData, layout, configOptions);  
+      this.plotlyService.newPlot(this.systemTrueCostBarChart.nativeElement, chartData, layout, defaultPlotlyConfig(configOptions));  
   }
 
 


### PR DESCRIPTION
#8282

## Description
- Plotly toolbars have too many options for editing the graph and must be slimmed down. for starters, lasso and box select along with the Plotly logo/link should be removed.
- Context: Plotly graphs have 3-5 different implementation strategies, but all require this adjustment to be made. >60 files must be changed so creating a central helper function to centralize the default functionality is the right move.
- helperFunction.ts now has a function to apply the default adjustments to the plotly modebar.
- Each usage of newPlot now wraps it's config argument in the helper function, which applies the default config settings.
- Provides options to expand functionality.