### PR TITLE
Issue 8454: Import Custom Lighting into Replacement Lighting Calc

### DIFF
--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.html
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.html
@@ -50,14 +50,6 @@
         </select>
       </div>
 
-      <!-- <div class="form-group" *ngIf="fixtureTypes && fixtureTypes.length > 0">
-        <label for="{{'name_'+idString}}">Fixture Name
-        </label>
-          <input name="name" formControlName="name" type="text" class="form-control"
-            id="{{'name_'+idString}}" (input)="calculate()" onfocus="this.select();"
-            (focus)="focusField('name')">
-      </div> -->
-
       <div class="form-group" *ngIf="fixtureTypes && fixtureTypes.length > 0">
         <label for="{{'type_'+idString}}">Fixture type
         </label>

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.html
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.html
@@ -41,6 +41,7 @@
 
       <div class="form-group">
         <label for="{{'category_'+idString}}">Fixture Category
+            <a id="materialHelp" class="form-text small click-link" (click)="showMaterialModal(false)">Add Custom Fixture</a>
         </label>
         <select name="type" class="form-control" id="{{'category_'+idString}}" formControlName="category"
           (change)="setCategory()" (focus)="focusField('category')">
@@ -49,7 +50,15 @@
         </select>
       </div>
 
-      <div class="form-group" *ngIf="form.controls.category.value != 0">
+      <!-- <div class="form-group" *ngIf="fixtureTypes && fixtureTypes.length > 0">
+        <label for="{{'name_'+idString}}">Fixture Name
+        </label>
+          <input name="name" formControlName="name" type="text" class="form-control"
+            id="{{'name_'+idString}}" (input)="calculate()" onfocus="this.select();"
+            (focus)="focusField('name')">
+      </div> -->
+
+      <div class="form-group" *ngIf="fixtureTypes && fixtureTypes.length > 0">
         <label for="{{'type_'+idString}}">Fixture type
         </label>
         <select name="type" class="form-control" id="{{'type_'+idString}}" formControlName="type"
@@ -60,7 +69,7 @@
         </select>
       </div>
 
-      <div class="form-group help-text" *ngIf="form.controls.category.value != 0 && form.controls.lampLife.value">
+      <div class="form-group help-text" *ngIf="fixtureTypes && fixtureTypes.length > 0 && form.controls.lampLife.value">
         <label>Lamp Life
         </label>
         <div class="input-group">
@@ -192,6 +201,17 @@
 
     </div>
   </form>
+</div>
+<div bsModal #materialModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="materialModalLabel"
+  aria-hidden="true" [config]="{backdrop: 'static'}">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div>
+        <app-lighting-fixtures-material *ngIf="showModal" (closeModal)="hideMaterialModal($event)" (hideModal)="hideMaterialModal($event)"
+          [settings]="settings" [editExistingMaterial]="editExistingMaterial" [existingMaterial]="existingMaterial"></app-lighting-fixtures-material>
+      </div>
+    </div>
+  </div>
 </div>
 
 

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
@@ -237,12 +237,12 @@ export class LightingReplacementFormComponent implements OnInit, OnDestroy {
     this.materialModal.show();
   }
 
-  hideMaterialModal(event?: LightingFixtureMaterial) {
-    if (event) {
+  hideMaterialModal(result?: LightingFixtureMaterial) {
+    if (result) {
       this.form.controls.category.setValue(0);
       this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0).fixturesData;
       this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
-      this.form.controls.type.setValue(event.type && event.type.trim() !== '' ? event.type : event.name);
+      this.form.controls.type.setValue(result.type && result.type.trim() !== '' ? result.type : result.name);
       this.setProperties();
     }
     this.showModal = false;

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
@@ -65,12 +65,11 @@ export class LightingReplacementFormComponent implements OnInit, OnDestroy {
   indicateLumenDegradationFactorDiff: boolean = false;
   indicateFixtureTypeDiff: boolean = false;
 
-  customFixturesSub: Subscription;
+  lightingFixtureCategoriesSub: Subscription;
 
   constructor(private lightingReplacementService: LightingReplacementService, private cd: ChangeDetectorRef) {}
 
   ngOnInit() {
-    this.lightingFixtureCategories = this.lightingReplacementService.getLightingFixtureCategories();
     this.displayDetails = this.lightingReplacementService.showAdditionalDetails;
     if (this.isBaseline) {
       this.idString = 'baseline_' + this.index;
@@ -80,24 +79,23 @@ export class LightingReplacementFormComponent implements OnInit, OnDestroy {
     }
 
     this.form = this.lightingReplacementService.getFormFromObj(this.data);
-    this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => { return fixtureCategory.category == this.form.controls.category.value }).fixturesData;
-    this.computeFixtureDiff();
-    this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
+    this.lightingReplacementService.loadLightingFixtureCategories();
+    this.lightingFixtureCategoriesSub = this.lightingReplacementService.lightingFixtureCategories$.subscribe(categories => {
+      if (!categories) {
+        return;
+      }
+      this.lightingFixtureCategories = categories;
+      this.fixtureTypes = categories.find(fixtureCategory => fixtureCategory.category == this.form.controls.category.value).fixturesData;
+      this.checkSelectFixtureDiff();
+      this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
+    });
     if (this.selected == false) {
       this.form.disable();
     }
-
-    this.customFixturesSub = this.lightingReplacementService.customFixturesUpdated.subscribe(() => {
-      if (this.form.controls.category.value === 0) {
-        this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0).fixturesData;
-        this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
-        this.checkSelectFixtureDiff();
-      }
-    });
   }
 
   ngOnDestroy() {
-    this.customFixturesSub?.unsubscribe();
+    this.lightingFixtureCategoriesSub?.unsubscribe();
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter, ViewChild, ElementRef, SimpleChanges, HostListener, ChangeDetectorRef } from '@angular/core';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { LightingReplacementData } from '../../../../shared/models/lighting';
 import { UntypedFormGroup } from '@angular/forms';
 import { LightingReplacementService } from '../lighting-replacement.service';
@@ -6,6 +7,10 @@ import { OperatingHours } from '../../../../shared/models/operations';
 import { LightingFixtureData } from '../../../../tools-suite-api/lighting-suite-api.service';
 import { LightingSuiteApiService } from '../../../../tools-suite-api/lighting-suite-api.service';
 import { LightingFixtureCategory } from '../../../../tools-suite-api/lighting-suite-api.service';
+import { LightingFixtureMaterial } from '../../../../shared/models/materials';
+import { Settings } from '../../../../shared/models/settings';
+import { LightingFixtureServiceDbService } from '../../../../indexedDb/lighting-fixture-db.service';
+import { firstValueFrom } from 'rxjs';
 @Component({
     selector: 'app-lighting-replacement-form',
     templateUrl: './lighting-replacement-form.component.html',
@@ -27,8 +32,13 @@ export class LightingReplacementFormComponent implements OnInit {
   isBaseline: boolean;
   @Input()
   selected: boolean;
+  @Input()
+  settings: Settings
+  @Input()
+  baselineSelected: boolean;
 
   @ViewChild('formElement', { static: false }) formElement: ElementRef;
+  @ViewChild('materialModal', { static: false }) public materialModal: ModalDirective;
   @HostListener('window:resize', ['$event'])
   onResize(event) {
     this.setOpHoursModalWidth();
@@ -38,6 +48,10 @@ export class LightingReplacementFormComponent implements OnInit {
 
   idString: string;
   isEditingName: boolean = false;
+  existingMaterial: LightingFixtureMaterial;
+  showModal: boolean = false;
+  hasDeletedCustomMaterial: boolean = false
+  editExistingMaterial: boolean;
   form: UntypedFormGroup;
 
   showOperatingHoursModal: boolean;
@@ -54,7 +68,8 @@ export class LightingReplacementFormComponent implements OnInit {
   indicateLumenDegradationFactorDiff: boolean = false;
   indicateFixtureTypeDiff: boolean = false;
 
-  constructor(private lightingReplacementService: LightingReplacementService, private cd: ChangeDetectorRef, private lightingSuiteApiService: LightingSuiteApiService) {}
+  constructor(private lightingReplacementService: LightingReplacementService, private cd: ChangeDetectorRef,
+    private lightingSuiteApiService: LightingSuiteApiService, private lightingFixtureServiceDbService: LightingFixtureServiceDbService) {}
 
   ngOnInit() {
     this.lightingFixtureCategories = this.lightingSuiteApiService.getLightingSystems();
@@ -68,11 +83,41 @@ export class LightingReplacementFormComponent implements OnInit {
 
     this.form = this.lightingReplacementService.getFormFromObj(this.data);
     this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => { return fixtureCategory.category == this.form.controls.category.value }).fixturesData;
-    this.checkSelectFixtureDiff();
+    this.computeFixtureDiff();
     this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
     if (this.selected == false) {
       this.form.disable();
     }
+
+    this.loadCustomFixtures().then(() => {
+      if (this.form.controls.category.value === 0) {
+        this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0).fixturesData;
+        this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
+        this.checkSelectFixtureDiff();
+      }
+    });
+  }
+
+  async loadCustomFixtures(): Promise<Array<LightingFixtureData>> {
+    let customMaterials: Array<LightingFixtureMaterial> = await firstValueFrom(this.lightingFixtureServiceDbService.getAllCustomMaterials());
+    let customFixturesData: Array<LightingFixtureData> = customMaterials.map(material => this.toLightingFixtureData(material));
+    let customCategory: LightingFixtureCategory = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0);
+    customCategory.fixturesData = customFixturesData;
+    return customFixturesData;
+  }
+
+  toLightingFixtureData(material: LightingFixtureMaterial): LightingFixtureData {
+    return {
+      category: material.category,
+      type: material.type && material.type.trim() !== '' ? material.type : material.name,
+      lampsPerFixture: material.lampsPerFixture,
+      wattsPerLamp: material.wattsPerLamp,
+      lumensPerLamp: material.lumensPerLamp,
+      lampLife: material.lampLife,
+      coefficientOfUtilization: material.coefficientOfUtilization,
+      ballastFactor: material.ballastFactor,
+      lumenDegradationFactor: material.lumenDegradationFactor
+    };
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -183,6 +228,11 @@ export class LightingReplacementFormComponent implements OnInit {
   }
 
   checkSelectFixtureDiff() {
+    this.computeFixtureDiff();
+    this.cd.detectChanges();
+  }
+
+  computeFixtureDiff() {
     if (this.form.controls.category.value != 0) {
       let fixtureData: LightingFixtureData = this.fixtureTypes.find(fixtureType => { return fixtureType.type == this.form.controls.type.value });
       if (fixtureData != undefined && fixtureData.type != "") {
@@ -199,7 +249,30 @@ export class LightingReplacementFormComponent implements OnInit {
       this.setNotDiff();
     }
     this.indicateFixtureTypeDiff = this.indicateLampsPerFixtureDiff || this.indicateWattsPerLampDiff || this.indicateLumensPerLampDiff || this.indicateCoefficientOfUtilizationDiff || this.indicateBallastFactorDiff || this.indicateLumenDegradationFactorDiff;
-    this.cd.detectChanges();
+  }
+
+  showMaterialModal(editExistingMaterial: boolean) {
+    this.editExistingMaterial = editExistingMaterial;
+    this.showModal = true;
+    this.materialModal.show();
+  }
+
+  async hideMaterialModal(event?: LightingFixtureMaterial) {
+    if (event) {
+      await this.loadCustomFixtures();
+      this.form.controls.category.setValue(0);
+      this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0).fixturesData;
+      this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
+      this.form.controls.type.setValue(event.type && event.type.trim() !== '' ? event.type : event.name);
+      this.setProperties();
+    }
+    this.showModal = false;
+    this.dismissMessage();
+    this.materialModal.hide();
+  }
+
+  dismissMessage() {
+    this.hasDeletedCustomMaterial = false;
   }
 
   setNotDiff() {

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement-form/lighting-replacement-form.component.ts
@@ -1,23 +1,21 @@
-import { Component, OnInit, Input, Output, EventEmitter, ViewChild, ElementRef, SimpleChanges, HostListener, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, Output, EventEmitter, ViewChild, ElementRef, SimpleChanges, HostListener, ChangeDetectorRef } from '@angular/core';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { LightingReplacementData } from '../../../../shared/models/lighting';
 import { UntypedFormGroup } from '@angular/forms';
 import { LightingReplacementService } from '../lighting-replacement.service';
 import { OperatingHours } from '../../../../shared/models/operations';
 import { LightingFixtureData } from '../../../../tools-suite-api/lighting-suite-api.service';
-import { LightingSuiteApiService } from '../../../../tools-suite-api/lighting-suite-api.service';
 import { LightingFixtureCategory } from '../../../../tools-suite-api/lighting-suite-api.service';
 import { LightingFixtureMaterial } from '../../../../shared/models/materials';
 import { Settings } from '../../../../shared/models/settings';
-import { LightingFixtureServiceDbService } from '../../../../indexedDb/lighting-fixture-db.service';
-import { firstValueFrom } from 'rxjs';
+import { Subscription } from 'rxjs';
 @Component({
     selector: 'app-lighting-replacement-form',
     templateUrl: './lighting-replacement-form.component.html',
     styleUrls: ['./lighting-replacement-form.component.css'],
     standalone: false
 })
-export class LightingReplacementFormComponent implements OnInit {
+export class LightingReplacementFormComponent implements OnInit, OnDestroy {
   @Input()
   data: LightingReplacementData;
   @Output('emitCalculate')
@@ -50,7 +48,6 @@ export class LightingReplacementFormComponent implements OnInit {
   isEditingName: boolean = false;
   existingMaterial: LightingFixtureMaterial;
   showModal: boolean = false;
-  hasDeletedCustomMaterial: boolean = false
   editExistingMaterial: boolean;
   form: UntypedFormGroup;
 
@@ -68,11 +65,12 @@ export class LightingReplacementFormComponent implements OnInit {
   indicateLumenDegradationFactorDiff: boolean = false;
   indicateFixtureTypeDiff: boolean = false;
 
-  constructor(private lightingReplacementService: LightingReplacementService, private cd: ChangeDetectorRef,
-    private lightingSuiteApiService: LightingSuiteApiService, private lightingFixtureServiceDbService: LightingFixtureServiceDbService) {}
+  customFixturesSub: Subscription;
+
+  constructor(private lightingReplacementService: LightingReplacementService, private cd: ChangeDetectorRef) {}
 
   ngOnInit() {
-    this.lightingFixtureCategories = this.lightingSuiteApiService.getLightingSystems();
+    this.lightingFixtureCategories = this.lightingReplacementService.getLightingFixtureCategories();
     this.displayDetails = this.lightingReplacementService.showAdditionalDetails;
     if (this.isBaseline) {
       this.idString = 'baseline_' + this.index;
@@ -89,7 +87,7 @@ export class LightingReplacementFormComponent implements OnInit {
       this.form.disable();
     }
 
-    this.loadCustomFixtures().then(() => {
+    this.customFixturesSub = this.lightingReplacementService.customFixturesUpdated.subscribe(() => {
       if (this.form.controls.category.value === 0) {
         this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0).fixturesData;
         this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
@@ -98,26 +96,8 @@ export class LightingReplacementFormComponent implements OnInit {
     });
   }
 
-  async loadCustomFixtures(): Promise<Array<LightingFixtureData>> {
-    let customMaterials: Array<LightingFixtureMaterial> = await firstValueFrom(this.lightingFixtureServiceDbService.getAllCustomMaterials());
-    let customFixturesData: Array<LightingFixtureData> = customMaterials.map(material => this.toLightingFixtureData(material));
-    let customCategory: LightingFixtureCategory = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0);
-    customCategory.fixturesData = customFixturesData;
-    return customFixturesData;
-  }
-
-  toLightingFixtureData(material: LightingFixtureMaterial): LightingFixtureData {
-    return {
-      category: material.category,
-      type: material.type && material.type.trim() !== '' ? material.type : material.name,
-      lampsPerFixture: material.lampsPerFixture,
-      wattsPerLamp: material.wattsPerLamp,
-      lumensPerLamp: material.lumensPerLamp,
-      lampLife: material.lampLife,
-      coefficientOfUtilization: material.coefficientOfUtilization,
-      ballastFactor: material.ballastFactor,
-      lumenDegradationFactor: material.lumenDegradationFactor
-    };
+  ngOnDestroy() {
+    this.customFixturesSub?.unsubscribe();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -257,9 +237,8 @@ export class LightingReplacementFormComponent implements OnInit {
     this.materialModal.show();
   }
 
-  async hideMaterialModal(event?: LightingFixtureMaterial) {
+  hideMaterialModal(event?: LightingFixtureMaterial) {
     if (event) {
-      await this.loadCustomFixtures();
       this.form.controls.category.setValue(0);
       this.fixtureTypes = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0).fixturesData;
       this.lightingReplacementService.selectedFixtureTypes.next(this.fixtureTypes);
@@ -267,12 +246,7 @@ export class LightingReplacementFormComponent implements OnInit {
       this.setProperties();
     }
     this.showModal = false;
-    this.dismissMessage();
     this.materialModal.hide();
-  }
-
-  dismissMessage() {
-    this.hasDeletedCustomMaterial = false;
   }
 
   setNotDiff() {

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement.component.html
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement.component.html
@@ -94,7 +94,7 @@
           <div *ngFor="let data of modificationData; let index = index;">
             <app-lighting-replacement-form [data]="data" [index]="index" [isBaseline]="false"
               (emitCalculate)="updateModificationData($event, index)" (emitFocusField)="focusField($event)"
-              (emitRemoveFixture)="removeModificationFixture($event)" [selected]="!baselineSelected", [settings]="settings">
+              (emitRemoveFixture)="removeModificationFixture($event)" [selected]="!baselineSelected" [settings]="settings">
             </app-lighting-replacement-form>
           </div>
         </div>

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement.component.html
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement.component.html
@@ -94,7 +94,7 @@
           <div *ngFor="let data of modificationData; let index = index;">
             <app-lighting-replacement-form [data]="data" [index]="index" [isBaseline]="false"
               (emitCalculate)="updateModificationData($event, index)" (emitFocusField)="focusField($event)"
-              (emitRemoveFixture)="removeModificationFixture($event)" [selected]="!baselineSelected">
+              (emitRemoveFixture)="removeModificationFixture($event)" [selected]="!baselineSelected", [settings]="settings">
             </app-lighting-replacement-form>
           </div>
         </div>

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement.module.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement.module.ts
@@ -8,14 +8,17 @@ import { LightingReplacementResultsComponent } from './lighting-replacement-resu
 import { LightingReplacementHelpComponent } from './lighting-replacement-help/lighting-replacement-help.component';
 import { ExportableResultsTableModule } from '../../../shared/exportable-results-table/exportable-results-table.module';
 import { OperatingHoursModalModule } from '../../../shared/operating-hours-modal/operating-hours-modal.module';
-
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { SuiteDbModule } from '../../../suiteDb/suiteDb.module';
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
     ExportableResultsTableModule,
-    OperatingHoursModalModule
+    OperatingHoursModalModule,
+    ModalModule,
+    SuiteDbModule
   ],
   declarations: [LightingReplacementComponent, LightingReplacementFormComponent, LightingReplacementResultsComponent, LightingReplacementHelpComponent],
   exports: [LightingReplacementComponent],

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement.service.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement.service.ts
@@ -1,13 +1,15 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import * as _ from 'lodash';
 import { LightingReplacementResults, LightingReplacementData, LightingReplacementResult } from '../../../shared/models/lighting';
 import { LightingReplacementTreasureHunt } from '../../../shared/models/treasure-hunt';
 import { OperatingHours } from '../../../shared/models/operations';
 import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
-import { LightingFixtureData } from '../../../tools-suite-api/lighting-suite-api.service';
-import { BehaviorSubject } from 'rxjs';
+import { LightingFixtureCategory, LightingFixtureData, LightingSuiteApiService } from '../../../tools-suite-api/lighting-suite-api.service';
+import { LightingFixtureServiceDbService } from '../../../indexedDb/lighting-fixture-db.service';
+import { LightingFixtureMaterial } from '../../../shared/models/materials';
+import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 @Injectable()
-export class LightingReplacementService {
+export class LightingReplacementService implements OnDestroy {
 
   baselineData: Array<LightingReplacementData>;
   modificationData: Array<LightingReplacementData>;
@@ -17,8 +19,55 @@ export class LightingReplacementService {
   selectedFixtureTypes: BehaviorSubject<Array<LightingFixtureData>>;
   showAdditionalDetails: boolean = false;
 
-  constructor(private fb: UntypedFormBuilder) {
+  lightingFixtureCategories: Array<LightingFixtureCategory>;
+
+  customFixturesUpdated: Subject<void> = new Subject<void>();
+  private customFixturesSub: Subscription;
+  private latestCustomMaterials: Array<LightingFixtureMaterial>;
+
+  constructor(private fb: UntypedFormBuilder, private lightingSuiteApiService: LightingSuiteApiService,
+    private lightingFixtureServiceDbService: LightingFixtureServiceDbService) {
     this.selectedFixtureTypes = new BehaviorSubject(undefined);
+    this.customFixturesSub = this.lightingFixtureServiceDbService.dbLightingFixtureMaterials.subscribe(materials => {
+      this.latestCustomMaterials = materials;
+      if (this.lightingFixtureCategories) {
+        this.applyCustomFixtures(materials);
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.customFixturesSub?.unsubscribe();
+  }
+
+  getLightingFixtureCategories(): Array<LightingFixtureCategory> {
+    if (!this.lightingFixtureCategories) {
+      this.lightingFixtureCategories = this.lightingSuiteApiService.getLightingSystems();
+      if (this.latestCustomMaterials) {
+        this.applyCustomFixtures(this.latestCustomMaterials);
+      }
+    }
+    return this.lightingFixtureCategories;
+  }
+
+  applyCustomFixtures(materials: Array<LightingFixtureMaterial>) {
+    let customCategory: LightingFixtureCategory = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0);
+    customCategory.fixturesData = materials.filter(material => !material.isDefault).map(material => this.toLightingFixtureData(material));
+    this.customFixturesUpdated.next();
+  }
+
+  toLightingFixtureData(material: LightingFixtureMaterial): LightingFixtureData {
+    return {
+      category: material.category,
+      type: material.type && material.type.trim() !== '' ? material.type : material.name,
+      lampsPerFixture: material.lampsPerFixture,
+      wattsPerLamp: material.wattsPerLamp,
+      lumensPerLamp: material.lumensPerLamp,
+      lampLife: material.lampLife,
+      coefficientOfUtilization: material.coefficientOfUtilization,
+      ballastFactor: material.ballastFactor,
+      lumenDegradationFactor: material.lumenDegradationFactor
+    };
   }
 
   initObject(index: number, opperatingHoursPerYear: OperatingHours): LightingReplacementData {

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement.service.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement.service.ts
@@ -124,7 +124,7 @@ export class LightingReplacementService implements OnDestroy {
       totalLighting: 0,
       electricityUse: 0,
       //added for #2381
-      lampLife: form.controls.lumensPerLamp.value,
+      lampLife: form.controls.lampLife.value,
       ballastFactor: form.controls.ballastFactor.value,
       lumenDegradationFactor: form.controls.lumenDegradationFactor.value,
       coefficientOfUtilization: form.controls.coefficientOfUtilization.value,

--- a/src/app/calculator/lighting/lighting-replacement/lighting-replacement.service.ts
+++ b/src/app/calculator/lighting/lighting-replacement/lighting-replacement.service.ts
@@ -7,7 +7,7 @@ import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms
 import { LightingFixtureCategory, LightingFixtureData, LightingSuiteApiService } from '../../../tools-suite-api/lighting-suite-api.service';
 import { LightingFixtureServiceDbService } from '../../../indexedDb/lighting-fixture-db.service';
 import { LightingFixtureMaterial } from '../../../shared/models/materials';
-import { BehaviorSubject, Subject, Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 @Injectable()
 export class LightingReplacementService implements OnDestroy {
 
@@ -19,20 +19,19 @@ export class LightingReplacementService implements OnDestroy {
   selectedFixtureTypes: BehaviorSubject<Array<LightingFixtureData>>;
   showAdditionalDetails: boolean = false;
 
-  lightingFixtureCategories: Array<LightingFixtureCategory>;
+  lightingFixtureCategories$: BehaviorSubject<Array<LightingFixtureCategory>>;
 
-  customFixturesUpdated: Subject<void> = new Subject<void>();
   private customFixturesSub: Subscription;
   private latestCustomMaterials: Array<LightingFixtureMaterial>;
 
   constructor(private fb: UntypedFormBuilder, private lightingSuiteApiService: LightingSuiteApiService,
     private lightingFixtureServiceDbService: LightingFixtureServiceDbService) {
     this.selectedFixtureTypes = new BehaviorSubject(undefined);
+    this.lightingFixtureCategories$ = new BehaviorSubject(undefined);
+
     this.customFixturesSub = this.lightingFixtureServiceDbService.dbLightingFixtureMaterials.subscribe(materials => {
       this.latestCustomMaterials = materials;
-      if (this.lightingFixtureCategories) {
-        this.applyCustomFixtures(materials);
-      }
+      this.applyCustomFixtures();
     });
   }
 
@@ -40,20 +39,21 @@ export class LightingReplacementService implements OnDestroy {
     this.customFixturesSub?.unsubscribe();
   }
 
-  getLightingFixtureCategories(): Array<LightingFixtureCategory> {
-    if (!this.lightingFixtureCategories) {
-      this.lightingFixtureCategories = this.lightingSuiteApiService.getLightingSystems();
-      if (this.latestCustomMaterials) {
-        this.applyCustomFixtures(this.latestCustomMaterials);
-      }
+  loadLightingFixtureCategories() {
+    if (!this.lightingFixtureCategories$.value) {
+      this.lightingFixtureCategories$.next(this.lightingSuiteApiService.getLightingSystems());
+      this.applyCustomFixtures();
     }
-    return this.lightingFixtureCategories;
   }
 
-  applyCustomFixtures(materials: Array<LightingFixtureMaterial>) {
-    let customCategory: LightingFixtureCategory = this.lightingFixtureCategories.find(fixtureCategory => fixtureCategory.category === 0);
-    customCategory.fixturesData = materials.filter(material => !material.isDefault).map(material => this.toLightingFixtureData(material));
-    this.customFixturesUpdated.next();
+  applyCustomFixtures() {
+    let categories = this.lightingFixtureCategories$.value;
+    if (!categories || !this.latestCustomMaterials) {
+      return;
+    }
+    let customCategory: LightingFixtureCategory = categories.find(fixtureCategory => fixtureCategory.category === 0);
+    customCategory.fixturesData = this.latestCustomMaterials.filter(material => !material.isDefault).map(material => this.toLightingFixtureData(material));
+    this.lightingFixtureCategories$.next(categories);
   }
 
   toLightingFixtureData(material: LightingFixtureMaterial): LightingFixtureData {

--- a/src/app/core/core.component.ts
+++ b/src/app/core/core.component.ts
@@ -24,6 +24,7 @@ import { CORE_DATA_WARNING, SECONDARY_DATA_WARNING, SnackbarService } from '../s
 import { BrowserStorageAvailable, BrowserStorageService } from '../shared/browser-storage.service';
 import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
 import { FlueGasMaterialDbService } from '../indexedDb/flue-gas-material-db.service';
+import { LightingFixtureServiceDbService } from '../indexedDb/lighting-fixture-db.service';
 import { ToolsSuiteApiService } from '../tools-suite-api/tools-suite-api.service';
 import { DialogRef} from '@angular/cdk/dialog';
 import { ModalDialogService } from '../shared/modal-dialog.service';
@@ -100,6 +101,7 @@ export class CoreComponent implements OnInit {
     private exportToJustifiTemplateService: ExportToJustifiTemplateService,
     private solidLiquidMaterialDbService: SolidLiquidMaterialDbService,
     private flueGasMaterialDbService: FlueGasMaterialDbService,
+    private lightingFixtureServiceDbService: LightingFixtureServiceDbService,
     private toolsSuiteApiService: ToolsSuiteApiService,
     private modalDialogService: ModalDialogService,
     private featureFlagService: FeatureFlagService,
@@ -258,6 +260,7 @@ export class CoreComponent implements OnInit {
       //data initialized in createDefaultProcessHeatingMaterials on startup
       await this.solidLiquidMaterialDbService.setAllMaterialsFromDb();
       await this.flueGasMaterialDbService.setAllMaterialsFromDb();
+      await this.lightingFixtureServiceDbService.setAllMaterialsFromDb();
     }
   }
 

--- a/src/app/shared/backup-data.service.ts
+++ b/src/app/shared/backup-data.service.ts
@@ -15,7 +15,8 @@ import { LiquidLoadMaterialDbService } from '../indexedDb/liquid-load-material-d
 import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
 import { SolidLoadMaterialDbService } from '../indexedDb/solid-load-material-db.service';
 import { WallLossesSurfaceDbService } from '../indexedDb/wall-losses-surface-db.service';
-import { AtmosphereSpecificHeat, FlueGasMaterial, GasLoadChargeMaterial, LiquidLoadChargeMaterial, SolidLiquidFlueGasMaterial, SolidLoadChargeMaterial, SuiteDbMotor, SuiteDbPump, WallLossesSurface } from './models/materials';
+import { LightingFixtureServiceDbService } from '../indexedDb/lighting-fixture-db.service';
+import { AtmosphereSpecificHeat, FlueGasMaterial, GasLoadChargeMaterial, LightingFixtureMaterial, LiquidLoadChargeMaterial, SolidLiquidFlueGasMaterial, SolidLoadChargeMaterial, SuiteDbMotor, SuiteDbPump, WallLossesSurface } from './models/materials';
 import { ApplicationInstanceDbService } from '../indexedDb/application-instance-db.service';
 import { Settings } from './models/settings';
 import { firstValueFrom } from 'rxjs';
@@ -41,6 +42,7 @@ export class BackupDataService {
     private solidLiquidMaterialDbService: SolidLiquidMaterialDbService,
     private diagramDbService: DiagramIdbService,
     private atmosphereDbService: AtmosphereDbService,
+    private lightingFixtureServiceDbService: LightingFixtureServiceDbService,
   ) { }
 
 
@@ -117,6 +119,7 @@ export class BackupDataService {
     backupFile.wallLossesSurfaces = await firstValueFrom(this.wallLossesSurfaceDbService.getAllCustomMaterials());
     backupFile.flueGasMaterials = this.flueGasMaterialDbService.getAllCustomMaterials();
     backupFile.solidLiquidFlueGasMaterials = this.solidLiquidMaterialDbService.getAllCustomMaterials();
+    backupFile.lightingFixtureMaterials = await firstValueFrom(this.lightingFixtureServiceDbService.getAllCustomMaterials());
   }
   
   async downloadBackupFile() {
@@ -149,5 +152,6 @@ export interface MeasurBackupFile {
   solidLoadChargeMaterials?: SolidLoadChargeMaterial[],
   atmosphereSpecificHeats?: AtmosphereSpecificHeat[],
   wallLossesSurfaces?: WallLossesSurface[],
+  lightingFixtureMaterials?: LightingFixtureMaterial[],
 }
 

--- a/src/app/shared/import-backup.service.ts
+++ b/src/app/shared/import-backup.service.ts
@@ -15,6 +15,7 @@ import { SettingsDbService } from '../indexedDb/settings-db.service';
 import { SolidLiquidMaterialDbService } from '../indexedDb/solid-liquid-material-db.service';
 import { SolidLoadMaterialDbService } from '../indexedDb/solid-load-material-db.service';
 import { WallLossesSurfaceDbService } from '../indexedDb/wall-losses-surface-db.service';
+import { LightingFixtureServiceDbService } from '../indexedDb/lighting-fixture-db.service';
 import { Directory } from './models/directory';
 import { Assessment } from './models/assessment';
 import { InventoryItem } from './models/inventory/inventory';
@@ -58,6 +59,7 @@ export class ImportBackupService {
     private flueGasMaterialDbService: FlueGasMaterialDbService,
     private solidLiquidMaterialDbService: SolidLiquidMaterialDbService,
     private atmosphereDbService: AtmosphereDbService,
+    private lightingFixtureServiceDbService: LightingFixtureServiceDbService,
     private inventoryDbService: InventoryDbService,
     private manageAppDataService: ManageAppDataService,
     private diagramDbService: DiagramIdbService,
@@ -269,6 +271,12 @@ export class ImportBackupService {
       material.selected = false;
       delete material.id;
       await this.solidLiquidMaterialDbService.addMaterial(material);
+    };
+
+    for await (let material of measurBackupFile.lightingFixtureMaterials ?? []) {
+      material.selected = false;
+      delete material.id;
+      await firstValueFrom(this.lightingFixtureServiceDbService.addWithObservable(material));
     };
   }
 

--- a/src/app/suiteDb/lighting-fixtures/lighting-fixtures-material.component.ts
+++ b/src/app/suiteDb/lighting-fixtures/lighting-fixtures-material.component.ts
@@ -152,6 +152,8 @@ export class LightingFixturesMaterialComponent implements OnInit {
     async addMaterial() {
         if (this.canAdd) {
             this.canAdd = false;
+            this.newMaterial.category = 'Custom';
+            this.newMaterial.type = this.newMaterial.name;
             await firstValueFrom(this.lightingFixtureServiceDbService.addWithObservable(this.newMaterial));
             let materials = await firstValueFrom(this.lightingFixtureServiceDbService.getAllWithObservable());
             this.lightingFixtureServiceDbService.dbLightingFixtureMaterials.next(materials);
@@ -161,6 +163,8 @@ export class LightingFixturesMaterialComponent implements OnInit {
 
     async updateMaterial() {
         this.newMaterial.id = this.idbEditMaterialId;
+        this.newMaterial.category = 'Custom';
+        this.newMaterial.type = this.newMaterial.name;
         await firstValueFrom(this.lightingFixtureServiceDbService.updateWithObservable(this.newMaterial));
         let materials = await firstValueFrom(this.lightingFixtureServiceDbService.getAllWithObservable());
         this.lightingFixtureServiceDbService.dbLightingFixtureMaterials.next(materials);
@@ -190,7 +194,7 @@ export class LightingFixturesMaterialComponent implements OnInit {
 
     onFixtureTypeChange(selectedFixture: any) {
         if (selectedFixture) {
-            this.newMaterial.name = selectedFixture.type ?? '';
+            this.newMaterial.name = selectedFixture.type ? selectedFixture.type + ' (mod)' : '';
             this.newMaterial.lampsPerFixture = selectedFixture.lampsPerFixture ?? 0;
             this.newMaterial.wattsPerLamp = selectedFixture.wattsPerLamp ?? 0;
             this.newMaterial.lumensPerLamp = selectedFixture.lumensPerLamp ?? 0;


### PR DESCRIPTION
#8454 
- Corrected Custom Materials Lighting to only create custom Fixture Types, stopping you from having a custom "Metal Halide" fixture inside the default "Metal Halide fixtures".
- Can create and import Custom materials into the Replacement Lighting Calculator.


# Pull Request Template

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
