### PR TITLE
Issue 8638: Conversion corrections, Updating some units in both Imp and Met

### DIFF
--- a/src/app/calculator/steam/steam-leak/convert-steam-leak.service.ts
+++ b/src/app/calculator/steam/steam-leak/convert-steam-leak.service.ts
@@ -20,7 +20,7 @@ export class ConvertSteamLeakService {
         inputArray[i].orificeMethodData.holeSize = this.convertUnitsService.value(inputArray[i].orificeMethodData.holeSize).from('cm').to('in');
         inputArray[i].orificeMethodData.atmosphericPressure = this.convertUnitsService.value(inputArray[i].orificeMethodData.atmosphericPressure).from('kPaa').to('psia');
 
-        inputArray[i].plumeMethodData.plumeLength = this.convertUnitsService.value(inputArray[i].plumeMethodData.plumeLength).from('cm').to('in');
+        inputArray[i].plumeMethodData.plumeLength = this.convertUnitsService.value(inputArray[i].plumeMethodData.plumeLength).from('m').to('ft');
         inputArray[i].plumeMethodData.ambientTemperature = this.convertUnitsService.value(inputArray[i].plumeMethodData.ambientTemperature).from('C').to('F');
       }
     }
@@ -55,41 +55,41 @@ export class ConvertSteamLeakService {
   }
 
   convertInputDataImperialToMetric(inputData: SteamLeakSurveyData): SteamLeakSurveyData {
-    inputData.estimateMethodData.leakRate = this.convertUnitsService.value(inputData.estimateMethodData.leakRate).from('lb').to('kg');
-    inputData.estimateMethodData.leakRate = roundVal(inputData.estimateMethodData.leakRate);
+    inputData.estimateMethodData.steamPressure = roundVal(this.convertUnitsService.value(inputData.estimateMethodData.steamPressure).from('psig').to('kPag'), 0);
+    inputData.estimateMethodData.steamTemperature = roundVal(this.convertUnitsService.value(inputData.estimateMethodData.steamTemperature).from('F').to('C'), 1);
+    inputData.estimateMethodData.leakRate = roundVal(this.convertUnitsService.value(inputData.estimateMethodData.leakRate).from('lb').to('kg'));
 
-    inputData.estimateTurbineMethodData.leakRate = this.convertUnitsService.value(inputData.estimateTurbineMethodData.leakRate).from('lb').to('kg');
-    inputData.estimateTurbineMethodData.leakRate = roundVal(inputData.estimateTurbineMethodData.leakRate);
+    inputData.estimateTurbineMethodData.leakRate = roundVal(this.convertUnitsService.value(inputData.estimateTurbineMethodData.leakRate).from('lb').to('kg'));
 
-    inputData.orificeMethodData.holeSize = this.convertUnitsService.value(inputData.orificeMethodData.holeSize).from('in').to('cm');
-    inputData.orificeMethodData.holeSize = roundVal(inputData.orificeMethodData.holeSize);
-    inputData.orificeMethodData.atmosphericPressure = this.convertUnitsService.value(inputData.orificeMethodData.atmosphericPressure).from('psia').to('kPaa');
-    inputData.orificeMethodData.atmosphericPressure = roundVal(inputData.orificeMethodData.atmosphericPressure);
+    inputData.orificeMethodData.steamPressure = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.steamPressure).from('psig').to('kPag'), 0);
+    inputData.orificeMethodData.steamTemperature = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.steamTemperature).from('F').to('C'), 1);
+    inputData.orificeMethodData.holeSize = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.holeSize).from('in').to('cm'));
+    inputData.orificeMethodData.atmosphericPressure = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.atmosphericPressure).from('psia').to('kPaa'));
 
-    inputData.plumeMethodData.plumeLength = this.convertUnitsService.value(inputData.plumeMethodData.plumeLength).from('in').to('cm');
-    inputData.plumeMethodData.plumeLength = roundVal(inputData.plumeMethodData.plumeLength);
-    inputData.plumeMethodData.ambientTemperature = this.convertUnitsService.value(inputData.plumeMethodData.ambientTemperature).from('F').to('C');
-    inputData.plumeMethodData.ambientTemperature = roundVal(inputData.plumeMethodData.ambientTemperature);
+    inputData.plumeMethodData.steamPressure = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.steamPressure).from('psig').to('kPag'), 0);
+    inputData.plumeMethodData.steamTemperature = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.steamTemperature).from('F').to('C'), 1);
+    inputData.plumeMethodData.plumeLength = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.plumeLength).from('ft').to('m'), 4);
+    inputData.plumeMethodData.ambientTemperature = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.ambientTemperature).from('F').to('C'));
 
     return inputData;
   }
 
   convertInputDataMetricToImperial(inputData: SteamLeakSurveyData): SteamLeakSurveyData {
-    inputData.estimateMethodData.leakRate = this.convertUnitsService.value(inputData.estimateMethodData.leakRate).from('kg').to('lb');
-    inputData.estimateMethodData.leakRate = roundVal(inputData.estimateMethodData.leakRate);
+    inputData.estimateMethodData.steamPressure = roundVal(this.convertUnitsService.value(inputData.estimateMethodData.steamPressure).from('kPag').to('psig'), 0);
+    inputData.estimateMethodData.steamTemperature = roundVal(this.convertUnitsService.value(inputData.estimateMethodData.steamTemperature).from('C').to('F'), 1);
+    inputData.estimateMethodData.leakRate = roundVal(this.convertUnitsService.value(inputData.estimateMethodData.leakRate).from('kg').to('lb'));
 
-    inputData.estimateTurbineMethodData.leakRate = this.convertUnitsService.value(inputData.estimateTurbineMethodData.leakRate).from('kg').to('lb');
-    inputData.estimateTurbineMethodData.leakRate = roundVal(inputData.estimateTurbineMethodData.leakRate);
+    inputData.estimateTurbineMethodData.leakRate = roundVal(this.convertUnitsService.value(inputData.estimateTurbineMethodData.leakRate).from('kg').to('lb'));
 
-    inputData.orificeMethodData.holeSize = this.convertUnitsService.value(inputData.orificeMethodData.holeSize).from('cm').to('in');
-    inputData.orificeMethodData.holeSize = roundVal(inputData.orificeMethodData.holeSize);
-    inputData.orificeMethodData.atmosphericPressure = this.convertUnitsService.value(inputData.orificeMethodData.atmosphericPressure).from('kPaa').to('psia');
-    inputData.orificeMethodData.atmosphericPressure = roundVal(inputData.orificeMethodData.atmosphericPressure);
+    inputData.orificeMethodData.steamPressure = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.steamPressure).from('kPag').to('psig'), 0);
+    inputData.orificeMethodData.steamTemperature = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.steamTemperature).from('C').to('F'), 1);
+    inputData.orificeMethodData.holeSize = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.holeSize).from('cm').to('in'));
+    inputData.orificeMethodData.atmosphericPressure = roundVal(this.convertUnitsService.value(inputData.orificeMethodData.atmosphericPressure).from('kPaa').to('psia'));
 
-    inputData.plumeMethodData.plumeLength = this.convertUnitsService.value(inputData.plumeMethodData.plumeLength).from('cm').to('in');
-    inputData.plumeMethodData.plumeLength = roundVal(inputData.plumeMethodData.plumeLength);
-    inputData.plumeMethodData.ambientTemperature = this.convertUnitsService.value(inputData.plumeMethodData.ambientTemperature).from('C').to('F');
-    inputData.plumeMethodData.ambientTemperature = roundVal(inputData.plumeMethodData.ambientTemperature);
+    inputData.plumeMethodData.steamPressure = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.steamPressure).from('kPag').to('psig'), 0);
+    inputData.plumeMethodData.steamTemperature = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.steamTemperature).from('C').to('F'), 1);
+    inputData.plumeMethodData.plumeLength = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.plumeLength).from('m').to('ft'), 2);
+    inputData.plumeMethodData.ambientTemperature = roundVal(this.convertUnitsService.value(inputData.plumeMethodData.ambientTemperature).from('C').to('F'));
 
     return inputData;
   }

--- a/src/app/calculator/steam/steam-leak/cost-of-steam-form/cost-of-steam-form.component.html
+++ b/src/app/calculator/steam/steam-leak/cost-of-steam-form/cost-of-steam-form.component.html
@@ -199,7 +199,7 @@
       @if (surveyService.output().baselineTotal.steamLoss) {
         <span class="small bold">
           {{ surveyService.output().baselineTotal.steamLoss | number:'1.0-0' }}
-          @if (settings().unitsOfMeasure === 'Imperial') { <span> lbs/yr</span> } @else { <span> kg/yr</span> }
+          @if (settings().unitsOfMeasure === 'Imperial') { <span> klb/yr</span> } @else { <span> tonne/yr</span> }
         </span>
       } @else {
         <span> -- </span>

--- a/src/app/calculator/steam/steam-leak/steam-leak-copy-table/steam-leak-copy-table.component.html
+++ b/src/app/calculator/steam/steam-leak/steam-leak-copy-table/steam-leak-copy-table.component.html
@@ -14,8 +14,8 @@
                     </td>
                     <td>
                         Annual Steam Loss
-                        @if (settings().unitsOfMeasure !== 'Metric') { <span>(lb/yr)</span> }
-                        @else { <span>(kg/yr)</span> }
+                        @if (settings().unitsOfMeasure !== 'Metric') { <span>(klb/yr)</span> }
+                        @else { <span>(tonne/yr)</span> }
                     </td>
                     <td>
                         Annual Energy Loss

--- a/src/app/calculator/steam/steam-leak/steam-leak-survey-results-table/steam-leak-survey-results-table.component.html
+++ b/src/app/calculator/steam/steam-leak/steam-leak-survey-results-table/steam-leak-survey-results-table.component.html
@@ -18,8 +18,8 @@
         </td>
         <td>
           Annual Steam Loss
-          (@if (settings().unitsOfMeasure !== 'Metric') { <span>lb/yr</span> }
-          @else { <span>kg/yr</span> })
+          (@if (settings().unitsOfMeasure !== 'Metric') { <span>klb/yr</span> }
+          @else { <span>tonne/yr</span> })
         </td>
         <td>Energy Loss (MMBtu/yr)</td>
         <td>Annual Cost</td>

--- a/src/app/calculator/steam/steam-leak/steam-leak-survey-results/steam-leak-survey-results.component.html
+++ b/src/app/calculator/steam/steam-leak/steam-leak-survey-results/steam-leak-survey-results.component.html
@@ -8,7 +8,7 @@
             <td class="text-center w-50">
                 @if (output.baselineTotal.steamLoss) {
                     {{ output.baselineTotal.steamLoss | number:'1.0-0' }}
-                    @if (settings().unitsOfMeasure === 'Imperial') { <span> lbs/yr</span> } @else { <span> kg/yr</span> }
+                    @if (settings().unitsOfMeasure === 'Imperial') { <span> klb/yr</span> } @else { <span> tonne/yr</span> }
                 } @else {
                     <span> -- </span>
                 }
@@ -46,7 +46,7 @@
             <td class="text-center w-50">
                 @if (output.modificationTotal.steamLoss) {
                     {{ output.modificationTotal.steamLoss | number:'1.0-0' }}
-                    @if (settings().unitsOfMeasure === 'Imperial') { <span> lbs/yr</span> } @else { <span> kg/yr</span> }
+                    @if (settings().unitsOfMeasure === 'Imperial') { <span> klb/yr</span> } @else { <span> tonne/yr</span> }
                 } @else {
                     <span> -- </span>
                 }
@@ -84,7 +84,7 @@
             <td class="text-center w-50">
                 @if (output.savings.steamLoss) {
                     {{ output.savings.steamLoss | number:'1.0-0' }}
-                    @if (settings().unitsOfMeasure === 'Imperial') { <span> lbs/yr</span> } @else { <span> kg/yr</span> }
+                    @if (settings().unitsOfMeasure === 'Imperial') { <span> klb/yr</span> } @else { <span> tonne/yr</span> }
                 } @else {
                     <span> -- </span>
                 }

--- a/src/app/calculator/steam/steam-leak/steam-leak-survey-service.ts
+++ b/src/app/calculator/steam/steam-leak/steam-leak-survey-service.ts
@@ -19,6 +19,7 @@ export class SteamLeakSurveyService {
     readonly currentField = signal<string>('default');
     private readonly resetEventsSubject = new Subject<void>();
     readonly resetEvents = this.resetEventsSubject.asObservable();
+    lastUnitsOfMeasure: string | undefined;
 
 
     readonly output = computed<SteamLeakSurveyOutput>(() => {
@@ -144,6 +145,27 @@ export class SteamLeakSurveyService {
       data = this.convertSteamLeakService.convertImperialFacilitySteamLeakData(data);
     }
     return data;
+  }
+
+  convertSurveyInput(oldUnits: string, newSettings: Settings): void {
+    const current = this.steamLeakInput();
+    if (!current) return;
+    const fakeOldSettings = { unitsOfMeasure: oldUnits } as Settings;
+    const convertedLeaks = current.steamLeakSurveyInputVec.map(leak => {
+      const copy: SteamLeakSurveyData = copyObject(leak);
+      if (oldUnits === 'Imperial' && newSettings.unitsOfMeasure === 'Metric') {
+        return this.convertSteamLeakService.convertInputDataImperialToMetric(copy);
+      } else if (oldUnits === 'Metric' && newSettings.unitsOfMeasure === 'Imperial') {
+        return this.convertSteamLeakService.convertInputDataMetricToImperial(copy);
+      }
+      return copy;
+    });
+    const convertedFacility = this.convertSteamLeakService.convertFacilitySteamLeakData(
+      copyObject(current.facilitySteamLeakData),
+      fakeOldSettings,
+      newSettings,
+    );
+    this.steamLeakInput.set({ steamLeakSurveyInputVec: convertedLeaks, facilitySteamLeakData: convertedFacility });
   }
 
     getResults(settings: Settings, input: SteamLeakSurveyInput): SteamLeakSurveyOutput {

--- a/src/app/calculator/steam/steam-leak/steam-leak-survey.component.ts
+++ b/src/app/calculator/steam/steam-leak/steam-leak-survey.component.ts
@@ -53,7 +53,13 @@ export class SteamLeakSurveyComponent implements OnInit, OnDestroy {
 
     if (!this.surveyService.steamLeakInput()) {
       this.surveyService.initDefaultEmptyInputs(this.activeSettings);
+    } else if (
+      this.surveyService.lastUnitsOfMeasure &&
+      this.surveyService.lastUnitsOfMeasure !== this.activeSettings.unitsOfMeasure
+    ) {
+      this.surveyService.convertSurveyInput(this.surveyService.lastUnitsOfMeasure, this.activeSettings);
     }
+    this.surveyService.lastUnitsOfMeasure = this.activeSettings.unitsOfMeasure;
 
     const assessment = this.assessment();
     if (assessment) {


### PR DESCRIPTION
#8638
- Conversion is corrected to fire on load of data, so Imp and Met values are correct. Was blocking leaks from being modified because values weren't converted and were outside the validation of the chosen global unit measurement.
- lbs/yr → klb/yr 
- kg/yr → tonne/yr

# Pull Request Template

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
