### PR TITLE
chore(ci): disable macos desktop bundling

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -56,78 +56,78 @@ jobs:
       NODE_VERSION: ${{ steps.output.outputs.NODE_VERSION }}
       BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
-  bundle_macos:
-    if: github.ref_name == 'master'
-    runs-on: macos-14
-    needs: [build]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact
-          path: dist/
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ needs.build.outputs.NODE_VERSION }}
-      - name: Setup cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
-      - *npm-setup
-      - name: Setup codesigning
-        env:
-          APPLE_CERT_A_BASE64: ${{ secrets.APPLE_CERT_A_BASE64 }}
-          APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
-          APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
-          APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
-        run: |
-          CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
-          PROV_PROF_PATH=$RUNNER_TEMP/embedded.provisionprofile
-          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+  # bundle_macos:
+  #   if: github.ref_name == 'master'
+  #   runs-on: macos-14
+  #   needs: [build]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 1
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build-artifact
+  #         path: dist/
+  #     - name: Setup node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ needs.build.outputs.NODE_VERSION }}
+  #     - name: Setup cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ~/.npm
+  #         key: npm-${{ hashFiles('package-lock.json') }}
+  #         restore-keys: npm-
+  #     - *npm-setup
+  #     - name: Setup codesigning
+  #       env:
+  #         APPLE_CERT_A_BASE64: ${{ secrets.APPLE_CERT_A_BASE64 }}
+  #         APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
+  #         APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
+  #         APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
+  #       run: |
+  #         CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
+  #         PROV_PROF_PATH=$RUNNER_TEMP/embedded.provisionprofile
+  #         KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
 
-          echo -n "$APPLE_CERT_A_BASE64" | base64 --decode -o $CERT_A_PATH
-          echo -n "$APPLE_PROV_PROF_BASE64" | base64 --decode -o $PROV_PROF_PATH
+  #         echo -n "$APPLE_CERT_A_BASE64" | base64 --decode -o $CERT_A_PATH
+  #         echo -n "$APPLE_PROV_PROF_BASE64" | base64 --decode -o $PROV_PROF_PATH
 
-          security -v create-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security -v default-keychain -s $KEYCHAIN_PATH
-          security -v unlock-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+  #         security -v create-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+  #         security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+  #         security -v default-keychain -s $KEYCHAIN_PATH
+  #         security -v unlock-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
 
-          security -v import $CERT_A_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+  #         security -v import $CERT_A_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+  #         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
 
-          cp "$PROV_PROF_PATH" ./embedded.provisionprofile
-      - name: Bundle
-        run: npm run dist -- --mac --universal --publish never
-      - name: Notarize
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SECRET: ${{ secrets.APPLE_APP_SECRET }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          BUNDLE_PATH=$(find output -name "MEASUR-*.*.*.dmg")
-          xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $BUNDLE_PATH &&
-          xcrun stapler staple $BUNDLE_PATH
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-macos-artifact
-          path: |
-            output/*.zip
-            output/*.zip.blockmap
-            output/*.dmg
-            output/*.dmg.blockmap
-            output/latest*.yml
-          compression-level: 0
-          if-no-files-found: error
-          retention-days: 1
+  #         cp "$PROV_PROF_PATH" ./embedded.provisionprofile
+  #     - name: Bundle
+  #       run: npm run dist -- --mac --universal --publish never
+  #     - name: Notarize
+  #       env:
+  #         APPLE_ID: ${{ secrets.APPLE_ID }}
+  #         APPLE_APP_SECRET: ${{ secrets.APPLE_APP_SECRET }}
+  #         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+  #       run: |
+  #         BUNDLE_PATH=$(find output -name "MEASUR-*.*.*.dmg")
+  #         xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $BUNDLE_PATH &&
+  #         xcrun stapler staple $BUNDLE_PATH
+  #     - name: Upload release artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: release-macos-artifact
+  #         path: |
+  #           output/*.zip
+  #           output/*.zip.blockmap
+  #           output/*.dmg
+  #           output/*.dmg.blockmap
+  #           output/latest*.yml
+  #         compression-level: 0
+  #         if-no-files-found: error
+  #         retention-days: 1
 
   bundle_win:
     if: github.ref_name == 'master'
@@ -258,7 +258,7 @@ jobs:
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-22.04
-    needs: [build, bundle_macos, bundle_linux, sign_win]
+    needs: [build, bundle_linux, sign_win]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:


### PR DESCRIPTION
# Disable MacOS Bundling for Desktop Releases
Temporary: Disables MacOS bundling part of `release_desktop` workflow until a later date when the developer certificate has been regenerated and provided.