### PR TITLE
Issue 8537: Fix gauge threshold for 0-1% values

### DIFF
--- a/src/app/treasure-hunt/treasure-hunt-gauge/treasure-hunt-gauge.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-gauge/treasure-hunt-gauge.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit, Input, ElementRef, ViewChild, HostListener, SimpleChanges } from '@angular/core';
-import bb, {gauge} from "billboard.js";
+import bb, { gauge } from "billboard.js";
 
 @Component({
-    selector: 'app-treasure-hunt-gauge',
-    templateUrl: './treasure-hunt-gauge.component.html',
-    styleUrls: ['./treasure-hunt-gauge.component.css'],
-    standalone: false
+  selector: 'app-treasure-hunt-gauge',
+  templateUrl: './treasure-hunt-gauge.component.html',
+  styleUrls: ['./treasure-hunt-gauge.component.css'],
+  standalone: false
 })
 export class TreasureHuntGaugeComponent implements OnInit {
   @Input()
@@ -29,7 +29,7 @@ export class TreasureHuntGaugeComponent implements OnInit {
     setTimeout(() => {
       this.initChart();
     }, 100);
-    
+
   }
 
   ngOnDestroy() { }
@@ -54,16 +54,23 @@ export class TreasureHuntGaugeComponent implements OnInit {
   }
 
   initChart() {
-        this.chart = bb.generate({
+    console.log(this.value)
+    this.chart = bb.generate({
       data: {
         columns: [
-      ["data", this.value]
+          ["data", this.value]
         ],
         type: gauge(),
       },
       gauge: {
         label: {
-          extents: function() { return ""; }
+          extents: function () { return ""; },
+          format: function (value) {
+            if (value > 0 && value < 1) {
+              return value.toFixed(2) + "%";
+            }
+            return value.toFixed(1) + "%";
+          }
         }
       },
       color: {

--- a/src/app/treasure-hunt/treasure-hunt-gauge/treasure-hunt-gauge.component.ts
+++ b/src/app/treasure-hunt/treasure-hunt-gauge/treasure-hunt-gauge.component.ts
@@ -54,7 +54,6 @@ export class TreasureHuntGaugeComponent implements OnInit {
   }
 
   initChart() {
-    console.log(this.value)
     this.chart = bb.generate({
       data: {
         columns: [


### PR DESCRIPTION
connects #8537

This pull request introduces improvements to the `TreasureHuntGaugeComponent` to fix the display format of gauge labels. The most significant changes are more precise percentage formatting for gauge values.

Enhancements to gauge label formatting:

* Added a `format` function to the gauge label configuration in `initChart` to display values between 0 and 1 with two decimal places, and other values with one decimal place, both followed by a percent sign.