### PR TITLE
Issue 6545: Sync actions for the Assessment Savings

### DIFF
--- a/src/app/fsat/fsat.component.ts
+++ b/src/app/fsat/fsat.component.ts
@@ -107,7 +107,7 @@ export class FsatComponent implements OnInit {
       this.assessment = this.assessmentDbService.findById(parseInt(params['id']))
       if (!this.assessment || (this.assessment && this.assessment.type !== 'FSAT')) {
         this.router.navigate(['/not-found'], { queryParams: { measurItemType: 'assessment' }});
-      } else { 
+      } else {
         this._fsat = (JSON.parse(JSON.stringify(this.assessment.fsat)));
         if (this._fsat.modifications) {
           if (this._fsat.modifications.length !== 0) {
@@ -237,7 +237,7 @@ export class FsatComponent implements OnInit {
   async saveSettings(newSettings: Settings) {
     this.settings = newSettings;
     await firstValueFrom(this.settingsDbService.updateWithObservable(this.settings));
-    let updatedSettings: Settings[] = await firstValueFrom(this.settingsDbService.getAllSettings());  
+    let updatedSettings: Settings[] = await firstValueFrom(this.settingsDbService.getAllSettings());
     this.settingsDbService.setAll(updatedSettings);
   }
 

--- a/src/app/shared/assessment-integration/assessment-integration.component.html
+++ b/src/app/shared/assessment-integration/assessment-integration.component.html
@@ -1,8 +1,8 @@
 <div class="integration-container p-3">
-    <div *ngIf="hasUpdatedEnergyData" class="d-flex flex-row alert alert-info p-2">
+    <div *ngIf="hasUpdatedEnergyData" class="d-flex flex-row alert alert-warning p-2">
         <label class="w-50">
             <span class="integration-label border-0 pr-3">
-                Updated energy use data can be retrieved from changes made to the integrated assessment.
+                Assessment Data has been updated since this opportunity was created. Please update the energy use data to ensure accurate results.
             </span>
         </label>
         <div class="w-50 input-group justify-content-center m-1 mt-2 mb-0">

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.html
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.html
@@ -28,44 +28,50 @@
             </div>
           </div>
         </div>
-        <div class="col-12 col-lg-4 col-item-br opportunity-name pl-3 pr-1">
-          <div class="d-flex h-100 justify-content-center align-items-center">
-            <table class="table table-borderless mb-0">
-              <tbody>
-                <tr class="no-border-top" [ngClass]="{ active: sortByVal.sortBy == 'teamName'}">
-                  <td class="w-75">
-                    Owner/Lead/Team
-                  </td>
-                  <td class="w-25">
-                    <span *ngIf="cardData.teamName">{{cardData.teamName}}</span>
-                    <span *ngIf="!cardData.teamName">&mdash;</span>
-                  </td>
-                </tr>
-                <tr [ngClass]="{ active: sortByVal.sortBy == 'annualCostSavings'}">
-                  <td class="w-75">Annual Savings ({{settings.currency}})</td>
-                  <td class="w-25">
-                    <span *ngIf="cardData.annualCostSavings">{{cardData.annualCostSavings | number:"1.0-0"}}</span>
-                    <span *ngIf="!cardData.annualCostSavings">&mdash;</span>
-                  </td>
-                </tr>
-                <tr [ngClass]="{active: sortByVal.sortBy == 'implementationCost'}">
-                  <td class="w-75">Implementation Cost ({{settings.currency}})</td>
-                  <td class="w-25">
-                    <span *ngIf="cardData.implementationCost">{{cardData.implementationCost | number:"1.0-0"}}</span>
-                    <span *ngIf="!cardData.implementationCost">&mdash;</span>
-                  </td>
-                </tr>
-                <tr [ngClass]="{ active: sortByVal.sortBy == 'paybackPeriod' }">
-                  <td class="w-75">
-                    Payback Period
-                  </td>
-                  <td class="w-25">
-                    <span *ngIf="cardData.paybackPeriod">{{cardData.paybackPeriod | number:"1.2-2"}}</span>
-                    <span *ngIf="!cardData.paybackPeriod">&mdash;</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+        <div class="col-12 col-lg-4 col-item-br opportunity-name p-0">
+          <div class="d-flex flex-column h-100">
+            <div class="d-flex flex-grow-1 justify-content-center align-items-center pl-3 pr-1">
+              <table class="table table-borderless mb-0">
+                <tbody>
+                  <tr class="no-border-top" [ngClass]="{ active: sortByVal.sortBy == 'teamName'}">
+                    <td class="w-75">
+                      Owner/Lead/Team
+                    </td>
+                    <td class="w-25">
+                      <span *ngIf="cardData.teamName">{{cardData.teamName}}</span>
+                      <span *ngIf="!cardData.teamName">&mdash;</span>
+                    </td>
+                  </tr>
+                  <tr [ngClass]="{ active: sortByVal.sortBy == 'annualCostSavings'}">
+                    <td class="w-75">Annual Savings ({{settings.currency}})</td>
+                    <td class="w-25">
+                      <span *ngIf="cardData.annualCostSavings">{{cardData.annualCostSavings | number:"1.0-0"}}</span>
+                      <span *ngIf="!cardData.annualCostSavings">&mdash;</span>
+                    </td>
+                  </tr>
+                  <tr [ngClass]="{active: sortByVal.sortBy == 'implementationCost'}">
+                    <td class="w-75">Implementation Cost ({{settings.currency}})</td>
+                    <td class="w-25">
+                      <span *ngIf="cardData.implementationCost">{{cardData.implementationCost | number:"1.0-0"}}</span>
+                      <span *ngIf="!cardData.implementationCost">&mdash;</span>
+                    </td>
+                  </tr>
+                  <tr [ngClass]="{ active: sortByVal.sortBy == 'paybackPeriod' }">
+                    <td class="w-75">
+                      Payback Period
+                    </td>
+                    <td class="w-25">
+                      <span *ngIf="cardData.paybackPeriod">{{cardData.paybackPeriod | number:"1.2-2"}}</span>
+                      <span *ngIf="!cardData.paybackPeriod">&mdash;</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div *ngIf="cardData.hasStaleAssessmentData" class="alert-warning text-center py-1 mb-0">
+              <i class="fa fa-exclamation-triangle"></i> Assessment data has changed
+              <button class="btn btn-sm btn-warning ml-2" (click)="syncAssessmentOpportunity(cardData)">Sync</button>
+            </div>
           </div>
         </div>
         <div class="col-12 col-lg-3 col-item-br">

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
@@ -8,6 +8,7 @@ import { Subscription } from 'rxjs';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { TreasureChestMenuService } from '../treasure-chest-menu/treasure-chest-menu.service';
 import { SortCardsData } from './sort-cards-by.pipe';
+import { AssessmentIntegrationService } from '../../../shared/assessment-integration/assessment-integration.service';
 
 @Component({
     selector: 'app-opportunity-cards',
@@ -35,13 +36,16 @@ export class OpportunityCardsComponent implements OnInit {
   updateOpportunityCardsSub: Subscription;
   deselectAllSub: Subscription;
   constructor(private opportunityCardsService: OpportunityCardsService, private calculatorsService: CalculatorsService, private treasureHuntService: TreasureHuntService,
-    private treasureChestMenuService: TreasureChestMenuService) { }
+    private treasureChestMenuService: TreasureChestMenuService,
+    private assessmentIntegrationService: AssessmentIntegrationService) { }
 
   ngOnInit() {
-    this.updateOpportunityCardsSub = this.opportunityCardsService.updateOpportunityCards.subscribe(val => {
+    this.updateOpportunityCardsSub = this.opportunityCardsService.updateOpportunityCards.subscribe(async val => {
       if (val == true) {
         this.treasureHunt = this.treasureHuntService.treasureHunt.getValue();
         this.opportunityCardList = this.opportunityCardsService.getOpportunityCardsData(this.treasureHunt, this.settings);
+        await this.opportunityCardsService.checkAssessmentOpportunityStaleness(this.opportunityCardList, this.settings);
+        this.opportunityCardList = Array.from(this.opportunityCardList);
         this.opportunityCardsService.opportunityCards.next(this.opportunityCardList);
         this.opportunityCardsService.updateOpportunityCards.next(false);
       }
@@ -194,6 +198,33 @@ export class OpportunityCardsComponent implements OnInit {
         this.toggleSelected(card);
       }
     });
+  }
+
+  async syncAssessmentOpportunity(cardData: OpportunityCardData) {
+    const existingData = cardData.assessmentOpportunity.existingIntegrationData;
+    const integratedAssessment = await this.assessmentIntegrationService.setIntegratedAssessment(
+      existingData.assessmentId, existingData.assessmentType, this.settings
+    );
+    if (!integratedAssessment?.assessment || !integratedAssessment.energyOptions) {
+      return;
+    }
+    existingData.energyOptions.baseline = integratedAssessment.energyOptions.baseline;
+    if (integratedAssessment.hasModifications && existingData.energyOptions.modifications?.length > 0) {
+      integratedAssessment.energyOptions.modifications.forEach(modification => {
+        const existingMod = existingData.energyOptions.modifications.find(
+          m => m.modificationId === modification.modificationId
+        );
+        if (existingMod) {
+          existingMod.annualEnergy = modification.annualEnergy;
+          existingMod.co2EmissionsOutput = modification.co2EmissionsOutput;
+          existingMod.annualCost = modification.annualCost;
+          existingMod.name = modification.name;
+        }
+      });
+    }
+    cardData.hasStaleAssessmentData = false;
+    this.opportunityCardList = Array.from(this.opportunityCardList);
+    this.saveOpportunityChanges(cardData);
   }
 
   createCopy(cardData: OpportunityCardData) {

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.component.ts
@@ -4,7 +4,8 @@ import { Settings } from '../../../shared/models/settings';
 import { OpportunityCardsService, OpportunityCardData } from './opportunity-cards.service';
 import { CalculatorsService } from '../../calculators/calculators.service';
 import { TreasureHuntService } from '../../treasure-hunt.service';
-import { Subscription } from 'rxjs';
+import { from, Subscription } from 'rxjs';
+import { concatMap, filter } from 'rxjs/operators';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { TreasureChestMenuService } from '../treasure-chest-menu/treasure-chest-menu.service';
 import { SortCardsData } from './sort-cards-by.pipe';
@@ -40,15 +41,17 @@ export class OpportunityCardsComponent implements OnInit {
     private assessmentIntegrationService: AssessmentIntegrationService) { }
 
   ngOnInit() {
-    this.updateOpportunityCardsSub = this.opportunityCardsService.updateOpportunityCards.subscribe(async val => {
-      if (val == true) {
+    this.updateOpportunityCardsSub = this.opportunityCardsService.updateOpportunityCards.pipe(
+      filter(val => val === true),
+      concatMap(() => {
         this.treasureHunt = this.treasureHuntService.treasureHunt.getValue();
         this.opportunityCardList = this.opportunityCardsService.getOpportunityCardsData(this.treasureHunt, this.settings);
-        await this.opportunityCardsService.checkAssessmentOpportunityStaleness(this.opportunityCardList, this.settings);
-        this.opportunityCardList = Array.from(this.opportunityCardList);
-        this.opportunityCardsService.opportunityCards.next(this.opportunityCardList);
-        this.opportunityCardsService.updateOpportunityCards.next(false);
-      }
+        return from(this.opportunityCardsService.checkAssessmentOpportunityStaleness(this.opportunityCardList, this.settings));
+      })
+    ).subscribe(() => {
+      this.opportunityCardList = Array.from(this.opportunityCardList);
+      this.opportunityCardsService.opportunityCards.next(this.opportunityCardList);
+      this.opportunityCardsService.updateOpportunityCards.next(false);
     });
     this.updatedOpportunityCardSub = this.opportunityCardsService.updatedOpportunityCard.subscribe(updatedOpportunityCard => {
       if (updatedOpportunityCard) {
@@ -209,6 +212,7 @@ export class OpportunityCardsComponent implements OnInit {
       return;
     }
     existingData.energyOptions.baseline = integratedAssessment.energyOptions.baseline;
+    cardData.assessmentOpportunity.baselineEnergyUseItems = integratedAssessment.baselineEnergyUseItems;
     if (integratedAssessment.hasModifications && existingData.energyOptions.modifications?.length > 0) {
       integratedAssessment.energyOptions.modifications.forEach(modification => {
         const existingMod = existingData.energyOptions.modifications.find(
@@ -221,6 +225,12 @@ export class OpportunityCardsComponent implements OnInit {
           existingMod.name = modification.name;
         }
       });
+      const selectedModification = integratedAssessment.modificationEnergyUseItems?.find(
+        item => item.modificationId === existingData.selectedModificationId
+      );
+      if (selectedModification) {
+        cardData.assessmentOpportunity.modificationEnergyUseItems = selectedModification.energies;
+      }
     }
     cardData.hasStaleAssessmentData = false;
     this.opportunityCardList = Array.from(this.opportunityCardList);

--- a/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.service.ts
+++ b/src/app/treasure-hunt/treasure-chest/opportunity-cards/opportunity-cards.service.ts
@@ -34,6 +34,7 @@ import { CoolingTowerBasinTreasureHuntService } from '../../treasure-hunt-calcul
 import { AssessmentOpportunityService } from '../../treasure-hunt-calculator-services/assessment-opportunity.service';
 import { BoilerBlowdownRateTreasureHuntService } from '../../treasure-hunt-calculator-services/boiler-blowdown-rate-treasure-hunt.service';
 import { PowerFactorCorrectionTreasureHuntService } from '../../treasure-hunt-calculator-services/power-factor-correction-treasure-hunt.service';
+import { AssessmentIntegrationService } from '../../../shared/assessment-integration/assessment-integration.service';
 
 @Injectable()
 export class OpportunityCardsService {
@@ -71,8 +72,9 @@ export class OpportunityCardsService {
     private coolingTowerFanTreasureHuntService: CoolingTowerFanTreasureHuntService,
     private coolingTowerBasinTreasureHuntService: CoolingTowerBasinTreasureHuntService,
     private assessmentOpportunityService: AssessmentOpportunityService,
-    private boilerBlowdownRateTreasureHuntService: BoilerBlowdownRateTreasureHuntService,    
-    private powerFactorCorrectionTreasureHuntService: PowerFactorCorrectionTreasureHuntService
+    private boilerBlowdownRateTreasureHuntService: BoilerBlowdownRateTreasureHuntService,
+    private powerFactorCorrectionTreasureHuntService: PowerFactorCorrectionTreasureHuntService,
+    private assessmentIntegrationService: AssessmentIntegrationService
   ) {
     this.updatedOpportunityCard = new BehaviorSubject<OpportunityCardData>(undefined);
     this.opportunityCards = new BehaviorSubject(new Array());
@@ -158,6 +160,30 @@ export class OpportunityCardsService {
     });
 
     return opportunityCardsData;
+  }
+
+  async checkAssessmentOpportunityStaleness(cards: OpportunityCardData[], settings: Settings): Promise<void> {
+    for (const card of cards) {
+      if (card.opportunityType !== Treasure.assessmentOpportunity || !card.assessmentOpportunity?.existingIntegrationData) {
+        continue;
+      }
+      const existingData = card.assessmentOpportunity.existingIntegrationData;
+      const integratedAssessment = await this.assessmentIntegrationService.setIntegratedAssessment(
+        existingData.assessmentId, existingData.assessmentType, settings
+      );
+      if (!integratedAssessment?.assessment || !integratedAssessment.energyOptions || !existingData.energyOptions) {
+        continue;
+      }
+      if (existingData.energyOptions.modifications?.length > 0) {
+        card.hasStaleAssessmentData = this.assessmentIntegrationService.checkHasUpdatedEnergyData(
+          existingData.energyOptions, integratedAssessment.energyOptions
+        );
+      } else {
+        card.hasStaleAssessmentData = this.assessmentIntegrationService.checkisOptionDifferent(
+          existingData.energyOptions.baseline, integratedAssessment.energyOptions.baseline
+        );
+      }
+    }
   }
 
   //lightingReplacement;
@@ -867,6 +893,7 @@ export interface OpportunityCardData {
   powerFactorCorrection?: PowerFactorCorrectionTreasureHunt;
   iconCalcType?: string;
   needBackground?: boolean;
+  hasStaleAssessmentData?: boolean;
 }
 
 export interface PercentEnergySavings {


### PR DESCRIPTION
#6545
- New Sync Banner on The TH Opportunity Card appears when the Assessment and the TH copy for Assessment Savings is out of Sync. 
- Pressing Sync on the Opportunity Card or entering the Assessment Savings and using the Sync button removes the warning and updates the Copied Assessment for TH.

# Pull Request Template

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
