### PR TITLE
fixup: display results with 0 savings

### DIFF
--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-side-panel/explore-opportunities-results/explore-opportunities-results.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-side-panel/explore-opportunities-results/explore-opportunities-results.component.html
@@ -62,7 +62,7 @@
 
     <div class="d-flex flex-column">
         <div [style.order]="modification.replaceCompressor.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.replaceCompressorsSavings.savings.power != 0">
+            *ngIf="modification.replaceCompressor.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.replaceCompressor}">
                 <span class="table-text">
@@ -77,7 +77,7 @@
             </div>
         </div>
         <div [style.order]="modification.addPrimaryReceiverVolume.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.addReceiverVolumeSavings.savings.power != 0">
+            *ngIf="modification.addPrimaryReceiverVolume.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.addReceiverVolume}">
                 <span class="table-text">
@@ -93,7 +93,7 @@
             </div>
         </div>
         <div [style.order]="modification.adjustCascadingSetPoints.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.adjustCascadingSetPointsSavings.savings.power != 0">
+            *ngIf="modification.adjustCascadingSetPoints.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.adjustCascadingSetPoints}">
                 <span class="table-text">
@@ -109,7 +109,7 @@
             </div>
         </div>
         <div [style.order]="modification.improveEndUseEfficiency.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.improveEndUseEfficiencySavings.savings.power != 0">
+            *ngIf="modification.improveEndUseEfficiency.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.improveEndUseEfficiency}">
                 <span class="table-text">
@@ -125,7 +125,7 @@
             </div>
         </div>
         <div [style.order]="modification.reduceAirLeaks.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.reduceAirLeaksSavings.savings.power != 0">
+            *ngIf="modification.reduceAirLeaks.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.reduceAirLeaks}">
                 <span class="table-text">
@@ -142,7 +142,7 @@
         </div>
 
         <div [style.order]="modification.reduceRuntime.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.reduceRunTimeSavings.savings.power != 0">
+            *ngIf="modification.reduceRuntime.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.reduceRuntime}">
                 <span class="table-text">
@@ -159,7 +159,7 @@
         </div>
 
         <div [style.order]="modification.reduceSystemAirPressure.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.reduceSystemAirPressureSavings.savings.power != 0">
+            *ngIf="modification.reduceSystemAirPressure.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.reduceSystemPressure}">
                 <span class="table-text">
@@ -176,7 +176,7 @@
         </div>
 
         <div [style.order]="modification.useAutomaticSequencer.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.useAutomaticSequencerSavings.savings.power != 0">
+            *ngIf="modification.useAutomaticSequencer.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.useAutomaticSequencer}">
                 <span class="table-text">
@@ -346,7 +346,7 @@
     </div>
     <div class="d-flex flex-column">
         <div [style.order]="modification.replaceCompressor.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.replaceCompressorsSavings.savings.cost != 0">
+            *ngIf="modification.replaceCompressor.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.replaceCompressor}">
                 <span class="table-text">
@@ -361,7 +361,7 @@
             </div>
         </div>
         <div [style.order]="modification.addPrimaryReceiverVolume.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.addReceiverVolumeSavings.savings.cost != 0">
+            *ngIf="modification.addPrimaryReceiverVolume.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.addReceiverVolume}">
                 <span class="table-text">
@@ -377,7 +377,7 @@
             </div>
         </div>
         <div [style.order]="modification.adjustCascadingSetPoints.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.adjustCascadingSetPointsSavings.savings.cost != 0">
+            *ngIf="modification.adjustCascadingSetPoints.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.adjustCascadingSetPoints}">
                 <span class="table-text">
@@ -393,7 +393,7 @@
             </div>
         </div>
         <div [style.order]="modification.improveEndUseEfficiency.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.improveEndUseEfficiencySavings.savings.cost != 0">
+            *ngIf="modification.improveEndUseEfficiency.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.improveEndUseEfficiency}">
                 <span class="table-text">
@@ -409,7 +409,7 @@
             </div>
         </div>
         <div [style.order]="modification.reduceAirLeaks.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.reduceAirLeaksSavings.savings.cost != 0">
+            *ngIf="modification.reduceAirLeaks.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.reduceAirLeaks}">
                 <span class="table-text">
@@ -426,7 +426,7 @@
         </div>
 
         <div [style.order]="modification.reduceRuntime.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.reduceRunTimeSavings.savings.cost != 0">
+            *ngIf="modification.reduceRuntime.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.reduceRuntime}">
                 <span class="table-text">
@@ -443,7 +443,7 @@
         </div>
 
         <div [style.order]="modification.reduceSystemAirPressure.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.reduceSystemAirPressureSavings.savings.cost != 0">
+            *ngIf="modification.reduceSystemAirPressure.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.reduceSystemPressure}">
                 <span class="table-text">
@@ -460,7 +460,7 @@
         </div>
 
         <div [style.order]="modification.useAutomaticSequencer.order" class="d-flex my-table-item"
-            *ngIf="dayTypeModificationResult.useAutomaticSequencerSavings.savings.cost != 0">
+            *ngIf="modification.useAutomaticSequencer.order != 100">
             <div class="d-flex align-items-center pl-1 pr-1 col-4"
                 [ngClass]="{'invalid': !compressedAirModificationValid.useAutomaticSequencer}">
                 <span class="table-text">

--- a/src/app/compressed-air-assessment/baseline-tab-content/end-uses-setup/end-uses-form/day-type-setup-form/day-type-setup.service.ts
+++ b/src/app/compressed-air-assessment/baseline-tab-content/end-uses-setup/end-uses-form/day-type-setup-form/day-type-setup.service.ts
@@ -10,16 +10,24 @@ export class DayTypeSetupService {
   endUseDayTypeSetup: BehaviorSubject<EndUseDayTypeSetup>;
   dayTypeSetupWarnings: DayTypeSetupWarnings;
 
-  constructor(private formBuilder: UntypedFormBuilder) { 
+  constructor(private formBuilder: UntypedFormBuilder) {
     this.endUseDayTypeSetup = new BehaviorSubject<EndUseDayTypeSetup>(undefined);
   }
 
   getDayTypeSetupFormFromObj(endUseDayTypeSetup: EndUseDayTypeSetup, dayTypeAirflowTotals: DayTypeAirflowTotals): UntypedFormGroup {
     let dayTypeLeakRate = endUseDayTypeSetup.dayTypeLeakRates.find(leakRate => leakRate.dayTypeId === endUseDayTypeSetup.selectedDayTypeId);
-    let form: UntypedFormGroup = this.formBuilder.group({
-      selectedDayTypeId: [endUseDayTypeSetup.selectedDayTypeId],
-      dayTypeLeakRate: [dayTypeLeakRate.dayTypeLeakRate],
-    });
+    let form: UntypedFormGroup;
+    if (dayTypeLeakRate) {
+      form = this.formBuilder.group({
+        selectedDayTypeId: [endUseDayTypeSetup.selectedDayTypeId],
+        dayTypeLeakRate: [dayTypeLeakRate.dayTypeLeakRate],
+      });
+    } else {
+      form = this.formBuilder.group({
+        selectedDayTypeId: [endUseDayTypeSetup.selectedDayTypeId],
+        dayTypeLeakRate: [0],
+      });
+    }
     form = this.setDayTypeLeakRateValidation(form, dayTypeAirflowTotals);
     form = this.markFormDirtyToDisplayValidation(form);
     return form;
@@ -30,8 +38,8 @@ export class DayTypeSetupService {
     let dayTypeLeakRate: number = form.controls.dayTypeLeakRate.value;
     endUseDayTypeSetup.dayTypeLeakRates.map(currentDaytypeLeakRate => {
       if (currentDaytypeLeakRate.dayTypeId === endUseDayTypeSetup.selectedDayTypeId) {
-          currentDaytypeLeakRate.dayTypeLeakRate = dayTypeLeakRate;
-      } 
+        currentDaytypeLeakRate.dayTypeLeakRate = dayTypeLeakRate;
+      }
     });
 
     return endUseDayTypeSetup;
@@ -43,7 +51,7 @@ export class DayTypeSetupService {
     form.controls.dayTypeLeakRate.setValidators(dayTypeLeakRateValidators);
     form.controls.dayTypeLeakRate.updateValueAndValidity();
     return form;
- }
+  }
 
   markFormDirtyToDisplayValidation(form: UntypedFormGroup) {
     for (let key in form.controls) {
@@ -70,9 +78,9 @@ export class DayTypeSetupService {
         let halfAirflowTotal: number = roundVal(dayTypeAirFlowTotals.totalDayTypeAverageAirflow / 2, 0);
         if (selectedLeakRate.dayTypeLeakRate !== undefined && selectedLeakRate.dayTypeLeakRate === halfAirflowTotal) {
           warning = `Leak rate is usually less than half of the System Profile average airflow for this day type. (${halfAirflowTotal})`;
-        } 
+        }
       }
-    } 
+    }
     return warning;
   }
 


### PR DESCRIPTION
connects #8502 

This pull request updates the logic for displaying compressed air assessment opportunity results and improves the robustness of the day type setup form. The main changes focus on how items are conditionally shown in the UI and how forms are initialized to prevent errors when expected data is missing.

**UI logic improvements for opportunity results:**

* Updated the conditional rendering in `explore-opportunities-results.component.html` to show each modification row based on whether its `order` property is not equal to 100, instead of checking if the savings (power or cost) are non-zero. This ensures that rows are displayed according to their intended order and visibility logic, regardless of their calculated savings values. [[1]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L65-R65) [[2]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L80-R80) [[3]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L96-R96) [[4]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L112-R112) [[5]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L128-R128) [[6]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L145-R145) [[7]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L162-R162) [[8]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L179-R179) [[9]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L349-R349) [[10]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L364-R364) [[11]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L380-R380) [[12]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L396-R396) [[13]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L412-R412) [[14]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L429-R429) [[15]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L446-R446) [[16]](diffhunk://#diff-4344fcd6769f516ed85475569ac4feed3d3cc463acfcde01a2bbae160a701396L463-R463)

**Form initialization robustness:**

* Modified `getDayTypeSetupFormFromObj` in `day-type-setup.service.ts` to handle cases where a `dayTypeLeakRate` does not exist for the selected day type. The form now defaults the `dayTypeLeakRate` to 0 in such cases, preventing potential errors and ensuring the form is always initialized with valid data.
