### PR TITLE
Issue 7862: Applies ConvertValue to Water Diagram

### DIFF
--- a/process-flow-diagram-component/src/AppWebComponent.tsx
+++ b/process-flow-diagram-component/src/AppWebComponent.tsx
@@ -2,20 +2,22 @@ import { Root, createRoot } from 'react-dom/client';
 import App from './App';
 import { CacheProvider } from '@emotion/react';
 import createCache, { EmotionCache } from "@emotion/cache";
-import { ProcessFlowParentState, FlowDiagramData, ProcessFlowDiagramState } from 'process-flow-lib';
+import { ProcessFlowParentState, FlowDiagramData, ProcessFlowDiagramState, ConvertValueFn } from 'process-flow-lib';
 
 class AppWebComponent extends HTMLElement {
   mountPoint!: HTMLDivElement;
   appRef!: Root;
   name!: string;
-  static observedAttributes = ['parentstate']; 
-  // * NOTE: 
+  static observedAttributes = ['parentstate'];
+  // * NOTE:
   // * 1. shadowRoot is typically a scoped variable only used for attaching shadow and setting mount point
   // * it was changed to be a class property here so it could be passed to DownloadImage, which requires a dom ref.
   // * 2. Due to this change, events must now be dispatched from shadowRoot, instead of 'this' (AppWebComponent)
   shadowRoot;
   // * make MUI library styles available too shadowDom
   MUIStylesCache: EmotionCache;
+  // * plain JS property, not an observed attribute like parentstate - functions can't be stringified
+  private _convertValueFn?: ConvertValueFn;
 
   renderDiagramComponent(parentState: ProcessFlowParentState) {
     if (parentState && parentState.parentContainer) {
@@ -26,9 +28,21 @@ class AppWebComponent extends HTMLElement {
             processDiagram={parentState.waterDiagram}
             shadowRoot={this.shadowRoot}
             saveFlowDiagramData={this.emitFlowDiagramDataUpdate}
+            convertValueFn={this._convertValueFn}
             />
         </CacheProvider>
         )
+    }
+  }
+
+  get convertValueFn(): ConvertValueFn | undefined {
+    return this._convertValueFn;
+  }
+
+  set convertValueFn(fn: ConvertValueFn | undefined) {
+    this._convertValueFn = fn;
+    if (this.appRef && this.parentstate) {
+      this.renderDiagramComponent(this.parentstate);
     }
   }
 

--- a/process-flow-diagram-component/src/components/Diagram/Diagram.tsx
+++ b/process-flow-diagram-component/src/components/Diagram/Diagram.tsx
@@ -25,7 +25,7 @@ import { Provider } from 'react-redux';
 import { addNode, addNodes, connectEdge, diagramInitialized, edgesChange, edgesUpdate, keyboardDeleteNode, nodesChange, openDrawerWithSelected, selectedIdChange } from './diagramReducer';
 import ValidationWindow, { ValidationWindowLocation } from './ValidationWindow';
 import StaticModal from '../Forms/StaticModal';
-import { ParentContainerDimensions, WaterDiagram, FlowDiagramData, ProcessFlowPart, UserDiagramOptions, DiagramSettings, DiagramCalculatedData, NodeErrors, getIsDiagramValid } from 'process-flow-lib';
+import { ConvertValueFn, ParentContainerDimensions, WaterDiagram, FlowDiagramData, ProcessFlowPart, UserDiagramOptions, DiagramSettings, DiagramCalculatedData, NodeErrors, getIsDiagramValid } from 'process-flow-lib';
 import MenuSidebar from '../Drawer/MenuSidebar';
 import DataSidebar from '../Drawer/DataSidebar';
 import SharedDrawer, { drawerClosedOffsetPx, drawerOpenOffsetPx } from '../Drawer/SharedDrawer';
@@ -40,6 +40,7 @@ export interface DiagramProps {
   parentContainer: ParentContainerDimensions,
   processDiagram?: WaterDiagram;
   saveFlowDiagramData: (flowDiagramData: FlowDiagramData) => void;
+  convertValueFn?: ConvertValueFn;
 }
 
 
@@ -236,7 +237,7 @@ const Diagram = (props: DiagramProps) => {
             shadowRootRef={props.shadowRoot}
             anchor={'left'}
           >
-          <MenuSidebar shadowRootRef={props.shadowRoot}/>
+          <MenuSidebar shadowRootRef={props.shadowRoot} convertValueFn={props.convertValueFn}/>
           </SharedDrawer>
         )}
 

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -4,7 +4,7 @@ import { applyEdgeChanges, applyNodeChanges, Edge, EdgeChange, Node, NodeChange,
 import { CSSProperties } from 'react';
 import { FormikErrors } from 'formik';
 import { ValidationWindowLocation } from './ValidationWindow';
-import { ComponentManageDataTabs, CustomEdgeData, DiagramAlertMessages, DiagramCalculatedData, DiagramSettings, FlowDiagramData, FlowErrors, Handles, MAX_FLOW_DECIMALS, ManageDataTab, NodeErrors, NodeFlowData, ParentContainerDimensions, ProcessFlowNodeType, ProcessFlowPart, UserDiagramOptions, WaterProcessComponentType, WaterSystemResults, WaterTreatment, checkDiagramNodeErrors, convertFlowDiagramData, getConnectionFromEdgeId, getContrastTextColor, getDefaultColorPalette, getDefaultSettings, getDefaultUserDiagramOptions, getEdgeDescription, getEdgeFromConnection } from 'process-flow-lib';
+import { ComponentManageDataTabs, CustomEdgeData, DiagramAlertMessages, DiagramCalculatedData, DiagramSettings, FlowDiagramData, FlowErrors, Handles, MAX_FLOW_DECIMALS, ManageDataTab, NodeErrors, NodeFlowData, ParentContainerDimensions, ProcessFlowNodeType, ProcessFlowPart, UserDiagramOptions, WaterProcessComponentType, WaterSystemResults, WaterTreatment, checkDiagramNodeErrors, getConnectionFromEdgeId, getContrastTextColor, getDefaultColorPalette, getDefaultSettings, getDefaultUserDiagramOptions, getEdgeDescription, getEdgeFromConnection } from 'process-flow-lib';
 import { createNewNode, getNodeSourceEdges, getNodeFlowTotals, setCalculatedNodeDataProperty, getNodeTargetEdges, formatDecimalPlaces, formatDataForMEASUR, formatNumberValue } from './FlowUtils';
 import { EstimatedFlowResults } from '../Forms/WaterSystemEstimation/SystemEstimationFormUtils';
 import { DiagramAlertState } from './DiagramAlert';
@@ -496,17 +496,20 @@ const setPaletteColorsReducer = (state: DiagramState, action: PayloadAction<stri
   });
 };
 
-const unitsOfMeasureChangeReducer = (state: DiagramState, action: PayloadAction<string>) => {
-  const convertedDiagramData = {
-    nodes: state.nodes,
-    edges: state.edges,
-    calculatedData: state.calculatedData
-  }
-  convertFlowDiagramData(convertedDiagramData, action.payload);
-  state.settings.unitsOfMeasure = action.payload;
-  state.nodes = convertedDiagramData.nodes as Node[];
-  state.edges = convertedDiagramData.edges as Edge[];
-  state.calculatedData = convertedDiagramData.calculatedData;
+export interface UnitsOfMeasureChangePayload {
+  newUnits: string;
+  nodes: Node[];
+  edges: Edge[];
+  calculatedData: DiagramCalculatedData;
+}
+
+// Conversion happens in MenuSidebar's onChange (using the injected ConvertValueFn) before
+// dispatch - keeps functions out of Redux state/actions.
+const unitsOfMeasureChangeReducer = (state: DiagramState, action: PayloadAction<UnitsOfMeasureChangePayload>) => {
+  state.settings.unitsOfMeasure = action.payload.newUnits;
+  state.nodes = action.payload.nodes as Node[];
+  state.edges = action.payload.edges as Edge[];
+  state.calculatedData = action.payload.calculatedData;
 };
 
 const flowDecimalPrecisionChangeReducer = (state: DiagramState, action: PayloadAction<string>) => {

--- a/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
+++ b/process-flow-diagram-component/src/components/Diagram/diagramReducer.ts
@@ -4,7 +4,7 @@ import { applyEdgeChanges, applyNodeChanges, Edge, EdgeChange, Node, NodeChange,
 import { CSSProperties } from 'react';
 import { FormikErrors } from 'formik';
 import { ValidationWindowLocation } from './ValidationWindow';
-import { ComponentManageDataTabs, CustomEdgeData, DiagramAlertMessages, DiagramCalculatedData, DiagramSettings, FlowDiagramData, FlowErrors, Handles, MAX_FLOW_DECIMALS, ManageDataTab, NodeErrors, NodeFlowData, ParentContainerDimensions, ProcessFlowNodeType, ProcessFlowPart, UserDiagramOptions, WaterProcessComponentType, WaterSystemResults, WaterTreatment, checkDiagramNodeErrors, getConnectionFromEdgeId, getContrastTextColor, getDefaultColorPalette, getDefaultSettings, getDefaultUserDiagramOptions, getEdgeDescription, getEdgeFromConnection } from 'process-flow-lib';
+import { ComponentManageDataTabs, ConvertValueFn, CustomEdgeData, DiagramAlertMessages, DiagramCalculatedData, DiagramSettings, FlowDiagramData, FlowErrors, Handles, MAX_FLOW_DECIMALS, ManageDataTab, NodeErrors, NodeFlowData, ParentContainerDimensions, ProcessFlowNodeType, ProcessFlowPart, UserDiagramOptions, WaterProcessComponentType, WaterSystemResults, WaterTreatment, checkDiagramNodeErrors, convertFlowDiagramData, getConnectionFromEdgeId, getContrastTextColor, getDefaultColorPalette, getDefaultSettings, getDefaultUserDiagramOptions, getEdgeDescription, getEdgeFromConnection } from 'process-flow-lib';
 import { createNewNode, getNodeSourceEdges, getNodeFlowTotals, setCalculatedNodeDataProperty, getNodeTargetEdges, formatDecimalPlaces, formatDataForMEASUR, formatNumberValue } from './FlowUtils';
 import { EstimatedFlowResults } from '../Forms/WaterSystemEstimation/SystemEstimationFormUtils';
 import { DiagramAlertState } from './DiagramAlert';
@@ -498,18 +498,20 @@ const setPaletteColorsReducer = (state: DiagramState, action: PayloadAction<stri
 
 export interface UnitsOfMeasureChangePayload {
   newUnits: string;
-  nodes: Node[];
-  edges: Edge[];
-  calculatedData: DiagramCalculatedData;
+  convertValueFn?: ConvertValueFn;
 }
 
-// Conversion happens in MenuSidebar's onChange (using the injected ConvertValueFn) before
-// dispatch - keeps functions out of Redux state/actions.
+// convertValueFn is passed through the action but never stored in state - it's only used
+// here to convert the current nodes/edges/calculatedData to the newly selected units.
 const unitsOfMeasureChangeReducer = (state: DiagramState, action: PayloadAction<UnitsOfMeasureChangePayload>) => {
-  state.settings.unitsOfMeasure = action.payload.newUnits;
-  state.nodes = action.payload.nodes as Node[];
-  state.edges = action.payload.edges as Edge[];
-  state.calculatedData = action.payload.calculatedData;
+  const { newUnits, convertValueFn } = action.payload;
+  const convertedDiagramData = { nodes: state.nodes as Node[], edges: state.edges as Edge[], calculatedData: state.calculatedData };
+  convertFlowDiagramData(convertedDiagramData, newUnits, convertValueFn);
+
+  state.settings.unitsOfMeasure = newUnits;
+  state.nodes = convertedDiagramData.nodes;
+  state.edges = convertedDiagramData.edges;
+  state.calculatedData = convertedDiagramData.calculatedData;
 };
 
 const flowDecimalPrecisionChangeReducer = (state: DiagramState, action: PayloadAction<string>) => {

--- a/process-flow-diagram-component/src/components/Diagram/store.ts
+++ b/process-flow-diagram-component/src/components/Diagram/store.ts
@@ -48,7 +48,12 @@ export function configureAppStore(waterDiagram: WaterDiagram) {
         },
       });
   
-      return getDefaultMiddleware().prepend(listenerMiddleware.middleware);
+      return getDefaultMiddleware({
+        // convertValueFn is transient (never stored in state); meta.arg/meta.baseQueryMeta are RTK's own defaults, restated here since this option replaces rather than merges with them.
+        serializableCheck: {
+          ignoredActionPaths: ['meta.arg', 'meta.baseQueryMeta', 'payload.convertValueFn'],
+        },
+      }).prepend(listenerMiddleware.middleware);
     },
   });
 

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -5,11 +5,11 @@ import DownloadButton from './DownloadButton';
 import TabPanel from './TabPanel';
 import { useAppDispatch, useAppSelector } from '../../hooks/state';
 import { conductivityUnitChange, defaultEdgeTypeChange, diagramOptionsChange, electricityCostChange, flowDecimalPrecisionChange, OptionsDependentState, setDialogOpen, showMarkerEndArrows, unitsOfMeasureChange, setPaletteColors, getPaletteColorForType } from '../Diagram/diagramReducer';
-import { RootState, selectEdges, selectCalculatedData, selectHasAssessment, selectNodes } from '../Diagram/store';
+import { RootState, selectHasAssessment, selectNodes } from '../Diagram/store';
 import { edgeTypeOptions, SelectListOption } from '../Diagram/FlowTypes';
 import ValidationWindow, { ValidationWindowLocation } from '../Diagram/ValidationWindow';
 import NotificationsIcon from '@mui/icons-material/Notifications';
-import { ConvertValueFn, NodeErrors, ProcessFlowPart, processFlowDiagramParts, UserDiagramOptions, flowDecimalPrecisionOptions, conductivityUnitOptions, convertFlowDiagramData, getContrastTextColor, getIsDiagramValid, WaterProcessComponentType } from 'process-flow-lib';
+import { ConvertValueFn, NodeErrors, ProcessFlowPart, processFlowDiagramParts, UserDiagramOptions, flowDecimalPrecisionOptions, conductivityUnitOptions, getContrastTextColor, getIsDiagramValid, WaterProcessComponentType } from 'process-flow-lib';
 import DiagramResults from './DiagramResults';
 import InputField from '../StyledMUI/InputField';
 import { Node } from '@xyflow/react';
@@ -45,8 +45,6 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
   
   const flowDecimalPrecision = useAppSelector((state: RootState) => state.diagram.settings.flowDecimalPrecision);
   const unitsOfMeasure = useAppSelector((state: RootState) => state.diagram.settings.unitsOfMeasure);
-  const edges = useAppSelector(selectEdges);
-  const calculatedData = useAppSelector(selectCalculatedData);
   const electricityUnitCost = useAppSelector((state: RootState) => state.diagram.settings.electricityCost);
   const conductivityUnit = useAppSelector((state: RootState) => state.diagram.settings.conductivityUnit);
   const validationWindowLocation: ValidationWindowLocation = useAppSelector((state) => state.diagram.validationWindowLocation);
@@ -201,9 +199,7 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
                   value={unitsOfMeasure}
                   onChange={(e) => {
                     const newUnits = e.target.value;
-                    const convertedDiagramData = { nodes, edges, calculatedData };
-                    convertFlowDiagramData(convertedDiagramData, newUnits, props.convertValueFn);
-                    dispatch(unitsOfMeasureChange({ newUnits, ...convertedDiagramData }));
+                    dispatch(unitsOfMeasureChange({ newUnits, convertValueFn: props.convertValueFn }));
                   }}
                   disabled={hasAssessment}
                   sx={{ minWidth: 120 }}

--- a/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
+++ b/process-flow-diagram-component/src/components/Drawer/MenuSidebar.tsx
@@ -5,11 +5,11 @@ import DownloadButton from './DownloadButton';
 import TabPanel from './TabPanel';
 import { useAppDispatch, useAppSelector } from '../../hooks/state';
 import { conductivityUnitChange, defaultEdgeTypeChange, diagramOptionsChange, electricityCostChange, flowDecimalPrecisionChange, OptionsDependentState, setDialogOpen, showMarkerEndArrows, unitsOfMeasureChange, setPaletteColors, getPaletteColorForType } from '../Diagram/diagramReducer';
-import { RootState, selectHasAssessment, selectNodes } from '../Diagram/store';
+import { RootState, selectEdges, selectCalculatedData, selectHasAssessment, selectNodes } from '../Diagram/store';
 import { edgeTypeOptions, SelectListOption } from '../Diagram/FlowTypes';
 import ValidationWindow, { ValidationWindowLocation } from '../Diagram/ValidationWindow';
 import NotificationsIcon from '@mui/icons-material/Notifications';
-import { NodeErrors, ProcessFlowPart, processFlowDiagramParts, UserDiagramOptions, flowDecimalPrecisionOptions, conductivityUnitOptions, getContrastTextColor, getIsDiagramValid, WaterProcessComponentType } from 'process-flow-lib';
+import { ConvertValueFn, NodeErrors, ProcessFlowPart, processFlowDiagramParts, UserDiagramOptions, flowDecimalPrecisionOptions, conductivityUnitOptions, convertFlowDiagramData, getContrastTextColor, getIsDiagramValid, WaterProcessComponentType } from 'process-flow-lib';
 import DiagramResults from './DiagramResults';
 import InputField from '../StyledMUI/InputField';
 import { Node } from '@xyflow/react';
@@ -45,6 +45,8 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
   
   const flowDecimalPrecision = useAppSelector((state: RootState) => state.diagram.settings.flowDecimalPrecision);
   const unitsOfMeasure = useAppSelector((state: RootState) => state.diagram.settings.unitsOfMeasure);
+  const edges = useAppSelector(selectEdges);
+  const calculatedData = useAppSelector(selectCalculatedData);
   const electricityUnitCost = useAppSelector((state: RootState) => state.diagram.settings.electricityCost);
   const conductivityUnit = useAppSelector((state: RootState) => state.diagram.settings.conductivityUnit);
   const validationWindowLocation: ValidationWindowLocation = useAppSelector((state) => state.diagram.validationWindowLocation);
@@ -197,7 +199,12 @@ const MenuSidebar = memo((props: MenuSidebarProps) => {
                   size="small"
                   label="Units of Measure"
                   value={unitsOfMeasure}
-                  onChange={(e) => dispatch(unitsOfMeasureChange(e.target.value))}
+                  onChange={(e) => {
+                    const newUnits = e.target.value;
+                    const convertedDiagramData = { nodes, edges, calculatedData };
+                    convertFlowDiagramData(convertedDiagramData, newUnits, props.convertValueFn);
+                    dispatch(unitsOfMeasureChange({ newUnits, ...convertedDiagramData }));
+                  }}
                   disabled={hasAssessment}
                   sx={{ minWidth: 120 }}
                   MenuProps={{
@@ -492,6 +499,7 @@ export default MenuSidebar;
 
 export interface MenuSidebarProps {
   shadowRootRef: any;
+  convertValueFn?: ConvertValueFn;
 }
 
 

--- a/src/app/shared/process-flow-diagram-wrapper/process-flow-diagram-wrapper.component.ts
+++ b/src/app/shared/process-flow-diagram-wrapper/process-flow-diagram-wrapper.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Input, SimpleChanges, ViewChild } from '@angular/core';
 import { ProcessFlowDiagramService } from './process-flow-diagram.service';
 import { Subscription } from 'rxjs';
-import { ProcessFlowDiagramState, ProcessFlowParentState } from 'process-flow-lib';
+import { ConvertValueFn, ProcessFlowDiagramState, ProcessFlowParentState } from 'process-flow-lib';
 
 @Component({
     selector: 'app-process-flow-diagram-wrapper',
@@ -14,6 +14,8 @@ export class ProcessFlowDiagramWrapperComponent {
     processFlowDiagramDataSub: Subscription;
     @Input()
     processFlowParentState: ProcessFlowParentState;
+    @Input()
+    convertValueFn?: ConvertValueFn;
 
     constructor(private processFlowDiagramService: ProcessFlowDiagramService) { }
 
@@ -25,6 +27,7 @@ export class ProcessFlowDiagramWrapperComponent {
         if (this.processFlowDiagramElement) {
             // console.log('SET DIAGRAM FROM MEASUR updateDiagramParentState flowDiagramData', JSON.parse(JSON.stringify(this.processFlowParentState.waterDiagram.flowDiagramData)));
             this.processFlowDiagramElement.nativeElement.parentstate = this.processFlowParentState;
+            this.processFlowDiagramElement.nativeElement.convertValueFn = this.convertValueFn;
         }
     }
 

--- a/src/app/water-process-diagram/water-diagram/water-diagram.component.html
+++ b/src/app/water-process-diagram/water-diagram/water-diagram.component.html
@@ -1,4 +1,5 @@
-<app-process-flow-diagram-wrapper 
-    *ngIf="processFlowParentState" 
+<app-process-flow-diagram-wrapper
+    *ngIf="processFlowParentState"
     [processFlowParentState]="processFlowParentState"
+    [convertValueFn]="convertValueFn"
     ></app-process-flow-diagram-wrapper>

--- a/src/app/water-process-diagram/water-diagram/water-diagram.component.ts
+++ b/src/app/water-process-diagram/water-diagram/water-diagram.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { WaterProcessDiagramService } from '../water-process-diagram.service';
-import { WaterDiagram, ProcessFlowParentState } from 'process-flow-lib';
+import { WaterDiagram, ProcessFlowParentState, ConvertValueFn } from 'process-flow-lib';
+import { ConvertValue } from '../../shared/convert-units/ConvertValue';
 
 @Component({
   selector: 'app-water-diagram',
@@ -14,6 +15,7 @@ export class WaterDiagramComponent {
   waterDiagram: WaterDiagram;
   processFlowParentState: ProcessFlowParentState;
   processFlowDiagramDataSub: Subscription;
+  convertValueFn: ConvertValueFn = (value, from, to) => new ConvertValue(value, from, to).convertedValue;
   constructor(private waterProcessDiagramService: WaterProcessDiagramService) {}
 
   ngOnInit() {

--- a/src/process-flow-lib/water/logic/utils.ts
+++ b/src/process-flow-lib/water/logic/utils.ts
@@ -25,15 +25,31 @@ export function getContrastTextColor(bgColor: string): string {
 }
 
 
-const convertFlowValue = (value: number, newUnits: string) => {
-  if (isValidNumber(value)) {
-    if (newUnits === 'Metric') {
-      // * return m3 
-      return value * 3785.4118;
-    } else if (newUnits === 'Imperial') {
-      // * return mGal 
-      return value / 3785.4118;
-    }
+// process-flow-lib can't import it directly (separate bundle). Falls back if unset.
+export type ConvertValueFn = (value: number, from: string, to: string) => number;
+
+const defaultConvertFlowValue = (value: number, newUnits: string): number => {
+  if (newUnits === 'Metric') {
+    // * return m3
+    return value * 3785.4118;
+  } else if (newUnits === 'Imperial') {
+    // * return mGal
+    return value / 3785.4118;
+  }
+  return value;
+}
+
+const convertFlowValue = (value: number, newUnits: string, convertValueFn?: ConvertValueFn) => {
+  if (!isValidNumber(value)) {
+    return value;
+  }
+  if (!convertValueFn) {
+    return defaultConvertFlowValue(value, newUnits);
+  }
+  if (newUnits === 'Metric') {
+    return convertValueFn(value, 'Mgal', 'm3');
+  } else if (newUnits === 'Imperial') {
+    return convertValueFn(value, 'm3', 'Mgal');
   }
   return value;
 }
@@ -43,12 +59,12 @@ const isValidNumber = (num: number): boolean => {
 }
 
 
-export const convertFlowDiagramData = (flowDiagramData: { nodes: Node[], edges: Edge[], calculatedData: DiagramCalculatedData }, newUnits: string) => {
+export const convertFlowDiagramData = (flowDiagramData: { nodes: Node[], edges: Edge[], calculatedData: DiagramCalculatedData }, newUnits: string, convertValueFn?: ConvertValueFn) => {
   flowDiagramData.nodes = flowDiagramData.nodes.map((nd: Node<ProcessFlowPart>) => {
-    const convertedTotalSourceFlow = convertFlowValue(nd.data.userEnteredData.totalSourceFlow, newUnits);
-    const convertedTotalDischargeFlow = convertFlowValue(nd.data.userEnteredData.totalDischargeFlow, newUnits);
-    const convertedTotalKnownLosses = convertFlowValue(nd.data.userEnteredData.totalKnownLosses, newUnits);
-    const convertedWaterInProduct = convertFlowValue(nd.data.userEnteredData.waterInProduct, newUnits);
+    const convertedTotalSourceFlow = convertFlowValue(nd.data.userEnteredData.totalSourceFlow, newUnits, convertValueFn);
+    const convertedTotalDischargeFlow = convertFlowValue(nd.data.userEnteredData.totalDischargeFlow, newUnits, convertValueFn);
+    const convertedTotalKnownLosses = convertFlowValue(nd.data.userEnteredData.totalKnownLosses, newUnits, convertValueFn);
+    const convertedWaterInProduct = convertFlowValue(nd.data.userEnteredData.waterInProduct, newUnits, convertValueFn);
 
     const convertedUserEnteredData: NodeFlowData = {
       totalKnownLosses: convertedTotalKnownLosses,
@@ -67,7 +83,7 @@ export const convertFlowDiagramData = (flowDiagramData: { nodes: Node[], edges: 
   });
 
   flowDiagramData.edges = flowDiagramData.edges.map((edge: Edge<CustomEdgeData>) => {
-    const convertedEdgeflowValue = convertFlowValue(edge.data.flowValue, newUnits);
+    const convertedEdgeflowValue = convertFlowValue(edge.data.flowValue, newUnits, convertValueFn);
     return {
       ...edge,
       data: {
@@ -77,10 +93,10 @@ export const convertFlowDiagramData = (flowDiagramData: { nodes: Node[], edges: 
     }
   });
 
-  flowDiagramData.calculatedData = convertCalculatedData(flowDiagramData.calculatedData, newUnits);
+  flowDiagramData.calculatedData = convertCalculatedData(flowDiagramData.calculatedData, newUnits, convertValueFn);
 }
 
-  export const convertCalculatedData = (diagramCalculatedData: DiagramCalculatedData, newUnits: string): DiagramCalculatedData => {
+  export const convertCalculatedData = (diagramCalculatedData: DiagramCalculatedData, newUnits: string, convertValueFn?: ConvertValueFn): DiagramCalculatedData => {
     if (diagramCalculatedData) {
       let convertedCalculatedData: DiagramCalculatedData = {
         nodes: {}
@@ -88,10 +104,10 @@ export const convertFlowDiagramData = (flowDiagramData: { nodes: Node[], edges: 
       Object.entries(diagramCalculatedData.nodes).forEach(([nodeId, nodeData]) => {
         let convertedNodeData: NodeFlowData = {
           name: nodeData.name,
-          totalSourceFlow: convertFlowValue(nodeData.totalSourceFlow, newUnits),
-          totalDischargeFlow: convertFlowValue(nodeData.totalDischargeFlow, newUnits),
-          totalKnownLosses: convertFlowValue(nodeData.totalKnownLosses, newUnits),
-          waterInProduct: convertFlowValue(nodeData.waterInProduct, newUnits),
+          totalSourceFlow: convertFlowValue(nodeData.totalSourceFlow, newUnits, convertValueFn),
+          totalDischargeFlow: convertFlowValue(nodeData.totalDischargeFlow, newUnits, convertValueFn),
+          totalKnownLosses: convertFlowValue(nodeData.totalKnownLosses, newUnits, convertValueFn),
+          waterInProduct: convertFlowValue(nodeData.waterInProduct, newUnits, convertValueFn),
         };
         convertedCalculatedData.nodes[nodeId] = convertedNodeData;
       });


### PR DESCRIPTION
# Pull Request Template
#7862 
- ConvertValue is routed into the Water Diagram.
- ConvertValue was passed as a prop, It cannot be passed as a function.
- Selecting Units Of Measure updates the units correctly.


To test:
comment this line of code form MenuSidebar.tsx: disabled={hasAssessment}. 
you can now go to water diagram, options tab, and change Units Of Measure.

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
