### PR TITLE
8332 - Tooltip adjustment for Enthalpy and Pressure

### DIFF
--- a/src/app/calculator/steam/saturated-properties/saturated-properties-ph-chart/saturated-properties-ph-chart.component.ts
+++ b/src/app/calculator/steam/saturated-properties/saturated-properties-ph-chart/saturated-properties-ph-chart.component.ts
@@ -156,7 +156,7 @@ export class SaturatedPropertiesPhChartComponent implements OnInit, OnChanges {
       let trace = this.saturatedPropertiesService.getEmptyTrace();
       trace.x = line.enthalpy;
       trace.y = line.pressure;
-      trace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, true);
+      trace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, false);
       this.enthalpyChart.data.push(trace);
     });
   }
@@ -189,7 +189,7 @@ export class SaturatedPropertiesPhChartComponent implements OnInit, OnChanges {
     domeOutlineTrace.line.width = 2;
     domeOutlineTrace.line.color = "#000000";
     domeOutlineTrace.name = "Saturated"
-    domeOutlineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, true);
+    domeOutlineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, false);
 
     this.enthalpyChart.data.push(domeFillTrace, domeOutlineTrace);
   }
@@ -208,7 +208,7 @@ export class SaturatedPropertiesPhChartComponent implements OnInit, OnChanges {
     let lineTrace = this.saturatedPropertiesService.getLineTrace(x, y);
     lineTrace.marker.color = graphColors[0];
     lineTrace.marker.line.color = graphColors[0];
-    lineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEntropyMeasurement, this.settings.steamTemperatureMeasurement, true);
+    lineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEntropyMeasurement, this.settings.steamTemperatureMeasurement, false);
 
     if (this.enthalpyChart.existingPoint) {
       this.enthalpyChart.data[this.enthalpyChart.data.length - 1] = lineTrace;

--- a/src/app/calculator/steam/saturated-properties/saturated-properties-ph-chart/saturated-properties-ph-chart.component.ts
+++ b/src/app/calculator/steam/saturated-properties/saturated-properties-ph-chart/saturated-properties-ph-chart.component.ts
@@ -208,7 +208,7 @@ export class SaturatedPropertiesPhChartComponent implements OnInit, OnChanges {
     let lineTrace = this.saturatedPropertiesService.getLineTrace(x, y);
     lineTrace.marker.color = graphColors[0];
     lineTrace.marker.line.color = graphColors[0];
-    lineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEntropyMeasurement, this.settings.steamTemperatureMeasurement, false);
+    lineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, false);
 
     if (this.enthalpyChart.existingPoint) {
       this.enthalpyChart.data[this.enthalpyChart.data.length - 1] = lineTrace;

--- a/src/app/calculator/steam/steam-properties/steam-properties-ph-chart/steam-properties-ph-chart.component.ts
+++ b/src/app/calculator/steam/steam-properties/steam-properties-ph-chart/steam-properties-ph-chart.component.ts
@@ -194,7 +194,7 @@ export class SteamPropertiesPhChartComponent implements OnInit {
     domeOutlineTrace.line.width = 2;
     domeOutlineTrace.line.color = "#000000";
     domeOutlineTrace.name = "Saturated"
-    domeOutlineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, true);
+    domeOutlineTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, false);
 
     this.enthalpyChart.data.push(domeFillTrace, domeOutlineTrace);
   }
@@ -208,7 +208,7 @@ export class SteamPropertiesPhChartComponent implements OnInit {
     pointTrace.marker.color = graphColors[0];
     pointTrace.x = [enthalpy];
     pointTrace.y = [convertedPressure];
-    pointTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, true);
+    pointTrace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, false);
 
     if (this.enthalpyChart.existingPoint) {
       this.enthalpyChart.data[this.enthalpyChart.data.length - 1] = pointTrace;

--- a/src/app/calculator/steam/steam-properties/steam-properties-ph-chart/steam-properties-ph-chart.component.ts
+++ b/src/app/calculator/steam/steam-properties/steam-properties-ph-chart/steam-properties-ph-chart.component.ts
@@ -161,7 +161,7 @@ export class SteamPropertiesPhChartComponent implements OnInit {
       let trace = this.saturatedPropertiesService.getEmptyTrace();
       trace.x = line.enthalpy;
       trace.y = line.pressure;
-      trace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, true);
+      trace.hovertemplate = this.saturatedPropertiesService.getHoverTemplate(this.settings.steamSpecificEnthalpyMeasurement, this.settings.steamPressureMeasurement, false);
       this.enthalpyChart.data.push(trace);
     });
   }


### PR DESCRIPTION
#8332 
- Adjusted function calls to show correct tooltips depending on what graph is shown. 
- For both Saturated and Steam Properties.
- Functionality was already present, but the boolean value was incorrect.
