### PR TITLE
Issue 8626: Icon addition, correcting Steam Visible Fields

### DIFF
--- a/src/app/calculator/steam/steam-leak/cost-of-steam-form/cost-of-steam-form.component.html
+++ b/src/app/calculator/steam/steam-leak/cost-of-steam-form/cost-of-steam-form.component.html
@@ -158,7 +158,7 @@
     </div>
   </div>
 
-  <!-- @if (facilityForm.controls.utilityType.value === 1 || facilityForm.controls.utilityType.value === 2 || facilityForm.controls.utilityType.value === 3) { -->
+  @if (facilityForm.controls.utilityType.value !== SteamLeakUtilityType.Steam) {
     <div class="form-group">
       <label for="steam-boilerEfficiency">Boiler Efficiency</label>
       <div class="input-group">
@@ -191,7 +191,7 @@
         }
       </div>
     </div>
-  <!-- } -->
+  }
 
   <div class="row pt-1">
     <div class="col-6"><label class="small bold">Annual Steam Loss</label></div>

--- a/src/app/calculator/steam/steam-leak/steam-leak-survey.component.html
+++ b/src/app/calculator/steam/steam-leak/steam-leak-survey.component.html
@@ -3,7 +3,7 @@
         [class.justify-content-between]="inTreasureHunt()">
         <div class="d-flex pl-2 align-items-center">
         <div class="calc-icon-header icon-steam d-none d-sm-flex" [class.in-treasure-hunt]="inTreasureHunt()">
-            <!-- <img src="assets/images/calculator-icons/steam-icons/steam-leak-icon.png"> -->
+            <img src="assets/images/calculator-icons/compressed-air-icons/CAleak-icon.png">
         </div>
         <div class="mx-auto">
             <h3>Steam - Leak Survey</h3>

--- a/src/app/calculator/steam/steam-list/steam-list.component.html
+++ b/src/app/calculator/steam/steam-list/steam-list.component.html
@@ -75,6 +75,8 @@
                 <div class="calc-icon-div d-flex justify-content-center align-items-center steam">
                     <!-- <img src="assets/images/calculator-icons/steam-icons/steam-leak-icon.png"
                         class="calc-img" [routerLink]="['/calculators/steam-leak']"> -->
+                    <img src="assets/images/calculator-icons/compressed-air-icons/CAleak-icon.png"
+                    class="calc-img" [routerLink]="['/calculators/steam-leak']">
                 </div>
             </div>
             <div class="d-flex flex-fill flex-column justify-content-center">

--- a/src/app/shared/models/treasure-hunt.ts
+++ b/src/app/shared/models/treasure-hunt.ts
@@ -257,8 +257,8 @@ export const opportunities: OpportunityForFiltering[] = [
         description: 'Calculate the blowdown rate of a boiler.'
     },
     {
-        iconString: 'assets/images/calculator-icons/utilities-icons/steam-reduction-icon.png',
-        iconClass: 'steam-reduction-icon',
+        iconString: 'assets/images/calculator-icons/compressed-air-icons/CAleak-icon.png',
+        iconClass: 'steam-calc-icon',
         imageSizeClass: 'calc-img th-calc-img-w',
         iconCalcType: 'steam',
         opportunityType: 'steam-leak-survey',

--- a/src/app/treasure-hunt/treasure-hunt-calculator-services/steam-leak-treasure-hunt.service.ts
+++ b/src/app/treasure-hunt/treasure-hunt-calculator-services/steam-leak-treasure-hunt.service.ts
@@ -120,7 +120,7 @@ import * as _ from 'lodash';
             steamLeakSurvey: steamLeakSurvey,
             name: opportunitySummary.opportunityName,
             opportunitySheet: steamLeakSurvey.opportunitySheet,
-            iconString: 'assets/images/calculator-icons/utilities-icons/steam-reduction-icon.png',
+            iconString: 'assets/images/calculator-icons/compressed-air-icons/CAleak-icon.png',
             teamName: steamLeakSurvey.opportunitySheet ? steamLeakSurvey.opportunitySheet.owner : undefined,
             iconCalcType: 'steam',
             needBackground: true


### PR DESCRIPTION
#8626 
- Utility Type: Steam  has less fields visible fields as they don't have weight in the calculation for Steam.
- Icon for Steam Leak has been updated in both TH and Calculator instances. Icon is CA Leak Icon but orange background to match Steam.


# Pull Request Template

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
