### PR TITLE
Issue 8469 : Set releases target branch to master

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -278,6 +278,7 @@ jobs:
         with:
           name: MEASUR v${{ env.VERSION }}
           tag_name: v${{ env.VERSION }}
+          target_commitish: master
           draft: true # Comment out if enabling tag gating and publishing via action
           generate_release_notes: false
           files: |


### PR DESCRIPTION
#8469

## Overview
Drafted releases generated post-push to `master` are producing drafts that target the `develop` branch (the default). This causes inconsistency as all releases are associated with pushes  to `master`.

## Changes
- Assign master as `target_commitish` for desktop release workflow

### References
- [action-gh-release@v1 Inputs](https://github.com/softprops/action-gh-release/tree/v0.1.15#inputs)