### PR TITLE
Issue 8808: CA Allow negative savings opportunities

### DIFF
--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.css
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.css
@@ -19,3 +19,7 @@ td, th{
   input.form-control.ng-invalid{
     border: red solid 2px;
   }
+
+  input.form-control.ng-invalid.negative-allowed{
+    border: 1px solid #ced4da;
+  }

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.css
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.css
@@ -19,3 +19,7 @@ td, th{
   input.form-control.ng-invalid{
     border: red solid 2px;
   }
+
+  input.form-control.ng-invalid.negative-value-warning{
+    border: 1px solid #ced4da;
+  }

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.html
@@ -81,21 +81,24 @@
         <label for="{{'airflowReduction_'+itemIndex}}">Airflow Reduction</label>
         <div class="input-group">
             <input type="number" class="form-control" formControlName="airflowReduction"
+                [ngClass]="{'negative-value-warning': form.controls.airflowReduction.errors?.min}"
                 (focus)="helpTextField('airflowReduction')" id="{{'airflowReduction_'+itemIndex}}" (input)="save()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="units input-group-addon">acfm</span>
             <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="units input-group-addon">m<sup>3</sup>/min</span>
         </div>
         <span class="alert-danger pull-right small"
-            *ngIf="form.controls.airflowReduction.invalid && !form.controls.airflowReduction.pristine">
+            *ngIf="(form.controls.airflowReduction.errors?.required || form.controls.airflowReduction.errors?.max) && !form.controls.airflowReduction.pristine">
             <span *ngIf="form.controls.airflowReduction.errors.required">Value Required</span>
-            <span *ngIf="form.controls.airflowReduction.errors.min">Value can't be negative.
-            </span>
             <span *ngIf="form.controls.airflowReduction.errors.max">
                 Value can't be greater than the max airflow in the system
                 ({{form.controls.airflowReduction.errors.max.max | number: '1.0-1'}}
                 <span *ngIf="settings.unitsOfMeasure == 'Imperial'">acfm</span>
                 <span *ngIf="settings.unitsOfMeasure == 'Metric'">m<sup>3</sup>/min</span>).
             </span>
+        </span>
+        <span class="alert-warning pull-right small"
+            *ngIf="form.controls.airflowReduction.errors?.min && !form.controls.airflowReduction.pristine">
+            Value should be greater than zero to achieve savings.
         </span>
     </div>
 </form>

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.html
@@ -81,7 +81,7 @@
         <label for="{{'airflowReduction_'+itemIndex}}">Airflow Reduction</label>
         <div class="input-group">
             <input type="number" class="form-control" formControlName="airflowReduction"
-                [ngClass]="{'negative-allowed': form.controls.airflowReduction.errors?.min}"
+                [ngClass]="{'negative-allowed': form.controls.airflowReduction.value < 0}"
                 (focus)="helpTextField('airflowReduction')" id="{{'airflowReduction_'+itemIndex}}" (input)="save()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="units input-group-addon">acfm</span>
             <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="units input-group-addon">m<sup>3</sup>/min</span>
@@ -97,7 +97,7 @@
             </span>
         </span>
         <span class="alert-warning pull-right small"
-            *ngIf="form.controls.airflowReduction.errors?.min && !form.controls.airflowReduction.pristine">
+            *ngIf="form.controls.airflowReduction.value < 0 && !form.controls.airflowReduction.pristine">
             Value should be greater than zero to achieve savings.
         </span>
     </div>

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency-item/improve-end-use-efficiency-item.component.html
@@ -81,21 +81,24 @@
         <label for="{{'airflowReduction_'+itemIndex}}">Airflow Reduction</label>
         <div class="input-group">
             <input type="number" class="form-control" formControlName="airflowReduction"
+                [ngClass]="{'negative-allowed': form.controls.airflowReduction.errors?.min}"
                 (focus)="helpTextField('airflowReduction')" id="{{'airflowReduction_'+itemIndex}}" (input)="save()">
             <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="units input-group-addon">acfm</span>
             <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="units input-group-addon">m<sup>3</sup>/min</span>
         </div>
         <span class="alert-danger pull-right small"
-            *ngIf="form.controls.airflowReduction.invalid && !form.controls.airflowReduction.pristine">
+            *ngIf="(form.controls.airflowReduction.errors?.required || form.controls.airflowReduction.errors?.max) && !form.controls.airflowReduction.pristine">
             <span *ngIf="form.controls.airflowReduction.errors.required">Value Required</span>
-            <span *ngIf="form.controls.airflowReduction.errors.min">Value can't be negative.
-            </span>
             <span *ngIf="form.controls.airflowReduction.errors.max">
                 Value can't be greater than the max airflow in the system
                 ({{form.controls.airflowReduction.errors.max.max | number: '1.0-1'}}
                 <span *ngIf="settings.unitsOfMeasure == 'Imperial'">acfm</span>
                 <span *ngIf="settings.unitsOfMeasure == 'Metric'">m<sup>3</sup>/min</span>).
             </span>
+        </span>
+        <span class="alert-warning pull-right small"
+            *ngIf="form.controls.airflowReduction.errors?.min && !form.controls.airflowReduction.pristine">
+            Value should be greater than zero to achieve savings.
         </span>
     </div>
 </form>

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency.service.ts
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/improve-end-use-efficiency/improve-end-use-efficiency.service.ts
@@ -30,7 +30,7 @@ export class ImproveEndUseEfficiencyService {
 
   setFormValidators(form: UntypedFormGroup, baselineResults: BaselineResults): UntypedFormGroup{
     if(form.controls.reductionType.value == 'Fixed'){
-      form.controls.airflowReduction.setValidators([Validators.required, Validators.min(0), Validators.max(baselineResults.total.maxAirFlow)])
+      form.controls.airflowReduction.setValidators([Validators.required, Validators.max(baselineResults.total.maxAirFlow)])
       form.controls.airflowReduction.updateValueAndValidity();
     }else if(form.controls.reductionType.value == 'Variable'){
       form.controls.airflowReduction.setValidators([]);

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.html
@@ -62,7 +62,7 @@
                         }
                         @if (form.controls.averageSystemPressureReduction.errors.max) {
                             <span>
-                                Value can't be greater than the minumum pressure in the system
+                                Value can't be greater than the minimum pressure in the system
                                 ({{form.controls.averageSystemPressureReduction.errors.max.max | number: '1.0-1'}}
                                 @if (settings.unitsOfMeasure == 'Imperial') {
                                     <span>psig</span>

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.html
@@ -5,7 +5,7 @@
             <span class="supply-demand">
                 Supply
             </span>
-            @if (form.invalid && form.controls.order.value != 100) {
+            @if ((form.controls.implementationCost.invalid || hasPressureReductionBlockingError) && form.controls.order.value != 100) {
                 <span>
                     <span class="fa fa-exclamation-circle"></span>
                 </span>
@@ -41,8 +41,7 @@
                 }
             </div>
 
-            <div class="form-group"
-                [ngClass]="{'invalid': form.controls.averageSystemPressureReduction.errors?.required || form.controls.averageSystemPressureReduction.errors?.max}">
+            <div class="form-group" [ngClass]="{'invalid': hasPressureReductionBlockingError}">
                 <label for="averageSystemPressureReduction">Average System Pressure Reduction</label>
                 <div class="input-group">
                     <input type="number" class="form-control" formControlName="averageSystemPressureReduction"
@@ -55,7 +54,7 @@
                         <span class="units input-group-addon">barg</span>
                     }
                 </div>
-                @if ((form.controls.averageSystemPressureReduction.errors?.required || form.controls.averageSystemPressureReduction.errors?.max) && !form.controls.averageSystemPressureReduction.pristine) {
+                @if (hasPressureReductionBlockingError && !form.controls.averageSystemPressureReduction.pristine) {
                     <span class="alert-danger pull-right small">
                         @if (form.controls.averageSystemPressureReduction.errors.required) {
                             <span>Value Required</span>

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.html
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.html
@@ -5,55 +5,81 @@
             <span class="supply-demand">
                 Supply
             </span>
-            <span *ngIf="form.invalid && form.controls.order.value != 100">
-                <span class="fa fa-exclamation-circle"></span>
-            </span>
+            @if (form.invalid && form.controls.order.value != 100) {
+                <span>
+                    <span class="fa fa-exclamation-circle"></span>
+                </span>
+            }
             <select id="reduceSystemAirPressureOrder" formControlName="order" class="form-control pull-right"
                 (change)="save(true)">
                 <option [ngValue]=100>Off</option>
-                <option *ngFor="let option of orderOptions" [ngValue]="option">{{option}}</option>
+                @for (option of orderOptions; track option) {
+                    <option [ngValue]="option">{{option}}</option>
+                }
             </select>
         </label>
     </div>
 
 
-    <div *ngIf="form.controls.order.value != 100" class="mb-2 pt-1">
-        <div class="form-group" [ngClass]="{'invalid': form.controls.implementationCost.invalid}">
-            <label for="reduceSystemPressureImplementationCost">Implementation Cost</label>
-            <div class="input-group">
-                <input type="number" class="form-control" formControlName="implementationCost"
-                    name="reduceSystemPressureImplementationCost" id="reduceSystemPressureImplementationCost"
-                    (input)="save(false)" (focus)="helpTextField('implementationCost')">
-                <span class="input-group-addon units">$</span>
+    @if (form.controls.order.value != 100) {
+        <div class="mb-2 pt-1">
+            <div class="form-group" [ngClass]="{'invalid': form.controls.implementationCost.invalid}">
+                <label for="reduceSystemPressureImplementationCost">Implementation Cost</label>
+                <div class="input-group">
+                    <input type="number" class="form-control" formControlName="implementationCost"
+                        name="reduceSystemPressureImplementationCost" id="reduceSystemPressureImplementationCost"
+                        (input)="save(false)" (focus)="helpTextField('implementationCost')">
+                    <span class="input-group-addon units">$</span>
+                </div>
+                @if (form.controls.implementationCost.invalid && !form.controls.implementationCost.pristine) {
+                    <span class="alert-danger pull-right small">
+                        @if (form.controls.implementationCost.errors.min) {
+                            <span>Value can't be negative.
+                            </span>
+                        }
+                    </span>
+                }
             </div>
-            <span class="alert-danger pull-right small"
-                *ngIf="form.controls.implementationCost.invalid && !form.controls.implementationCost.pristine">
-                <span *ngIf="form.controls.implementationCost.errors.min">Value can't be negative.
-                </span>
-            </span>
-        </div>
 
-        <div class="form-group" [ngClass]="{'invalid': form.controls.averageSystemPressureReduction.invalid}">
-            <label for="averageSystemPressureReduction">Average System Pressure Reduction</label>
-            <div class="input-group">
-                <input type="number" class="form-control" formControlName="averageSystemPressureReduction"
-                    (focus)="helpTextField('avgSystemPressureReduction')" name="averageSystemPressureReduction"
-                    id="averageSystemPressureReduction" (input)="save(false)">
-                <span *ngIf="settings.unitsOfMeasure == 'Imperial'" class="units input-group-addon">psig</span>
-                <span *ngIf="settings.unitsOfMeasure == 'Metric'" class="units input-group-addon">barg</span>
+            <div class="form-group"
+                [ngClass]="{'invalid': form.controls.averageSystemPressureReduction.errors?.required || form.controls.averageSystemPressureReduction.errors?.max}">
+                <label for="averageSystemPressureReduction">Average System Pressure Reduction</label>
+                <div class="input-group">
+                    <input type="number" class="form-control" formControlName="averageSystemPressureReduction"
+                        (focus)="helpTextField('avgSystemPressureReduction')" name="averageSystemPressureReduction"
+                        id="averageSystemPressureReduction" (input)="save(false)">
+                    @if (settings.unitsOfMeasure == 'Imperial') {
+                        <span class="units input-group-addon">psig</span>
+                    }
+                    @if (settings.unitsOfMeasure == 'Metric') {
+                        <span class="units input-group-addon">barg</span>
+                    }
+                </div>
+                @if ((form.controls.averageSystemPressureReduction.errors?.required || form.controls.averageSystemPressureReduction.errors?.max) && !form.controls.averageSystemPressureReduction.pristine) {
+                    <span class="alert-danger pull-right small">
+                        @if (form.controls.averageSystemPressureReduction.errors.required) {
+                            <span>Value Required</span>
+                        }
+                        @if (form.controls.averageSystemPressureReduction.errors.max) {
+                            <span>
+                                Value can't be greater than the minumum pressure in the system
+                                ({{form.controls.averageSystemPressureReduction.errors.max.max | number: '1.0-1'}}
+                                @if (settings.unitsOfMeasure == 'Imperial') {
+                                    <span>psig</span>
+                                }
+                                @if (settings.unitsOfMeasure == 'Metric') {
+                                    <span>barg</span>
+                                }).
+                            </span>
+                        }
+                    </span>
+                }
+                @if (form.controls.averageSystemPressureReduction.errors?.min && !form.controls.averageSystemPressureReduction.pristine) {
+                    <span class="alert-warning pull-right small">
+                        Value should be greater than zero to achieve savings.
+                    </span>
+                }
             </div>
-            <span class="alert-danger pull-right small"
-                *ngIf="form.controls.averageSystemPressureReduction.invalid && !form.controls.averageSystemPressureReduction.pristine">
-                <span *ngIf="form.controls.averageSystemPressureReduction.errors.required">Value Required</span>
-                <span *ngIf="form.controls.averageSystemPressureReduction.errors.min">Value can't be negative.
-                </span>
-                <span *ngIf="form.controls.averageSystemPressureReduction.errors.max">
-                    Value can't be greater than the minumum pressure in the system
-                    ({{form.controls.averageSystemPressureReduction.errors.max.max | number: '1.0-1'}}
-                    <span *ngIf="settings.unitsOfMeasure == 'Imperial'">psig</span>
-                    <span *ngIf="settings.unitsOfMeasure == 'Metric'">barg</span>).
-                </span>
-            </span>
         </div>
-    </div>
+    }
 </form>

--- a/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.ts
+++ b/src/app/compressed-air-assessment/assessment-tab-content/explore-opportunities/explore-opportunities-form/reduce-system-air-pressure/reduce-system-air-pressure.component.ts
@@ -42,6 +42,11 @@ export class ReduceSystemAirPressureComponent implements OnInit {
     this.selectedModificationIdSub.unsubscribe();
   }
 
+  get hasPressureReductionBlockingError(): boolean {
+    const errors = this.form?.controls.averageSystemPressureReduction.errors;
+    return !!(errors?.required || errors?.max);
+  }
+
   helpTextField(str: string) {
     this.compressedAirAssessmentService.helpTextField.next(str);
     this.compressedAirAssessmentService.focusedField.next('reduceAirSystemAirPressure');


### PR DESCRIPTION
# Pull Request Template
#8808 
Reduce System Air Pressure - Average System Pressure Reduction and Improve End Use Efficiency - Airflow Reduction
now allow negative values. Instead of an error message there is the warning "Value should be greater than zero to achieve savings".

## Checklist
- Variable, function, and class names are descriptive
- Code leverages existing architecture, helper methods, and shared modules when applicable
- Development artifacts such as console logs, test values, and comments have been removed
- All Copilot, Claude Code, or other LLM implementations have been reviewed as if contributed by another developer
- UI changes have been manually tested for usability and appearance
- This PR references the related issue number (if applicable), ex. issue -> `#0000`

## Description
- **For development team**: Optional. Update the issue with a comment, if necessary.
- **For open source contributors**: The PR description clearly explains the purpose and scope of the changes

---
