### PR TITLE
Issue 8187 - Color Picker Functional Correction

### DIFF
--- a/process-flow-diagram-component/src/App.css
+++ b/process-flow-diagram-component/src/App.css
@@ -252,44 +252,9 @@ a {
 }
 
 .react-flow__node-summingNode.expandIcon:hover {
-      box-shadow: 0px 3.54px 4.55px 0px #00000005, 
-      0px 3.54px 4.55px 0px #0000000D, 
-      0px 0.51px 1.01px 0px #0000001A
-}
-
-.react-flow__node-summingNode,
-.react-flow__node-group {
-  min-width: 150px;
-  border: 1px solid rgb(108, 117, 125);
-  background-color: rgb(108, 117, 125);
-}
-
-.react-flow__node-waterIntake,
-.react-flow__node-group {
-  /* background-color: var(--water-intake); */
-  background-color: #75a1ff;
-}
-
-.react-flow__node-waterUsingSystem,
-.react-flow__node-group {
-  /* background-color: var(--water-using-system); */
-  background-color: rgb(0, 187, 255);
-}
-
-.react-flow__node-waterDischarge,
-.react-flow__node-group {
-  /* background-color: var(--water-discharge); */
-  background-color: rgb(127, 127, 255);
-}
-
-.react-flow__node-waterTreatment,
-.react-flow__node-group {
-  background-color: #009386;
-}
-
-.react-flow__node-wasteWaterTreatment,
-.react-flow__node-group {
-  background-color: #93e200;
+  box-shadow: 0px 3.54px 4.55px 0px #00000005, 
+  0px 3.54px 4.55px 0px #0000000D, 
+  0px 0.51px 1.01px 0px #0000001A
 }
 
 

--- a/process-flow-diagram-component/src/App.css
+++ b/process-flow-diagram-component/src/App.css
@@ -257,11 +257,6 @@ a {
   0px 0.51px 1.01px 0px #0000001A
 }
 
-.react-flow__node-summingNode,
-.react-flow__node-group {
-  min-width: 150px;
-}
-
 .react-flow__handle.knownLoss-handle {
   background-color: #ffffff;
   border-radius: 2px;
@@ -473,7 +468,6 @@ a {
   width: 16px;
   height: 16px;
   cursor: pointer;
-  accent-color: #1976d2;
 }
 
 .diagram-checkbox-label {

--- a/process-flow-diagram-component/src/App.css
+++ b/process-flow-diagram-component/src/App.css
@@ -469,6 +469,7 @@ a {
   width: 16px;
   height: 16px;
   cursor: pointer;
+  accent-color: #1976d2;
 }
 
 .diagram-checkbox-label {

--- a/process-flow-diagram-component/src/App.css
+++ b/process-flow-diagram-component/src/App.css
@@ -257,6 +257,10 @@ a {
   0px 0.51px 1.01px 0px #0000001A
 }
 
+.react-flow__node-summingNode,
+.react-flow__node-group {
+  min-width: 150px;
+}
 
 .react-flow__handle.knownLoss-handle {
   background-color: #ffffff;

--- a/process-flow-diagram-component/src/components/Diagram/Diagram.tsx
+++ b/process-flow-diagram-component/src/components/Diagram/Diagram.tsx
@@ -58,6 +58,7 @@ const Diagram = (props: DiagramProps) => {
   const settings: DiagramSettings = useAppSelector((state: RootState) => state.diagram.settings);
   const recentNodeColors = useAppSelector((state: RootState) => state.diagram.recentNodeColors);
   const recentEdgeColors = useAppSelector((state: RootState) => state.diagram.recentEdgeColors);
+  const paletteColors = useAppSelector((state: RootState) => state.diagram.paletteColors);
   const calculatedData: DiagramCalculatedData = useAppSelector((state: RootState) => state.diagram.calculatedData);
   const animated: boolean = useAppSelector((state: RootState) => state.diagram.diagramOptions.animated);
   const minimapVisible: boolean = useAppSelector((state: RootState) => state.diagram.diagramOptions.minimapVisible);
@@ -109,12 +110,13 @@ const Diagram = (props: DiagramProps) => {
         calculatedData,
         recentNodeColors,
         recentEdgeColors,
+        paletteColors,
         diagramNotes: debouncedDiagramNotes
       };
       formatDataForMEASUR(updatedDiagramData);
       props.saveFlowDiagramData(updatedDiagramData);
     }
-  }, [debouncedNodes, debouncedEdges, userDiagramOptions, settings, debouncedDiagramNotes]);
+  }, [debouncedNodes, debouncedEdges, userDiagramOptions, settings, debouncedDiagramNotes, paletteColors]);
   const onDragOver = useCallback((event) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';

--- a/process-flow-diagram-component/src/components/Diagram/Diagram.tsx
+++ b/process-flow-diagram-component/src/components/Diagram/Diagram.tsx
@@ -58,7 +58,7 @@ const Diagram = (props: DiagramProps) => {
   const settings: DiagramSettings = useAppSelector((state: RootState) => state.diagram.settings);
   const recentNodeColors = useAppSelector((state: RootState) => state.diagram.recentNodeColors);
   const recentEdgeColors = useAppSelector((state: RootState) => state.diagram.recentEdgeColors);
-  const paletteColors = useAppSelector((state: RootState) => state.diagram.paletteColors);
+  const paletteColors = userDiagramOptions.paletteColors;
   const calculatedData: DiagramCalculatedData = useAppSelector((state: RootState) => state.diagram.calculatedData);
   const animated: boolean = useAppSelector((state: RootState) => state.diagram.diagramOptions.animated);
   const minimapVisible: boolean = useAppSelector((state: RootState) => state.diagram.diagramOptions.minimapVisible);
@@ -110,7 +110,6 @@ const Diagram = (props: DiagramProps) => {
         calculatedData,
         recentNodeColors,
         recentEdgeColors,
-        paletteColors,
         diagramNotes: debouncedDiagramNotes
       };
       formatDataForMEASUR(updatedDiagramData);

--- a/process-flow-diagram-component/src/components/Diagram/FlowUtils.ts
+++ b/process-flow-diagram-component/src/components/Diagram/FlowUtils.ts
@@ -288,3 +288,20 @@ export const getFlowDisplayValues = (componentEdges: Edge<CustomEdgeData>[]) => 
     return flowValue;
   });
 }
+
+/** Returns black or white for best contrast against the given hex background color. */
+export function getContrastTextColor(bgColor: string): string {
+  const hex = bgColor.replace('#', '');
+  let r = 0, g = 0, b = 0;
+  if (hex.length === 3) {
+    r = parseInt(hex[0] + hex[0], 16);
+    g = parseInt(hex[1] + hex[1], 16);
+    b = parseInt(hex[2] + hex[2], 16);
+  } else if (hex.length === 6) {
+    r = parseInt(hex.substring(0, 2), 16);
+    g = parseInt(hex.substring(2, 4), 16);
+    b = parseInt(hex.substring(4, 6), 16);
+  }
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? '#000' : '#fff';
+}

--- a/process-flow-diagram-component/src/components/Diagram/FlowUtils.ts
+++ b/process-flow-diagram-component/src/components/Diagram/FlowUtils.ts
@@ -303,5 +303,5 @@ export function getContrastTextColor(bgColor: string): string {
     b = parseInt(hex.substring(4, 6), 16);
   }
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.6 ? '#000' : '#fff';
+  return luminance > 0.6 ? '#000000' : '#ffffff';
 }

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -59,7 +59,6 @@ export interface DiagramState {
   manageDataTabs: ManageDataTab[],
   diagramAlert: DiagramAlertState,
   diagramNotes: string,
-  paletteColors: string[],
 }
 
 export const getDefaultDiagramData = (currentState?: DiagramState): DiagramState => {
@@ -69,7 +68,7 @@ export const getDefaultDiagramData = (currentState?: DiagramState): DiagramState
     edges: [],
     composedNodeData: [],
     settings: getDefaultSettings(),
-    diagramOptions: getDefaultUserDiagramOptions(),
+    diagramOptions: { ...getDefaultUserDiagramOptions(), paletteColors: getDefaultPaletteColors() },
     isDataDrawerOpen: false,
     isMenuDrawerOpen: true,
     selectedDataId: undefined,
@@ -92,7 +91,6 @@ export const getDefaultDiagramData = (currentState?: DiagramState): DiagramState
       open: false,
     },
     diagramNotes: '',
-    paletteColors: getDefaultPaletteColors(),
   }
 }
 
@@ -130,8 +128,7 @@ const diagramInitializedReducer = (state: DiagramState, action: PayloadAction<{ 
   state.nodeErrors = diagramData.nodeErrors ? { ...diagramData.nodeErrors } : {};
   state.recentNodeColors = diagramData.recentNodeColors.length !== 0 ? { ...diagramData.recentNodeColors } : getDefaultColorPalette();
   state.recentEdgeColors = diagramData.recentEdgeColors.length !== 0 ? { ...diagramData.recentEdgeColors } : getDefaultColorPalette();
-  state.paletteColors = diagramData.paletteColors ?? getDefaultPaletteColors();
-  state.isDataDrawerOpen = false;
+state.diagramOptions.paletteColors = diagramData.userDiagramOptions?.paletteColors ?? getDefaultPaletteColors();  state.isDataDrawerOpen = false;
   state.isMenuDrawerOpen = state.isMenuDrawerOpen ?? true;
   state.focusedEdgeId = undefined;
   state.selectedDataId = undefined;
@@ -165,7 +162,7 @@ const addNodeReducer = (state: DiagramState, action: PayloadAction<{ nodeType: W
   // * modifiedDate is not currently being read in the app
   newNode.data.modifiedDate = getStoreSerializedDate(newNode.data.modifiedDate as Date);
   // Apply the active palette color for this node's component type
-  const paletteColor = getPaletteColorForType(nodeType, state.paletteColors);
+  const paletteColor = getPaletteColorForType(nodeType, state.diagramOptions.paletteColors ?? getDefaultPaletteColors());
   if (paletteColor) {
     if (!newNode.style) newNode.style = {};
     newNode.style.backgroundColor = paletteColor;
@@ -488,7 +485,7 @@ const setDiagramNotesReducer = (state: DiagramState, action: PayloadAction<strin
  */
 const setPaletteColorsReducer = (state: DiagramState, action: PayloadAction<string[]>) => {
   const palette = action.payload;
-  state.paletteColors = palette;
+  state.diagramOptions.paletteColors = palette;
   state.nodes = state.nodes.map((node: Node<ProcessFlowPart>) => {
     const paletteColor = getPaletteColorForType(node.data.processComponentType as WaterProcessComponentType, palette);
     if (!paletteColor) {

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -5,12 +5,34 @@ import { CSSProperties } from 'react';
 import { FormikErrors } from 'formik';
 import { ValidationWindowLocation } from './ValidationWindow';
 import { ComponentManageDataTabs, CustomEdgeData, DiagramAlertMessages, DiagramCalculatedData, DiagramSettings, FlowDiagramData, FlowErrors, Handles, MAX_FLOW_DECIMALS, ManageDataTab, NodeErrors, NodeFlowData, ParentContainerDimensions, ProcessFlowNodeType, ProcessFlowPart, UserDiagramOptions, WaterProcessComponentType, WaterSystemResults, WaterTreatment, convertFlowDiagramData, getConnectionFromEdgeId, getDefaultColorPalette, getDefaultSettings, getDefaultUserDiagramOptions, getEdgeDescription, getEdgeFromConnection } from 'process-flow-lib';
-import { createNewNode, getNodeSourceEdges, getNodeFlowTotals, setCalculatedNodeDataProperty, getNodeTargetEdges, formatDecimalPlaces, formatDataForMEASUR, formatNumberValue } from './FlowUtils';
+import { createNewNode, getNodeSourceEdges, getNodeFlowTotals, setCalculatedNodeDataProperty, getNodeTargetEdges, formatDecimalPlaces, formatDataForMEASUR, formatNumberValue, getContrastTextColor } from './FlowUtils';
 import { EstimatedFlowResults } from '../Forms/WaterSystemEstimation/SystemEstimationFormUtils';
 import { DiagramAlertState } from './DiagramAlert';
 
 import packageJson from '../../../package.json';
 const CURRENT_DIAGRAM_VERSION: string = packageJson.version;
+
+/**
+ * Maps palette array index to its WaterProcessComponentType.
+ * Must stay in sync with allPalettes ordering in ColorPaletteDropdown.
+ */
+export const PALETTE_COMPONENT_ORDER: WaterProcessComponentType[] = [
+  'water-intake',
+  'water-using-system',
+  'water-discharge',
+  'water-treatment',
+  'waste-water-treatment',
+  'known-loss',
+];
+
+export const getDefaultPaletteColors = (): string[] => [
+  '#75a1ff', '#00bbff', '#7f7fff', '#009386', '#93e200', '#ffffff'
+];
+
+export const getPaletteColorForType = (type: WaterProcessComponentType, paletteColors: string[]): string | undefined => {
+  const typeIndex = PALETTE_COMPONENT_ORDER.indexOf(type);
+  return typeIndex !== -1 && paletteColors[typeIndex] ? paletteColors[typeIndex] : undefined;
+};
 
 export interface DiagramState {
   name: string,
@@ -37,6 +59,7 @@ export interface DiagramState {
   manageDataTabs: ManageDataTab[],
   diagramAlert: DiagramAlertState,
   diagramNotes: string,
+  paletteColors: string[],
 }
 
 export const getDefaultDiagramData = (currentState?: DiagramState): DiagramState => {
@@ -69,6 +92,7 @@ export const getDefaultDiagramData = (currentState?: DiagramState): DiagramState
       open: false,
     },
     diagramNotes: '',
+    paletteColors: getDefaultPaletteColors(),
   }
 }
 
@@ -106,6 +130,7 @@ const diagramInitializedReducer = (state: DiagramState, action: PayloadAction<{ 
   state.nodeErrors = diagramData.nodeErrors ? { ...diagramData.nodeErrors } : {};
   state.recentNodeColors = diagramData.recentNodeColors.length !== 0 ? { ...diagramData.recentNodeColors } : getDefaultColorPalette();
   state.recentEdgeColors = diagramData.recentEdgeColors.length !== 0 ? { ...diagramData.recentEdgeColors } : getDefaultColorPalette();
+  state.paletteColors = diagramData.paletteColors ?? getDefaultPaletteColors();
   state.isDataDrawerOpen = false;
   state.isMenuDrawerOpen = state.isMenuDrawerOpen ?? true;
   state.focusedEdgeId = undefined;
@@ -139,6 +164,13 @@ const addNodeReducer = (state: DiagramState, action: PayloadAction<{ nodeType: W
   let newNode: Node = createNewNode(nodeType, position, existingNames);
   // * modifiedDate is not currently being read in the app
   newNode.data.modifiedDate = getStoreSerializedDate(newNode.data.modifiedDate as Date);
+  // Apply the active palette color for this node's component type
+  const paletteColor = getPaletteColorForType(nodeType, state.paletteColors);
+  if (paletteColor) {
+    if (!newNode.style) newNode.style = {};
+    newNode.style.backgroundColor = paletteColor;
+    newNode.style.color = getContrastTextColor(paletteColor);
+  }
   state.nodes.push(newNode);
 };
 
@@ -450,6 +482,22 @@ const setDiagramNotesReducer = (state: DiagramState, action: PayloadAction<strin
   state.diagramNotes = action.payload;
 };
 
+/**
+ * Apply a full color palette to all nodes, coloring each by its processComponentType.
+ * Uses the same node.style.backgroundColor pattern as setNodeColorReducer.
+ */
+const setPaletteColorsReducer = (state: DiagramState, action: PayloadAction<string[]>) => {
+  const palette = action.payload;
+  state.paletteColors = palette;
+  state.nodes = state.nodes.map((node: Node<ProcessFlowPart>) => {
+    const paletteColor = getPaletteColorForType(node.data.processComponentType as WaterProcessComponentType, palette);
+    if (!paletteColor) {
+      return node;
+    }
+    return { ...node, style: { ...node.style, backgroundColor: paletteColor, color: getContrastTextColor(paletteColor) } };
+  });
+};
+
 const unitsOfMeasureChangeReducer = (state: DiagramState, action: PayloadAction<string>) => {
   const convertedDiagramData = {
     nodes: state.nodes,
@@ -619,6 +667,7 @@ export const diagramSlice = createSlice({
     edgesChangeFromPropagation: edgesChangeFromPropagationReducer,
     sumTotalFlowChange: sumTotalFlowChangeReducer,
     setDiagramNotes: setDiagramNotesReducer,
+    setPaletteColors: setPaletteColorsReducer,
   }
 })
 
@@ -666,7 +715,8 @@ export const {
   diagramAlertChange,
   toggleMenuDrawer,
   edgesChangeFromPropagation,
-  setDiagramNotes
+  setDiagramNotes,
+  setPaletteColors,
 } = diagramSlice.actions
 export default diagramSlice.reducer
 

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -21,8 +21,7 @@ export const PALETTE_COMPONENT_ORDER: WaterProcessComponentType[] = [
   'water-using-system',
   'water-discharge',
   'water-treatment',
-  'waste-water-treatment',
-  'known-loss',
+  'waste-water-treatment'
 ];
 
 export const getDefaultPaletteColors = (): string[] => [
@@ -128,7 +127,8 @@ const diagramInitializedReducer = (state: DiagramState, action: PayloadAction<{ 
   state.nodeErrors = diagramData.nodeErrors ? { ...diagramData.nodeErrors } : {};
   state.recentNodeColors = diagramData.recentNodeColors.length !== 0 ? { ...diagramData.recentNodeColors } : getDefaultColorPalette();
   state.recentEdgeColors = diagramData.recentEdgeColors.length !== 0 ? { ...diagramData.recentEdgeColors } : getDefaultColorPalette();
-  state.diagramOptions.paletteColors = diagramData.userDiagramOptions?.paletteColors ?? getDefaultPaletteColors();  state.isDataDrawerOpen = false;
+  state.diagramOptions.paletteColors = diagramData.userDiagramOptions?.paletteColors ?? getDefaultPaletteColors();  
+  state.isDataDrawerOpen = false;
   state.isMenuDrawerOpen = state.isMenuDrawerOpen ?? true;
   state.focusedEdgeId = undefined;
   state.selectedDataId = undefined;

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -164,9 +164,7 @@ const addNodeReducer = (state: DiagramState, action: PayloadAction<{ nodeType: W
   // Apply the active palette color for this node's component type
   const paletteColor = getPaletteColorForType(nodeType, state.diagramOptions.paletteColors ?? getDefaultPaletteColors());
   if (paletteColor) {
-    if (!newNode.style) newNode.style = {};
-    newNode.style.backgroundColor = paletteColor;
-    newNode.style.color = getContrastTextColor(paletteColor);
+    newNode.style = { ...newNode.style, backgroundColor: paletteColor, color: getContrastTextColor(paletteColor) };
   }
   state.nodes.push(newNode);
 };

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -128,7 +128,7 @@ const diagramInitializedReducer = (state: DiagramState, action: PayloadAction<{ 
   state.nodeErrors = diagramData.nodeErrors ? { ...diagramData.nodeErrors } : {};
   state.recentNodeColors = diagramData.recentNodeColors.length !== 0 ? { ...diagramData.recentNodeColors } : getDefaultColorPalette();
   state.recentEdgeColors = diagramData.recentEdgeColors.length !== 0 ? { ...diagramData.recentEdgeColors } : getDefaultColorPalette();
-state.diagramOptions.paletteColors = diagramData.userDiagramOptions?.paletteColors ?? getDefaultPaletteColors();  state.isDataDrawerOpen = false;
+  state.diagramOptions.paletteColors = diagramData.userDiagramOptions?.paletteColors ?? getDefaultPaletteColors();  state.isDataDrawerOpen = false;
   state.isMenuDrawerOpen = state.isMenuDrawerOpen ?? true;
   state.focusedEdgeId = undefined;
   state.selectedDataId = undefined;

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -26,7 +26,7 @@ export const PALETTE_COMPONENT_ORDER: WaterProcessComponentType[] = [
 ];
 
 export const getDefaultPaletteColors = (): string[] => [
-  '#75a1ff', '#00bbff', '#7f7fff', '#009386', '#93e200', '#ffffff'
+  '#75a1ff', '#00bbff', '#7f7fff', '#009386', '#93e200'
 ];
 
 export const getPaletteColorForType = (type: WaterProcessComponentType, paletteColors: string[]): string | undefined => {

--- a/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import { getContrastTextColor } from '../Diagram/FlowUtils';
+
+interface ColorPaletteDropdownProps {
+  selected: number;
+  onChange: (idx: number) => void;
+}
+
+export const mainPalettes = [
+  ['#75a1ff', '#00bbff', '#7f7fff', '#009386', '#93e200', '#ffffff'],
+  ['#88EFBF', '#FE5000', '#008A8F', '#B50094', '#FFFFFF', '#BDBDBD'],
+  ['#00B8B5', '#42008E', '#373A36', '#006BA6', '#005776', '#BDBDBD'],
+  ['#00662C', '#88EFBF', '#F9BF1B', '#008A8F', '#006BA6', '#BDBDBD'],
+  ['#00454D', '#7DA800', '#FE5000', '#e60b0b', '#ffffff', '#DBDCDB'],
+];
+// 3 colorblind-friendly palettes (user provided, with gray as 6th color)
+export const colorblindPalettes = [
+  ['#FFD600', '#2962FF', '#00C853', '#FF6D00', '#30352e', '#BDBDBD'],
+  ['#D5810B', '#DF69F7', '#1C24F2', '#00B30C', '#EEFF00', '#BDBDBD'],
+  ['#D50000', '#FFD600', '#00C853', '#2962FF', '#AA00FF', '#BDBDBD'],
+];
+export const allPalettes = [...mainPalettes, ...colorblindPalettes];
+
+
+const ColorRow: React.FC<{ colors: string[]; style?: React.CSSProperties }> = ({ colors, style }) => (
+  <div style={{ display: 'flex', gap: 8, margin: '8px 0', ...style }}>
+    {colors.map((color, idx) => {
+      const textColor = getContrastTextColor(color);
+      return (
+        <div
+          key={color + idx}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 6,
+            background: color,
+            border: '1px solid #ccc',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: textColor,
+            fontWeight: 600,
+            fontSize: 14
+          }}
+        >
+        </div>
+      );
+    })}
+  </div>
+);
+
+
+const ColorPaletteDropdown: React.FC<ColorPaletteDropdownProps> = ({ selected, onChange }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ margin: '24px 0', position: 'relative' }}>
+      <h3 style={{ fontSize: 16, marginBottom: 12 }}>Color Options</h3>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          cursor: 'pointer',
+          border: '2px solid #1976d2',
+          borderRadius: 8,
+          padding: 2,
+          background: '#f5faff',
+          minWidth: 210,
+          boxShadow: open ? '0 2px 8px rgba(0,0,0,0.15)' : undefined,
+        }}
+        onClick={() => setOpen((prev) => !prev)}
+        title="Select color palette"
+        >  <ColorRow colors={allPalettes[selected]} style={{ margin: 0 }} />
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ display: 'inline', verticalAlign: 'middle', marginLeft: 8 }}
+        >
+          {open ? (
+            <path d="M5 13l5-5 5 5" stroke="#1976d2" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          ) : (
+            <path d="M5 7l5 5 5-5" stroke="#1976d2" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          )}
+        </svg>
+      </div>
+      {open && (
+        <ClickAwayListener onClickAway={() => setOpen(false)}>
+          <div
+            style={{
+              position: 'absolute',
+              zIndex: 10,
+              background: '#fff',
+              border: '1px solid #ccc',
+              borderRadius: 8,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+              marginTop: 8,
+              left: 0,
+              minWidth: 210,
+              padding: 8,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+            }}
+          >
+            {allPalettes.map((palette, i) => {
+              if (i === mainPalettes.length) {
+                return [
+                  <div key="cb-header" style={{ fontSize: 13, color: '#000', fontWeight: 600, padding: '4px 0 2px 0', borderBottom: '1px solid #eee', margin: '4px 0 2px 0' }}>
+                    Colorblind Palettes
+                  </div>,
+                  <div
+                    key={i}
+                    onClick={() => {
+                      onChange(i);
+                      setOpen(false);
+                    }}
+                    style={{
+                      cursor: 'pointer',
+                      border: selected === i ? '2px solid #1976d2' : '2px solid transparent',
+                      borderRadius: 8,
+                      padding: 2,
+                      background: selected === i ? '#f5faff' : 'transparent',
+                      display: 'flex',
+                      alignItems: 'center',
+                      transition: 'border 0.2s, box-shadow 0.2s',
+                    }}
+                    title={`Select colorblind palette ${i - mainPalettes.length + 1}`}
+                  >
+                    <ColorRow colors={palette} style={{ margin: 0 }} />
+                  </div>
+                ];
+              }
+              return (
+                <div
+                  key={i}
+                  onClick={() => {
+                    onChange(i);
+                    setOpen(false);
+                  }}
+                  style={{
+                    cursor: 'pointer',
+                    border: selected === i ? '2px solid #1976d2' : '2px solid transparent',
+                    borderRadius: 8,
+                    padding: 2,
+                    background: selected === i ? '#f5faff' : 'transparent',
+                    display: 'flex',
+                    alignItems: 'center',
+                    transition: 'border 0.2s, box-shadow 0.2s',
+                  }}
+                  title={`Select color palette ${i + 1}`}
+                >
+                  <ColorRow colors={palette} style={{ margin: 0 }} />
+                </div>
+              );
+            })}
+          </div>
+        </ClickAwayListener>
+      )}
+    </div>
+  );
+};
+
+export default ColorPaletteDropdown;
+
+        

--- a/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
@@ -8,17 +8,17 @@ interface ColorPaletteDropdownProps {
 }
 
 export const mainPalettes = [
-  ['#75a1ff', '#00bbff', '#7f7fff', '#009386', '#93e200', '#ffffff'],
-  ['#88EFBF', '#FE5000', '#008A8F', '#B50094', '#FFFFFF', '#BDBDBD'],
-  ['#00B8B5', '#42008E', '#373A36', '#006BA6', '#005776', '#BDBDBD'],
-  ['#00662C', '#88EFBF', '#F9BF1B', '#008A8F', '#006BA6', '#BDBDBD'],
-  ['#00454D', '#7DA800', '#FE5000', '#e60b0b', '#ffffff', '#DBDCDB'],
+  ['#75a1ff', '#00bbff', '#7f7fff', '#009386', '#93e200'],
+  ['#88EFBF', '#FE5000', '#121212', '#008A8F', '#B50094'],
+  ['#00B8B5', '#42008E', '#373A36', '#006BA6', '#005776'],
+  ['#00662C', '#88EFBF', '#F9BF1B', '#008A8F', '#006BA6'],
+  ['#00454D', '#7DA800', '#FE5000', '#e60b0b', '#848383'],
 ];
 // 3 colorblind-friendly palettes (user provided, with gray as 6th color)
 export const colorblindPalettes = [
-  ['#FFD600', '#2962FF', '#00C853', '#FF6D00', '#30352e', '#BDBDBD'],
-  ['#D5810B', '#DF69F7', '#1C24F2', '#00B30C', '#EEFF00', '#BDBDBD'],
-  ['#D50000', '#FFD600', '#00C853', '#2962FF', '#AA00FF', '#BDBDBD'],
+  ['#FFD600', '#2962FF', '#00C853', '#FF6D00', '#30352e'],
+  ['#D5810B', '#DF69F7', '#1C24F2', '#00B30C', '#EEFF00'],
+  ['#D50000', '#FFD600', '#00C853', '#2962FF', '#AA00FF'],
 ];
 export const allPalettes = [...mainPalettes, ...colorblindPalettes];
 
@@ -54,8 +54,8 @@ const ColorRow: React.FC<{ colors: string[]; style?: React.CSSProperties }> = ({
 const ColorPaletteDropdown: React.FC<ColorPaletteDropdownProps> = ({ selected, onChange }) => {
   const [open, setOpen] = useState(false);
   return (
-    <div style={{ margin: '24px 0', position: 'relative' }}>
-      <h3 style={{ fontSize: 16, marginBottom: 12 }}>Color Options</h3>
+    <div style={{ margin: '0 0 24px 0', position: 'relative' }}>
+      <h3 style={{ fontSize: 16, marginBottom: 12 }}>Diagram Node Color Options</h3>
       <div
         role="button"
         tabIndex={0}
@@ -74,7 +74,7 @@ const ColorPaletteDropdown: React.FC<ColorPaletteDropdownProps> = ({ selected, o
         }}
         onClick={() => setOpen((prev) => !prev)}
         title="Select color palette"
-        >  <ColorRow colors={allPalettes[selected]} style={{ margin: 0 }} />
+        >  <ColorRow colors={allPalettes[selected] ?? allPalettes[0]} style={{ margin: 0 }} />
         <svg
           width="20"
           height="20"
@@ -113,7 +113,7 @@ const ColorPaletteDropdown: React.FC<ColorPaletteDropdownProps> = ({ selected, o
               if (i === mainPalettes.length) {
                 return [
                   <div key="cb-header" style={{ fontSize: 13, color: '#000', fontWeight: 600, padding: '4px 0 2px 0', borderBottom: '1px solid #eee', margin: '4px 0 2px 0' }}>
-                    Colorblind Palettes
+                    Colorblind Accessible Palettes
                   </div>,
                   <div
                     key={i}

--- a/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
@@ -14,7 +14,7 @@ export const mainPalettes = [
   ['#00662C', '#88EFBF', '#F9BF1B', '#008A8F', '#006BA6'],
   ['#00454D', '#7DA800', '#FE5000', '#e60b0b', '#848383'],
 ];
-// 3 colorblind-friendly palettes (user provided, with gray as 6th color)
+// 3 colorblind-friendly palettes (user provided)
 export const colorblindPalettes = [
   ['#FFD600', '#2962FF', '#00C853', '#FF6D00', '#30352e'],
   ['#D5810B', '#DF69F7', '#1C24F2', '#00B30C', '#EEFF00'],
@@ -73,6 +73,12 @@ const ColorPaletteDropdown: React.FC<ColorPaletteDropdownProps> = ({ selected, o
           boxShadow: open ? '0 2px 8px rgba(0,0,0,0.15)' : undefined,
         }}
         onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setOpen((prev) => !prev);
+          }
+        }}
         title="Select color palette"
         >  <ColorRow colors={allPalettes[selected] ?? allPalettes[0]} style={{ margin: 0 }} />
         <svg

--- a/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/ColorPaletteDropdown.tsx
@@ -55,7 +55,7 @@ const ColorPaletteDropdown: React.FC<ColorPaletteDropdownProps> = ({ selected, o
   const [open, setOpen] = useState(false);
   return (
     <div style={{ margin: '0 0 24px 0', position: 'relative' }}>
-      <h3 style={{ fontSize: 16, marginBottom: 12 }}>Diagram Node Color Options</h3>
+      <label style={{ display: 'block' }}>Set Water Component Colors</label>
       <div
         role="button"
         tabIndex={0}

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -4,7 +4,7 @@ import ContinuousSlider from './ContinuousSlider';
 import DownloadButton from './DownloadButton';
 import TabPanel from './TabPanel';
 import { useAppDispatch, useAppSelector } from '../../hooks/state';
-import { conductivityUnitChange, defaultEdgeTypeChange, diagramOptionsChange, electricityCostChange, flowDecimalPrecisionChange, OptionsDependentState, setDialogOpen, showMarkerEndArrows, unitsOfMeasureChange } from '../Diagram/diagramReducer';
+import { conductivityUnitChange, defaultEdgeTypeChange, diagramOptionsChange, electricityCostChange, flowDecimalPrecisionChange, OptionsDependentState, setDialogOpen, showMarkerEndArrows, unitsOfMeasureChange, setPaletteColors, getPaletteColorForType } from '../Diagram/diagramReducer';
 import { RootState, selectHasAssessment, selectNodes } from '../Diagram/store';
 import { edgeTypeOptions, SelectListOption } from '../Diagram/FlowTypes';
 import ValidationWindow, { ValidationWindowLocation } from '../Diagram/ValidationWindow';
@@ -15,6 +15,8 @@ import InputField from '../StyledMUI/InputField';
 import { Node } from '@xyflow/react';
 import TextField from '@mui/material/TextField';
 import { setDiagramNotes } from '../Diagram/diagramReducer';
+import ColorPaletteDropdown, { allPalettes } from "./ColorPaletteDropdown"
+import { getContrastTextColor } from '../Diagram/FlowUtils';
 const WaterComponent = styled(Paper)(({ theme, ...props }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(2),
@@ -29,6 +31,8 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const diagramNotes = useAppSelector((state) => state.diagram.diagramNotes);
+  const paletteColors = useAppSelector((state: RootState) => state.diagram.paletteColors);
+  const selectedPaletteIdx = allPalettes.findIndex((palette) => palette.every((color, i) => color === paletteColors[i]));
   const hasAssessment = useAppSelector(selectHasAssessment);
   const edgeType = useAppSelector((state: RootState) => state.diagram.diagramOptions.edgeType);
   const strokeWidth = useAppSelector((state: RootState) => state.diagram.diagramOptions.strokeWidth);
@@ -121,15 +125,20 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
           </Typography>
           <Box sx={{ flexGrow: 1, paddingY: '1rem', paddingX: '.5rem' }}>
             <Grid container spacing={{ xs: 1, sm: 1, md: 2 }} columns={{ xs: 1, sm: 2, md: 4 }}>
-              {processFlowParts.map((part: ProcessFlowPart) => (
-                <Grid size={{ xs: 1, sm: 2, md: 2 }}  key={part.processComponentType}>
-                  <WaterComponent className={`dndnode ${part.processComponentType}`}
-                    onDragStart={(event) => onDragStart(event, part.processComponentType)}
-                    draggable={true}>
-                    {part.name}
-                  </WaterComponent>
-                </Grid>
-              ))}
+              {processFlowParts.map((part: ProcessFlowPart) => {
+                const bgColor = getPaletteColorForType(part.processComponentType as any, paletteColors);
+                const textColor = bgColor ? getContrastTextColor(bgColor) : undefined;
+                return (
+                  <Grid size={{ xs: 1, sm: 2, md: 2 }}  key={part.processComponentType}>
+                    <WaterComponent className={`dndnode ${part.processComponentType}`}
+                      onDragStart={(event) => onDragStart(event, part.processComponentType)}
+                      draggable={true}
+                      style={{ backgroundColor: bgColor, color: textColor }}>
+                      {part.name}
+                    </WaterComponent>
+                  </Grid>
+                );
+              })}
               {/* <Grid item xs={1} sm={2} md={2}>
                 <WaterComponent className={`dndnode splitterNode`}
                   onDragStart={(event) => onDragStart(event, 'splitter-node-4')} draggable> 4-way Connection</WaterComponent>
@@ -172,6 +181,12 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
 
         <TabPanel value={selectedTab} index={2}>
           <Box paddingX={'.5rem'}>
+            <ColorPaletteDropdown
+              selected={selectedPaletteIdx}
+              onChange={(paletteIdx) => {
+                dispatch(setPaletteColors(allPalettes[paletteIdx]));
+              }}
+            />
             <div className="sidebar-options">
             <Box className={'sidebar-option-container'} padding={'.5rem'}>
               <FormControl fullWidth size="small">

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -31,8 +31,8 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const diagramNotes = useAppSelector((state) => state.diagram.diagramNotes);
-  const paletteColors = useAppSelector((state: RootState) => state.diagram.paletteColors);
-  const selectedPaletteIdx = allPalettes.findIndex((palette) => palette.every((color, i) => color === paletteColors[i]));
+  const paletteColors = useAppSelector((state: RootState) => state.diagram.diagramOptions.paletteColors);
+  const selectedPaletteIdx = allPalettes.findIndex((palette) => palette.every((color, i) => color === paletteColors?.[i]));
   const hasAssessment = useAppSelector(selectHasAssessment);
   const edgeType = useAppSelector((state: RootState) => state.diagram.diagramOptions.edgeType);
   const strokeWidth = useAppSelector((state: RootState) => state.diagram.diagramOptions.strokeWidth);
@@ -126,7 +126,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
           <Box sx={{ flexGrow: 1, paddingY: '1rem', paddingX: '.5rem' }}>
             <Grid container spacing={{ xs: 1, sm: 1, md: 2 }} columns={{ xs: 1, sm: 2, md: 4 }}>
               {processFlowParts.map((part: ProcessFlowPart) => {
-                const bgColor = getPaletteColorForType(part.processComponentType as any, paletteColors);
+                const bgColor = getPaletteColorForType(part.processComponentType as any, paletteColors ?? []);
                 const textColor = bgColor ? getContrastTextColor(bgColor) : undefined;
                 return (
                   <Grid size={{ xs: 1, sm: 2, md: 2 }}  key={part.processComponentType}>
@@ -181,14 +181,14 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
 
         <TabPanel value={selectedTab} index={2}>
           <Box paddingX={'.5rem'}>
-            <ColorPaletteDropdown
-              selected={selectedPaletteIdx}
-              onChange={(paletteIdx) => {
-                dispatch(setPaletteColors(allPalettes[paletteIdx]));
-              }}
-            />
             <div className="sidebar-options">
             <Box className={'sidebar-option-container'} padding={'.5rem'}>
+              <ColorPaletteDropdown
+                selected={selectedPaletteIdx}
+                onChange={(paletteIdx) => {
+                  dispatch(setPaletteColors(allPalettes[paletteIdx]));
+                }}
+              />
               <FormControl fullWidth size="small">
                 <InputLabel id="unitsOfMeasure-label">Units of Measure</InputLabel>
                 <Select

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -32,7 +32,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
   const dispatch = useAppDispatch();
   const diagramNotes = useAppSelector((state) => state.diagram.diagramNotes);
   const paletteColors = useAppSelector((state: RootState) => state.diagram.diagramOptions.paletteColors);
-  const selectedPaletteIdx = allPalettes.findIndex((palette) => palette.every((color, i) => color === paletteColors?.[i]));
+  const selectedPaletteIdx = allPalettes.findIndex((palette) => palette.every((color, i) => color?.toLowerCase() === paletteColors?.[i]?.toLowerCase()));
   const hasAssessment = useAppSelector(selectHasAssessment);
   const edgeType = useAppSelector((state: RootState) => state.diagram.diagramOptions.edgeType);
   const strokeWidth = useAppSelector((state: RootState) => state.diagram.diagramOptions.strokeWidth);
@@ -179,17 +179,17 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
           </Box>
         </TabPanel>
 
-        <TabPanel value={selectedTab} index={2}>
-          <Box paddingX={'.5rem'}>
+        <TabPanel value={selectedTab} index={2} style={{ paddingTop: 0 }}>
+          <Box paddingX={'.5rem'} paddingTop={0}>
             <div className="sidebar-options">
-            <Box className={'sidebar-option-container'} padding={'.5rem'}>
+            <Box className={'sidebar-option-container'} padding={'.5rem'} paddingTop={0} sx={{paddingTop: 0, marginTop: 0}}>
               <ColorPaletteDropdown
                 selected={selectedPaletteIdx}
                 onChange={(paletteIdx) => {
                   dispatch(setPaletteColors(allPalettes[paletteIdx]));
                 }}
               />
-              <FormControl fullWidth size="small">
+              <FormControl fullWidth size="small" sx={{ paddingTop: 0 }}>
                 <InputLabel id="unitsOfMeasure-label">Units of Measure</InputLabel>
                 <Select
                   labelId="unitsOfMeasure-label"
@@ -219,7 +219,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
               </FormControl>
             </Box>
 
-              <Box className={'sidebar-option-container'} padding={'.5rem'}>
+              <Box className={'sidebar-option-container'} padding={'.5rem'} paddingTop={0}>
                 <InputField
                   name={'electricityCost'}
                   id={'electricityCost'}
@@ -237,7 +237,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
                 />
               </Box>
                 
-            <Box className={'sidebar-option-container'} padding={'.5rem'}>
+            <Box className={'sidebar-option-container'} padding={'.5rem'} paddingTop={0}>
               <FormControl fullWidth size="small">
                 <InputLabel id="flowDecimalPrecision-label">Decimal Precision</InputLabel>
                 <Select
@@ -268,7 +268,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
               </FormControl>
             </Box>
 
-            <Box className={'sidebar-option-container'} padding={'.5rem'}>
+            <Box className={'sidebar-option-container'} padding={'.5rem'} paddingTop={0}>
               <FormControl fullWidth size="small">
                 <InputLabel id="conductivityUnit-label">Conductivity Unit</InputLabel>
                 <Select
@@ -299,7 +299,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
               </FormControl>
             </Box>
 
-            <Box className={'sidebar-option-container'} padding={'.5rem'}>
+            <Box className={'sidebar-option-container'} padding={'.5rem'} paddingTop={0}>
               <FormControl fullWidth size="small">
                 <InputLabel id="edgeType-label">Default Line Type</InputLabel>
                 <Select

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -9,7 +9,7 @@ import { RootState, selectHasAssessment, selectNodes } from '../Diagram/store';
 import { edgeTypeOptions, SelectListOption } from '../Diagram/FlowTypes';
 import ValidationWindow, { ValidationWindowLocation } from '../Diagram/ValidationWindow';
 import NotificationsIcon from '@mui/icons-material/Notifications';
-import { NodeErrors, ProcessFlowPart, processFlowDiagramParts, UserDiagramOptions, flowDecimalPrecisionOptions, conductivityUnitOptions, getIsDiagramValid } from 'process-flow-lib';
+import { NodeErrors, ProcessFlowPart, processFlowDiagramParts, UserDiagramOptions, flowDecimalPrecisionOptions, conductivityUnitOptions, getIsDiagramValid, WaterProcessComponentType } from 'process-flow-lib';
 import DiagramResults from './DiagramResults';
 import InputField from '../StyledMUI/InputField';
 import { Node } from '@xyflow/react';

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -126,7 +126,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
           <Box sx={{ flexGrow: 1, paddingY: '1rem', paddingX: '.5rem' }}>
             <Grid container spacing={{ xs: 1, sm: 1, md: 2 }} columns={{ xs: 1, sm: 2, md: 4 }}>
               {processFlowParts.map((part: ProcessFlowPart) => {
-                const bgColor = getPaletteColorForType(part.processComponentType as any, paletteColors ?? []);
+                const bgColor = getPaletteColorForType(part.processComponentType as WaterProcessComponentType, paletteColors ?? []);
                 const textColor = bgColor ? getContrastTextColor(bgColor) : undefined;
                 return (
                   <Grid size={{ xs: 1, sm: 2, md: 2 }}  key={part.processComponentType}>

--- a/process-flow-diagram-component/src/components/Drawer/TabPanel.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/TabPanel.tsx
@@ -1,8 +1,8 @@
-import { ParentContainerDimensions } from "process-flow-lib";
+import type { ReactNode } from "react";
 import { CSSProperties } from "react";
 
 interface TabPanelProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   index: number;
   value: number;
   style?: CSSProperties;

--- a/process-flow-diagram-component/src/components/Drawer/TabPanel.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/TabPanel.tsx
@@ -5,10 +5,11 @@ interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
   value: number;
+  style?: CSSProperties;
 }
 
 function TabPanel(props: TabPanelProps) {
-  const { children, value, index, ...other } = props;
+  const { children, value, index, style, ...other } = props;
 
   let wrapperCSSProps: CSSProperties = { 
     width: '100%', 
@@ -18,6 +19,7 @@ function TabPanel(props: TabPanelProps) {
     overflowY: 'auto',   
     minHeight: 0,
     flexDirection: 'column',
+    ...style,
   };
 
   if (value === index && (value === 0 || value === 2)) {

--- a/src/process-flow-lib/water/constants.ts
+++ b/src/process-flow-lib/water/constants.ts
@@ -170,11 +170,11 @@ export const CustomNodeStyleMap: Record<WaterProcessComponentType, CSSProperties
   },
   'waste-water-treatment': {
     backgroundColor: '#93e200',
-    color: "#000"
+    color: "#000000"
   },
   'known-loss': {
-    backgroundColor: '#fff',
-    color: "#000"
+    backgroundColor: '#ffffff',
+    color: "#000000"
   }
 };
 

--- a/src/process-flow-lib/water/types/diagram.ts
+++ b/src/process-flow-lib/water/types/diagram.ts
@@ -101,7 +101,6 @@ export interface ProcessFlowPart extends Record<string, unknown> {
     recentNodeColors: string[];
     recentEdgeColors: string[];
     diagramNotes?: string;
-    paletteColors?: string[];
   }
 
   export interface DiagramMetaData {
@@ -139,6 +138,7 @@ export interface ProcessFlowPart extends Record<string, unknown> {
     directionalArrowsVisible: boolean,
     flowLabelSize: number,
     animated: boolean,
+    paletteColors?: string[],
   }
   
   

--- a/src/process-flow-lib/water/types/diagram.ts
+++ b/src/process-flow-lib/water/types/diagram.ts
@@ -101,6 +101,7 @@ export interface ProcessFlowPart extends Record<string, unknown> {
     recentNodeColors: string[];
     recentEdgeColors: string[];
     diagramNotes?: string;
+    paletteColors?: string[];
   }
 
   export interface DiagramMetaData {


### PR DESCRIPTION
#8187

- Color Picker now uses the stores in a way that follows our design patterns better.
- Redundancy has been removed.
- Color choices now persist for users. If you select a different diagram color palette, the assessment's color changes will persist. Users will still need to adjust the color palette if they create a brand new assessment.
- Node Text will change colors from white to black and vice versa if its background is too light or dark.



# Pull Request Template

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
