### PR TITLE
fix(ci): Push jobs running on pr events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     uses: ./.github/workflows/pr_checks.yml
 
   web:
-    if: github.ref_name == 'develop' || github.ref_name == 'master'
+    if: github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
     uses: ./.github/workflows/release_web.yml
 
   desktop:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     uses: ./.github/workflows/release_desktop.yml
     secrets: inherit

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
       BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
   bundle_macos:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: macos-14
     needs: [build]
     steps:
@@ -106,6 +106,9 @@ jobs:
           cp "$PROV_PROF_PATH" ./embedded.provisionprofile
       - name: Bundle
         run: npm run dist -- --mac --universal --publish never
+      - name: Verify
+        run: |
+          codesign --verify --deep --strict --verbose=2 output/mac-universal/MEASUR.app
       - name: Notarize
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -130,7 +133,7 @@ jobs:
           retention-days: 1
 
   bundle_win:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: windows-2025
     needs: [build]
     steps:
@@ -178,7 +181,7 @@ jobs:
           retention-days: 1
 
   bundle_linux:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: ubuntu-24.04
     needs: [build]
     steps:
@@ -217,7 +220,7 @@ jobs:
           retention-days: 1
 
   sign_win:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: [self-hosted, cs]
     needs: [bundle_win]
     steps:
@@ -256,7 +259,7 @@ jobs:
         run: rm -rf ./output
 
   release:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: ubuntu-22.04
     needs: [build, bundle_macos, bundle_linux, sign_win]
     env:

--- a/.github/workflows/release_web.yml
+++ b/.github/workflows/release_web.yml
@@ -5,14 +5,14 @@ on:
 
 jobs:
   call_build:
-    if: github.ref_name == 'develop' || github.ref_name == 'master'
+    if: github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
     uses: ./.github/workflows/template_build.yml
     with:
       artifact-name: dist
       artifact-path: dist/browser
 
   call_deploy-dev:
-    if: github.ref_name == 'develop'
+    if: github.event_name == 'push' && github.ref_name == 'develop'
     needs: call_build
     uses: ./.github/workflows/template_deploy.yml
     with:
@@ -23,7 +23,7 @@ jobs:
       tag: dev
 
   call_deploy-prod:
-    if: github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'master'
     needs: call_build
     uses: ./.github/workflows/template_deploy.yml
     with:


### PR DESCRIPTION
## Description
Changes implemented to more explicitly set conditions for release jobs to target `push` event types to prevent attempts to run within PRs.

Most notably, `release_desktop` execution within a PR will result in a failure due to codesigning being disabled at the PR scope by default, which will fail upon attempt to notarize the build (now captured by verification step before notarization).

### Changes
  - Add explicit conditions for `release_web`, `release_desktop` to run when event type is `push` unambiguously
  - Add codesigning verification step for `bundle_macos`
